### PR TITLE
Add AppVeyor continuous integration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,102 @@
+environment:
+  global:
+    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+    # /E:ON and /V:ON options are not enabled in the batch script intepreter
+    # See: http://stackoverflow.com/a/13751649/163740
+    CMD_IN_ENV: 'cmd /E:ON /V:ON /C .\tools\appveyor\run_with_env.cmd'
+    ANACONDA_TOKEN:
+      secure: hNorKC0ZG2MdYxyGDiHwVrsB45vIupeSNVpdJ5q0jdEzdyCPi/Y7n1zMjYyqZ2co
+    PYPKG: iodata
+    GITHUB_REPO_NAME: theochem/iodata
+
+  matrix:
+    - PYTHON_VERSION: 2.7
+      CONDA: C:\Miniconda
+
+    - PYTHON_VERSION: 3.5
+      CONDA: C:\Miniconda35
+
+    - PYTHON_VERSION: 3.6
+      CONDA: C:\Miniconda36
+
+version: '{build}'
+image: Visual Studio 2015
+
+# For testing only...
+#skip_non_tags: true
+
+platform:
+- x86
+- x64
+
+branches:
+  only:
+    - master
+
+init:
+  - ps: if ($Env:PLATFORM -eq "x64") { $Env:CONDA = "${Env:CONDA}-x64" }
+  - ps: Write-Host $Env:PYTHON_VERSION
+  - ps: Write-Host $Env:CONDA
+  - ps: Write-Host $Env:GITHUB_REPO_NAME
+  - ps: Write-Host $Env:PLATFORM
+  - ps: Write-Host $Env:APPVEYOR_REPO_TAG
+  - ps: Write-Host $Env:APPVEYOR_REPO_TAG_NAME
+  - ps: Write-Host $Env:APPVEYOR_REPO_NAME
+
+install:
+  # Make sure the compiler is accessible
+  - '"%VS140COMNTOOLS%\..\..\VC\vcvarsall.bat" %PLATFORM%'
+
+  # Load the conda root environment, configure and install some packages
+  - '"%CONDA%\Scripts\activate.bat"'
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda install conda-build anaconda-client numpy cython
+  # Install codecov tool for uploading coverage reports
+  - pip install codecov coverage
+  # Show conda info for debugging
+  - conda info -a
+
+build: false
+
+test_script:
+  # Build the package
+  - git fetch origin --tags
+  - "%CMD_IN_ENV% conda build tools/conda.recipe"
+
+  # Install the package
+  - conda install --use-local %PYPKG%
+
+  # Run the tests outside the source tree.
+  - pushd "%HOMEPATH%" && (nosetests %PYPKG% -v --detailed-errors --with-coverage --cover-package=%PYPKG% --cover-tests --cover-erase --cover-inclusive --cover-branches --cover-xml & popd)
+
+after_test:
+  # Copy the conda build to the home dir, such that it can be registerd as an artifact
+  - move %CONDA%\conda-bld .
+
+  # Upload coverage reports
+  - 'codecov -f "%HOMEPATH%\coverage.xml"'
+
+artifacts:
+  # Files to be uploaded
+  - path: 'conda-bld\win-*\*.tar.bz2'
+
+on_success:
+  # This is virtually impossible with a normal dos batch script...
+  # Upload to anaconda, with the correct label derived from the version tag.
+  - ps:
+      if (($Env:APPVEYOR_REPO_TAG -eq "true") -and
+          ($Env:APPVEYOR_REPO_NAME -eq ${Env:GITHUB_REPO_NAME})) {
+        $tar_glob = ".\conda-bld\win-*\${Env:PYPKG}-${Env:APPVEYOR_REPO_TAG_NAME}-*.tar.bz2";
+        Write-Host $tar_glob;
+        if ($Env:APPVEYOR_REPO_TAG_NAME -like "*a*") {
+          Start-Process -FilePath anaconda -ArgumentList "-t $Env:ANACONDA_TOKEN upload
+          $tar_glob --no-progress -l alpha" -Wait -Passthru
+        } elseif ($Env:APPVEYOR_REPO_TAG_NAME -like "*b*") {
+          Start-Process -FilePath anaconda -ArgumentList "-t $Env:ANACONDA_TOKEN upload
+          $tar_glob --no-progress -l beta" -Wait -Passthru
+        } else {
+          Start-Process -FilePath anaconda -ArgumentList "-t $Env:ANACONDA_TOKEN upload
+          $tar_glob --no-progress" -Wait -Passthru
+        }
+      }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ IOData
 <a href='https://docs.python.org/2.7/'><img src='https://img.shields.io/badge/python-2.7-blue.svg'></a>
 <a href='https://docs.python.org/3.5/'><img src='https://img.shields.io/badge/python-3.5-blue.svg'></a>
 [![codecov](https://codecov.io/gh/theochem/iodata/branch/master/graph/badge.svg)](https://codecov.io/gh/theochem/iodata)
+[![Build status](https://ci.appveyor.com/api/projects/status/s1v03mj127dmoi7s/branch/master?svg=true)](https://ci.appveyor.com/project/theochem-ci-bot/iodata/branch/master)
 
 
 About

--- a/tools/appveyor/run_with_env.cmd
+++ b/tools/appveyor/run_with_env.cmd
@@ -1,0 +1,47 @@
+:: To build extensions for 64 bit Python 3, we need to configure environment
+:: variables to use the MSVC 2010 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 4 (SDK v7.1)
+::
+:: To build extensions for 64 bit Python 2, we need to configure environment
+:: variables to use the MSVC 2008 C++ compilers from GRMSDKX_EN_DVD.iso of:
+:: MS Windows SDK for Windows 7 and .NET Framework 3.5 (SDK v7.0)
+::
+:: 32 bit builds do not require specific environment configurations.
+::
+:: Note: this script needs to be run with the /E:ON and /V:ON flags for the
+:: cmd interpreter, at least for (SDK v7.0)
+::
+:: More details at:
+:: https://github.com/cython/cython/wiki/64BitCythonExtensionsOnWindows
+:: http://stackoverflow.com/a/13751649/163740
+::
+:: Author: Olivier Grisel
+:: License: CC0 1.0 Universal: http://creativecommons.org/publicdomain/zero/1.0/
+@ECHO OFF
+
+SET COMMAND_TO_RUN=%*
+SET WIN_SDK_ROOT=C:\Program Files\Microsoft SDKs\Windows
+
+SET MAJOR_PYTHON_VERSION="%PYTHON_VERSION:~0,1%"
+IF %MAJOR_PYTHON_VERSION% == "2" (
+    SET WINDOWS_SDK_VERSION="v7.0"
+) ELSE IF %MAJOR_PYTHON_VERSION% == "3" (
+    SET WINDOWS_SDK_VERSION="v7.1"
+) ELSE (
+    ECHO Unsupported Python version: "%MAJOR_PYTHON_VERSION%"
+    EXIT 1
+)
+
+IF "%PLATFORM%"=="X64" (
+    ECHO Configuring Windows SDK %WINDOWS_SDK_VERSION% for Python %MAJOR_PYTHON_VERSION% on a 64 bit architecture
+    SET DISTUTILS_USE_SDK=1
+    SET MSSdk=1
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Setup\WindowsSdkVer.exe" -q -version:%WINDOWS_SDK_VERSION%
+    "%WIN_SDK_ROOT%\%WINDOWS_SDK_VERSION%\Bin\SetEnv.cmd" /x64 /release
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+) ELSE (
+    ECHO Using default MSVC build environment for 32 bit architecture
+    ECHO Executing: %COMMAND_TO_RUN%
+    call %COMMAND_TO_RUN% || EXIT 1
+)


### PR DESCRIPTION
There is a problem with `iodata/molden.py` on Windows due to `file.seek()` and `file.tell()` methods. This is because a different newline character is used on Windows, so seek does not take you back to the exact same place (beginning of the previously read line). 
