### PR TITLE
Remove all annotations, use string instead

### DIFF
--- a/iodata/cube.py
+++ b/iodata/cube.py
@@ -21,7 +21,7 @@
 """Gaussian cube file format"""
 
 
-from __future__ import print_function, annotations
+from __future__ import print_function
 
 from typing import TextIO, Dict, Tuple, Union
 

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -24,8 +24,6 @@
    from/to a file. The format is deduced from the prefix or extension of the
    filename.
 """
-from __future__ import annotations
-
 import os
 from typing import List, Tuple, Type
 
@@ -266,7 +264,7 @@ class IOData:
             return len(self.pseudo_numbers)
 
     @classmethod
-    def from_file(cls, *filenames: str) -> IOData:
+    def from_file(cls, *filenames: str) -> "IOData":
         """Load data from a file.
 
         This routine uses the extension or prefix of the filename to

--- a/iodata/molden.py
+++ b/iodata/molden.py
@@ -20,7 +20,7 @@
 # --
 """Molden wavefunction input file format"""
 
-from __future__ import print_function, annotations
+from __future__ import print_function
 
 from typing import TextIO, Tuple, Dict, Union
 

--- a/iodata/molpro.py
+++ b/iodata/molpro.py
@@ -26,7 +26,7 @@
        FCIDUMP file while HORTON internally uses Physicist's notation.
 """
 
-from __future__ import print_function, annotations
+from __future__ import print_function
 
 from typing import Dict
 

--- a/iodata/vasp.py
+++ b/iodata/vasp.py
@@ -20,7 +20,7 @@
 # --
 """VASP POSCAR, CHGCAR and POTCAR file formats"""
 
-from __future__ import print_function, annotations
+from __future__ import print_function
 
 from typing import TextIO, Tuple, Dict
 


### PR DESCRIPTION
1. remove all "from __future__ import annotations"
2. use string name for delayed evalution
ref:https://github.com/theochem/iodata/issues/18