### PR TITLE
Use importlib to replace get_fn for data access

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,7 @@ install:
 # Configure conda and get a few essentials
 - conda config --set always_yes yes
 - conda config --add channels theochem
+- conda config --add channels conda-forge
 - conda install -q conda conda-build conda-verify
 
 # Set the version info from the git tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ branches:
     - /^[0-9]+\.[0-9]+(\.[0-9]+)?([ab][0-9]+)?$/
 
 before_install:
-- if ! [[ $TRAVIS_TAG || $TRAVIS_OS_NAME == "linux" && $MYCONDAPY == "3.6" ]]; then exit 0; fi
+# - if ! [[ $TRAVIS_TAG || $TRAVIS_OS_NAME == "linux" && $MYCONDAPY == "3.6" ]]; then exit 0; fi
 # Get miniconda. Take the right version, so re-installing python is hopefully not needed.
 - if test -e $HOME/miniconda/bin; then
     echo "miniconda already installed.";

--- a/iodata/cp2k.py
+++ b/iodata/cp2k.py
@@ -18,7 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
-# pragma pylint: disable=wrong-import-order
+# pragma pylint: disable=wrong-import-order,invalid-name
 """Module for handling CP2K file format."""
 
 

--- a/iodata/gaussian.py
+++ b/iodata/gaussian.py
@@ -18,7 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
-# pragma pylint: disable=wrong-import-order
+# pragma pylint: disable=wrong-import-order,invalid-name
 """Module for handling GAUSSIAN LOG and FCHK file formats."""
 
 

--- a/iodata/molpro.py
+++ b/iodata/molpro.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Module for handling MOLPRO file formal."""
 
 

--- a/iodata/test/cached/__init__.py
+++ b/iodata/test/cached/__init__.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+# HORTON: Helpful Open-source Research TOol for N-fermion systems.
+# Copyright (C) 2011-2017 The HORTON Development Team
+#
+# This file is part of HORTON.
+#
+# HORTON is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# HORTON is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -25,15 +25,9 @@ from contextlib import contextmanager
 import numpy as np
 from os import path
 
-from . mulliken import get_mulliken_operators
+from .mulliken import get_mulliken_operators
 
 __all__ = ['compute_mulliken_charges']
-
-
-def get_fn(fn):
-    """Get the path of a file in the cached directory"""
-    cur_pth = path.split(__file__)[0]
-    return cur_pth + "/cached/{}".format(fn)
 
 
 def compute_mulliken_charges(obasis, pseudo_numbers, dm):

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.cp2k module."""
 
 from nose.tools import assert_raises

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -22,13 +22,14 @@
 
 from nose.tools import assert_raises
 
-from . common import get_fn, truncated_file, check_orthonormal
+from . common import truncated_file, check_orthonormal
 
 from .. iodata import IOData
 from .. overlap import compute_overlap
-
-
-
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 # TODO: add more obasis tests?
 
 
@@ -41,8 +42,8 @@ def check_orthonormality(mol):
 
 
 def test_atom_si_uks():
-    fn_out = get_fn('atom_si.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'atom_si.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [14]).all()
     assert (mol.pseudo_numbers == [4]).all()
     assert (mol.orb_alpha_occs == [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]).all()
@@ -55,8 +56,8 @@ def test_atom_si_uks():
 
 
 def test_atom_o_rks():
-    fn_out = get_fn('atom_om2.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'atom_om2.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [8]).all()
     assert (mol.pseudo_numbers == [6]).all()
     assert (mol.orb_alpha_occs == [1, 1, 1, 1]).all()
@@ -68,8 +69,8 @@ def test_atom_o_rks():
 
 
 def test_carbon_gs_ae_contracted():
-    fn_out = get_fn('carbon_gs_ae_contracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_gs_ae_contracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [6]).all()
     assert (mol.orb_alpha_occs == [1, 1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]).all()
@@ -83,8 +84,8 @@ def test_carbon_gs_ae_contracted():
 
 
 def test_carbon_gs_ae_uncontracted():
-    fn_out = get_fn('carbon_gs_ae_uncontracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_gs_ae_uncontracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [6]).all()
     assert (mol.orb_alpha_occs == [1, 1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]).all()
@@ -98,8 +99,8 @@ def test_carbon_gs_ae_uncontracted():
 
 
 def test_carbon_gs_pp_contracted():
-    fn_out = get_fn('carbon_gs_pp_contracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_gs_pp_contracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [4]).all()
     assert (mol.orb_alpha_occs == [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]).all()
@@ -111,8 +112,8 @@ def test_carbon_gs_pp_contracted():
 
 
 def test_carbon_gs_pp_uncontracted():
-    fn_out = get_fn('carbon_gs_pp_uncontracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [4]).all()
     assert (mol.orb_alpha_occs == [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0]).all()
@@ -124,8 +125,8 @@ def test_carbon_gs_pp_uncontracted():
 
 
 def test_carbon_sc_ae_contracted():
-    fn_out = get_fn('carbon_sc_ae_contracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_sc_ae_contracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [6]).all()
     assert (mol.orb_alpha_occs == [1, 1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]).all()
@@ -137,8 +138,8 @@ def test_carbon_sc_ae_contracted():
 
 
 def test_carbon_sc_ae_uncontracted():
-    fn_out = get_fn('carbon_sc_ae_uncontracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_sc_ae_uncontracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [6]).all()
     assert (mol.orb_alpha_occs == [1, 1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]).all()
@@ -150,8 +151,8 @@ def test_carbon_sc_ae_uncontracted():
 
 
 def test_carbon_sc_pp_contracted():
-    fn_out = get_fn('carbon_sc_pp_contracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_sc_pp_contracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [4]).all()
     assert (mol.orb_alpha_occs == [1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]).all()
@@ -162,8 +163,8 @@ def test_carbon_sc_pp_contracted():
 
 
 def test_carbon_sc_pp_uncontracted():
-    fn_out = get_fn('carbon_sc_pp_uncontracted.cp2k.out')
-    mol = IOData.from_file(fn_out)
+    with path('iodata.test.cached', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_out:
+        mol = IOData.from_file(str(fn_out))
     assert (mol.numbers == [6]).all()
     assert (mol.pseudo_numbers == [4]).all()
     assert (mol.orb_alpha_occs == [1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0]).all()
@@ -174,20 +175,20 @@ def test_carbon_sc_pp_uncontracted():
 
 
 def test_errors():
-    fn_test = get_fn('carbon_sc_pp_uncontracted.cp2k.out')
-    with truncated_file('io.test.test_cp2k.test_errors', fn_test, 0, 0) as fn:
-        with assert_raises(IOError):
-            IOData.from_file(fn)
-    with truncated_file('io.test.test_cp2k.test_errors', fn_test, 107, 10) as fn:
-        with assert_raises(IOError):
-            IOData.from_file(fn)
-    with truncated_file('io.test.test_cp2k.test_errors', fn_test, 357, 10) as fn:
-        with assert_raises(IOError):
-            IOData.from_file(fn)
-    with truncated_file('io.test.test_cp2k.test_errors', fn_test, 405, 10) as fn:
-        with assert_raises(IOError):
-            IOData.from_file(fn)
-    fn_test = get_fn('carbon_gs_pp_uncontracted.cp2k.out')
-    with truncated_file('io.test.test_cp2k.test_errors', fn_test, 456, 10) as fn:
-        with assert_raises(IOError):
-            IOData.from_file(fn)
+    with path('iodata.test.cached', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_test:
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 0, 0) as fn:
+            with assert_raises(IOError):
+                IOData.from_file(fn)
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 107, 10) as fn:
+            with assert_raises(IOError):
+                IOData.from_file(fn)
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 357, 10) as fn:
+            with assert_raises(IOError):
+                IOData.from_file(fn)
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 405, 10) as fn:
+            with assert_raises(IOError):
+                IOData.from_file(fn)
+    with path('iodata.test.cached', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_test:
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 456, 10) as fn:
+            with assert_raises(IOError):
+                IOData.from_file(fn)

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.cube module."""
 
 

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -23,14 +23,19 @@
 
 import numpy as np
 
-from . common import get_fn, tmpdir
+from . common import tmpdir
 
 from .. iodata import IOData
 
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
+
 
 def test_load_aelta():
-    fn_cube = get_fn('aelta.cube')
-    mol = IOData.from_file(fn_cube)
+    with path('iodata.test.cached', 'aelta.cube') as fn_cube:
+        mol = IOData.from_file(str(fn_cube))
     assert mol.title == 'Some random cube for testing (sort of) useless data'
     assert mol.natom == 72
     assert abs(mol.coordinates[5, 0] - 27.275511) < 1e-5
@@ -53,8 +58,8 @@ def test_load_aelta():
 
 
 def test_load_dump_load_aelta():
-    fn_cube1 = get_fn('aelta.cube')
-    mol1 = IOData.from_file(fn_cube1)
+    with path('iodata.test.cached', 'aelta.cube') as fn_cube1:
+        mol1 = IOData.from_file(str(fn_cube1))
 
     with tmpdir('io.test.test_cube.test_load_dump_load_aelta') as dn:
         fn_cube2 = '%s/%s' % (dn, 'aelta.cube')

--- a/iodata/test/test_gaussian.py
+++ b/iodata/test/test_gaussian.py
@@ -25,19 +25,22 @@ import numpy as np
 
 from nose.tools import assert_raises
 
-from . common import get_fn
 from .. gaussian import load_operators_g09, load_fchk
 from .. iodata import IOData
 from .. utils import shells_to_nbasis, check_dm
 from .. overlap import compute_overlap
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 #TODO: shells_to_nbasis(obasis["shell_types"]) replacement test
 
 
 def test_load_operators_water_sto3g_hf_g03():
     eps = 1e-5
-    fn = get_fn('water_sto3g_hf_g03.log')
-    result = load_operators_g09(fn)
+    with path('iodata.test.cached', 'water_sto3g_hf_g03.log') as fn:
+        result = load_operators_g09(str(fn))
 
     overlap = result['olp']
     kinetic = result['kin']
@@ -72,8 +75,8 @@ def test_load_operators_water_sto3g_hf_g03():
 
 def test_load_operators_water_ccpvdz_pure_hf_g03():
     eps = 1e-5
-    fn = get_fn('water_ccpvdz_pure_hf_g03.log')
-    result = load_operators_g09(fn)
+    with path('iodata.test.cached', 'water_ccpvdz_pure_hf_g03.log') as fn:
+        result = load_operators_g09(str(fn))
 
     overlap = result['olp']
     kinetic = result['kin']
@@ -109,11 +112,13 @@ def test_load_operators_water_ccpvdz_pure_hf_g03():
 
 def test_load_fchk_nonexistent():
     with assert_raises(IOError):
-        load_fchk(get_fn('fubar_crap.fchk'))
+        with path('iodata.test.cached', 'fubar_crap.fchk') as fn:
+            load_fchk(str(fn))
 
 
 def test_load_fchk_hf_sto3g_num():
-    fields = load_fchk(get_fn('hf_sto3g.fchk'))
+    with path('iodata.test.cached', 'hf_sto3g.fchk') as fn:
+        fields = load_fchk(str(fn))
     assert fields['title'] == 'hf_sto3g'
     obasis = fields['obasis']
     coordinates = fields['coordinates']
@@ -132,7 +137,8 @@ def test_load_fchk_hf_sto3g_num():
 
 
 def test_load_fchk_h_sto3g_num():
-    fields = load_fchk(get_fn('h_sto3g.fchk'))
+    with path('iodata.test.cached', 'h_sto3g.fchk') as fn:
+        fields = load_fchk(str(fn))
     assert fields['title'] == 'h_sto3g'
     obasis = fields['obasis']
     coordinates = fields['coordinates']
@@ -148,7 +154,8 @@ def test_load_fchk_h_sto3g_num():
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
-    fields = load_fchk(get_fn('o2_cc_pvtz_pure.fchk'))
+    with path('iodata.test.cached', 'o2_cc_pvtz_pure.fchk') as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     coordinates = fields['coordinates']
     numbers = fields['numbers']
@@ -162,7 +169,8 @@ def test_load_fchk_o2_cc_pvtz_pure_num():
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
-    fields = load_fchk(get_fn('o2_cc_pvtz_cart.fchk'))
+    with path('iodata.test.cached', 'o2_cc_pvtz_cart.fchk') as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     coordinates = fields['coordinates']
     numbers = fields['numbers']
@@ -176,7 +184,8 @@ def test_load_fchk_o2_cc_pvtz_cart_num():
 
 
 def test_load_fchk_water_sto3g_hf():
-    fields = load_fchk(get_fn('water_sto3g_hf_g03.fchk'))
+    with path('iodata.test.cached', 'water_sto3g_hf_g03.fchk') as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     assert len(obasis["shell_types"]) == 5
     assert shells_to_nbasis(obasis["shell_types"]) == 7
@@ -205,7 +214,8 @@ def test_load_fchk_water_sto3g_hf():
 
 
 def test_load_fchk_lih_321g_hf():
-    fields = load_fchk(get_fn('li_h_3-21G_hf_g09.fchk'))
+    with path('iodata.test.cached', 'li_h_3-21G_hf_g09.fchk') as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     assert len(obasis["shell_types"]) == 7
     assert shells_to_nbasis(obasis["shell_types"]) == 11
@@ -254,7 +264,8 @@ def test_load_fchk_lih_321g_hf():
 
 def test_load_fchk_ghost_atoms():
     # Load fchk file with ghost atoms
-    fields = load_fchk(get_fn('water_dimer_ghost.fchk'))
+    with path('iodata.test.cached', 'water_dimer_ghost.fchk') as fn:
+        fields = load_fchk(str(fn))
     numbers = fields['numbers']
     coordinates = fields['coordinates']
     mulliken_charges = fields['mulliken_charges']
@@ -269,7 +280,8 @@ def test_load_fchk_ghost_atoms():
 
 
 def test_load_fchk_ch3_rohf_g03():
-    fields = load_fchk(get_fn('ch3_rohf_sto3g_g03.fchk'))
+    with path('iodata.test.cached', 'ch3_rohf_sto3g_g03.fchk') as fn:
+        fields = load_fchk(str(fn))
     orb_alpha = fields['orb_alpha']
     orb_alpha_coeffs = fields['orb_alpha_coeffs']
     orb_alpha_occs = fields['orb_alpha_occs']
@@ -286,7 +298,8 @@ def test_load_fchk_ch3_rohf_g03():
 
 
 def check_load_azirine(key, numbers):
-    fields = load_fchk(get_fn('2h-azirine-%s.fchk') % key)
+    with path('iodata.test.cached', '2h-azirine-{}.fchk'.format(key)) as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     assert shells_to_nbasis(obasis["shell_types"]) == 33
     dm_full = fields['dm_full_%s' % key]
@@ -311,7 +324,8 @@ def test_load_azirine_mp3():
 
 
 def check_load_nitrogen(key, numbers_full, numbers_spin):
-    fields = load_fchk(get_fn('nitrogen-%s.fchk') % key)
+    with path('iodata.test.cached', 'nitrogen-{}.fchk'.format(key)) as fn:
+        fields = load_fchk(str(fn))
     obasis = fields['obasis']
     assert shells_to_nbasis(obasis["shell_types"]) == 9
     dm_full = fields['dm_full_%s' % key]
@@ -340,7 +354,8 @@ def test_load_nitrogen_mp3():
 
 def check_normalization_dm_full_azirine(key):
     #TODO: replace with cached data
-    mol = IOData.from_file(get_fn('2h-azirine-%s.fchk') % key)
+    with path('iodata.test.cached', '2h-azirine-{}.fchk'.format(key)) as fn:
+        mol = IOData.from_file(str(fn))
     olp = compute_overlap(**mol.obasis)
     dm = getattr(mol, 'dm_full_%s' % key)
     check_dm(dm, olp, eps=1e-2, occ_max=2)
@@ -364,7 +379,8 @@ def test_normalization_dm_full_azirine_mp3():
 
 
 def test_load_water_hfs_321g():
-    mol = IOData.from_file(get_fn('water_hfs_321g.fchk'))
+    with path('iodata.test.cached', 'water_hfs_321g.fchk') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.polar[0, 0] == 7.23806684E+00
     assert mol.polar[1, 1] == 8.04213953E+00
     assert mol.polar[1, 2] == 1.20021770E-10
@@ -380,7 +396,8 @@ def test_load_water_hfs_321g():
 
 
 def test_load_monosilicic_acid_hf_lan():
-    mol = IOData.from_file(get_fn('monosilicic_acid_hf_lan.fchk'))
+    with path('iodata.test.cached', 'monosilicic_acid_hf_lan.fchk') as fn:
+        mol = IOData.from_file(str(fn))
     np.testing.assert_allclose(mol.dipole_moment, [
         -6.05823053E-01, -9.39656399E-03, 4.18948869E-01])
     np.testing.assert_allclose(mol.quadrupole_moment, [

--- a/iodata/test/test_gaussian.py
+++ b/iodata/test/test_gaussian.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.gaussian module."""
 
 

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -26,9 +26,12 @@ import numpy as np
 
 from numpy.testing import assert_raises
 
-from . common import get_fn
 from .. iodata import IOData
 from .. overlap import compute_overlap
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 
 def test_typecheck():
@@ -62,8 +65,8 @@ def test_unknown_format():
 
 
 def test_dm_water_sto3g_hf():
-    fn_fchk = get_fn('water_sto3g_hf_g03.fchk')
-    mol = IOData.from_file(fn_fchk)
+    with path('iodata.test.cached', 'water_sto3g_hf_g03.fchk') as fn_fchk:
+        mol = IOData.from_file(str(fn_fchk))
     dm = mol.get_dm_full()
     assert abs(dm[0, 0] - 2.10503807) < 1e-7
     assert abs(dm[0, 1] - -0.439115917) < 1e-7
@@ -75,8 +78,8 @@ def test_dm_water_sto3g_hf():
 
 
 def test_dm_lih_sto3g_hf():
-    fn_fchk = get_fn('li_h_3-21G_hf_g09.fchk')
-    mol = IOData.from_file(fn_fchk)
+    with path('iodata.test.cached', 'li_h_3-21G_hf_g09.fchk') as fn_fchk:
+        mol = IOData.from_file(str(fn_fchk))
 
     dm_full = mol.get_dm_full()
     assert abs(dm_full[0, 0] - 1.96589709) < 1e-7
@@ -100,8 +103,8 @@ def test_dm_lih_sto3g_hf():
 
 
 def test_dm_ch3_rohf_g03():
-    fn_fchk = get_fn('ch3_rohf_sto3g_g03.fchk')
-    mol = IOData.from_file(fn_fchk)
+    with path('iodata.test.cached', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
+        mol = IOData.from_file(str(fn_fchk))
 
     olp = compute_overlap(**mol.obasis)
     dm = mol.get_dm_full()

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -23,18 +23,21 @@
 
 import numpy as np, os
 
-from . common import compute_mulliken_charges, get_fn, tmpdir, compare_mols, check_normalization
+from . common import compute_mulliken_charges, tmpdir, compare_mols, check_normalization
 from .. iodata import IOData
 from .. overlap import compute_overlap
-
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 #TODO: optional import for obasis?
 #TODO: remove mulliken charges?
 
 
 def test_load_molden_li2_orca():
-    fn_molden = get_fn('li2.molden.input')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'li2.molden.input') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
 
     # Checkt title
     assert mol.title == 'Molden file created by orca_2mkl for BaseName=li2'
@@ -52,8 +55,8 @@ def test_load_molden_li2_orca():
 
 
 def test_load_molden_h2o_orca():
-    fn_molden = get_fn('h2o.molden.input')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'h2o.molden.input') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
 
     # Checkt title
     assert mol.title == 'Molden file created by orca_2mkl for BaseName=h2o'
@@ -72,8 +75,8 @@ def test_load_molden_h2o_orca():
 def test_load_molden_nh3_molden_pure():
     # The file tested here is created with molden. It should be read in
     # properly without altering normalization and sign conventions.
-    fn_molden = get_fn('nh3_molden_pure.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_molden_pure.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -84,8 +87,8 @@ def test_load_molden_nh3_molden_pure():
 def test_load_molden_nh3_molden_cart():
     # The file tested here is created with molden. It should be read in
     # properly without altering normalization and sign conventions.
-    fn_molden = get_fn('nh3_molden_cart.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_molden_cart.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -96,8 +99,8 @@ def test_load_molden_nh3_molden_cart():
 def test_load_molden_nh3_orca():
     # The file tested here is created with ORCA. It should be read in
     # properly by altering normalization and sign conventions.
-    fn_molden = get_fn('nh3_orca.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_orca.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -108,8 +111,8 @@ def test_load_molden_nh3_orca():
 def test_load_molden_nh3_psi4():
     # The file tested here is created with PSI4 (pre 1.0). It should be read in
     # properly by altering normalization conventions.
-    fn_molden = get_fn('nh3_psi4.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_psi4_1.0.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -120,8 +123,8 @@ def test_load_molden_nh3_psi4():
 def test_load_molden_nh3_psi4_1():
     # The file tested here is created with PSI4 (version 1.0). It should be read in
     # properly by renormalizing the contractions.
-    fn_molden = get_fn('nh3_psi4_1.0.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_psi4_1.0.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -132,8 +135,8 @@ def test_load_molden_nh3_psi4_1():
 def test_load_molden_he2_ghost_psi4_1():
     # The file tested here is created with PSI4 (version 1.0). It should be read in
     # properly by ignoring the ghost atoms.
-    fn_molden = get_fn('he2_ghost_psi4_1.0.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'he2_ghost_psi4_1.0.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     np.testing.assert_equal(mol.pseudo_numbers, np.array([2.0]))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
@@ -144,8 +147,8 @@ def test_load_molden_he2_ghost_psi4_1():
 
 def test_load_molden_nh3_molpro2012():
     # The file tested here is created with MOLPRO2012.
-    fn_molden = get_fn('nh3_molpro2012.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_molpro2012.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Molden program output.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -155,8 +158,8 @@ def test_load_molden_nh3_molpro2012():
 
 def test_load_molden_neon_turbomole():
     # The file tested here is created with Turbomole 7.1.
-    fn_molden = get_fn('neon_turbomole_def2-qzvp.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'neon_turbomole_def2-qzvp.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges.
     dm_full = mol.get_dm_full()
     charges = compute_mulliken_charges(mol.obasis, mol.pseudo_numbers, dm_full)
@@ -165,8 +168,8 @@ def test_load_molden_neon_turbomole():
 
 def test_load_molden_nh3_turbomole():
     # The file tested here is created with Turbomole 7.1
-    fn_molden = get_fn('nh3_turbomole.molden')
-    mol = IOData.from_file(fn_molden)
+    with path('iodata.test.cached', 'nh3_turbomole.molden') as fn_molden:
+        mol = IOData.from_file(str(fn_molden))
     # Check Mulliken charges. Comparison with numbers from the Turbomole output. These
     # are slightly different than in the other tests because we are using Cartesian
     # functions.
@@ -177,7 +180,8 @@ def test_load_molden_nh3_turbomole():
 
 
 def check_load_dump_consistency(fn):
-    mol1 = IOData.from_file(get_fn(fn))
+    with path('iodata.test.cached', fn) as file_name:
+        mol1 = IOData.from_file(str(file_name))
     with tmpdir('io.test.test_molden.check_load_dump_consistency.%s' % fn) as dn:
         fn_tmp = os.path.join(dn, 'foo.molden')
         mol1.to_file(fn_tmp)

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.molden module."""
 
 

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -21,18 +21,20 @@
 """Test iodata.molekel module."""
 
 
-from . common import get_fn, check_normalization
+from . common import check_normalization
 from .. iodata import IOData
 from .. utils import angstrom, shells_to_nbasis
 from .. overlap import compute_overlap
 
-
-#TODO: optional gbasis import?
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 
 def test_load_mkl_ethanol():
-    fn_mkl = get_fn('ethanol.mkl')
-    mol = IOData.from_file(fn_mkl)
+    with path('iodata.test.cached', 'ethanol.mkl') as fn_mkl:
+        mol = IOData.from_file(str(fn_mkl))
 
     # Direct checks with mkl file
     assert mol.numbers.shape == (9,)
@@ -64,8 +66,8 @@ def test_load_mkl_ethanol():
 
 
 def test_load_mkl_li2():
-    fn_mkl = get_fn('li2.mkl')
-    mol = IOData.from_file(fn_mkl)
+    with path('iodata.test.cached', 'li2.mkl') as fn_mkl:
+        mol = IOData.from_file(str(fn_mkl))
 
     # Check normalization
     olp = compute_overlap(**mol.obasis)
@@ -74,7 +76,7 @@ def test_load_mkl_li2():
 
 
 def test_load_mkl_h2():
-    fn_mkl = get_fn('h2_sto3g.mkl')
-    mol = IOData.from_file(fn_mkl)
+    with path('iodata.test.cached', 'h2_sto3g.mkl') as fn_mkl:
+        mol = IOData.from_file(str(fn_mkl))
     olp = compute_overlap(**mol.obasis)
     check_normalization(mol.orb_alpha_coeffs, mol.orb_alpha_occs, olp, 1e-5)

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.molekel module."""
 
 

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -22,12 +22,17 @@
 
 import numpy as np
 
-from .common import get_fn, tmpdir
+from .common import tmpdir
 from ..iodata import IOData
 
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 def test_load_fcidump_psi4_h2():
-    mol = IOData.from_file(get_fn('FCIDUMP.psi4.h2'))
+    with path('iodata.test.cached', 'FCIDUMP.psi4.h2') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.core_energy == 0.7151043364864863E+00
     assert mol.nelec == 2
     assert mol.ms2 == 0
@@ -51,7 +56,8 @@ def test_load_fcidump_psi4_h2():
 
 
 def test_load_fcidump_molpro_h2():
-    mol = IOData.from_file(get_fn('FCIDUMP.molpro.h2'))
+    with path('iodata.test.cached', 'FCIDUMP.molpro.h2') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.core_energy == 0.7151043364864863E+00
     assert mol.nelec == 2
     assert mol.ms2 == 0
@@ -76,11 +82,14 @@ def test_load_fcidump_molpro_h2():
 
 def test_dump_load_fcidimp_consistency_ao():
     # Setup IOData
-    mol0 = IOData.from_file(get_fn('water.xyz'))
+    with path('iodata.test.cached', 'water.xyz') as fn:
+        mol0 = IOData.from_file(str(fn))
     mol0.nelec = 10
     mol0.ms2 = 1
-    mol0.one_mo = np.load(get_fn("psi4_h2_one.npy"))
-    mol0.two_mo = np.load(get_fn("psi4_h2_two.npy"))
+    with path('iodata.test.cached', 'psi4_h2_one.npy') as fn:
+        mol0.one_mo = np.load(str(fn))
+    with path('iodata.test.cached', 'psi4_h2_two.npy') as fn:
+        mol0.two_mo = np.load(str(fn))
 
     # Dump to a file and load it again
     with tmpdir('io.test.test_molpro.test_dump_load_fcidump_consistency_ao') as dn:

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.molpro module."""
 
 import numpy as np

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import numpy as np

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -23,7 +23,11 @@
 import numpy as np
 from .. overlap import compute_overlap
 from iodata.overlap_accel import fac2, _binom
-from . common import get_fn
+
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 
 def test_fac2():
@@ -49,7 +53,8 @@ def test_binom():
 
 
 def test_load_fchk_hf_sto3g_num():
-    ref = np.load(get_fn("load_fchk_hf_sto3g_num.npy"))
+    with path('iodata.test.cached', 'load_fchk_hf_sto3g_num.npy') as fn_npy:
+        ref = np.load(str(fn_npy))
     d = dict([('centers', np.array([[0., 0., 0.19048439],
                                     [0., 0., -1.71435955]])),
               ('shell_map', np.array([0, 0, 0, 1])),
@@ -66,7 +71,8 @@ def test_load_fchk_hf_sto3g_num():
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
-    ref = np.load(get_fn("load_fchk_o2_cc_pvtz_pure_num.npy"))
+    with path('iodata.test.cached', 'load_fchk_o2_cc_pvtz_pure_num.npy') as fn_npy:
+        ref = np.load(str(fn_npy))
     d = dict([('centers', np.array([[0.00000000e+00, 0.00000000e+00, 1.09122830e+00],
                                     [1.33636924e-16, 0.00000000e+00, -1.09122830e+00]])), (
                   'shell_map',
@@ -111,7 +117,8 @@ def test_load_fchk_o2_cc_pvtz_pure_num():
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
-    ref = np.load(get_fn("load_fchk_o2_cc_pvtz_cart_num.npy"))
+    with path('iodata.test.cached', 'load_fchk_o2_cc_pvtz_cart_num.npy') as fn_npy:
+        ref = np.load(str(fn_npy))
     d = dict([('centers', np.array([[0.00000000e+00, 0.00000000e+00, 1.09122830e+00],
                                     [1.33636924e-16, 0.00000000e+00, -1.09122830e+00]])), (
                   'shell_map',

--- a/iodata/test/test_vasp.py
+++ b/iodata/test/test_vasp.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.vasp module."""
 
 import numpy as np

--- a/iodata/test/test_vasp.py
+++ b/iodata/test/test_vasp.py
@@ -20,13 +20,16 @@
 # --
 """Test iodata.vasp module."""
 
-
 import numpy as np
 
-from . common import get_fn, tmpdir, get_random_cell
+from . common import tmpdir, get_random_cell
 from .. utils import angstrom, electronvolt, volume
 from .. iodata import IOData
 from .. vasp import _unravel_counter
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 
 def test_unravel_counter():
@@ -42,8 +45,8 @@ def test_unravel_counter():
 
 
 def test_load_chgcar_oxygen():
-    fn = get_fn('CHGCAR.oxygen')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'CHGCAR.oxygen') as fn:
+        mol = IOData.from_file(str(fn))
     assert (mol.numbers == [8]).all()
     assert abs(volume(mol.rvecs) - (10 * angstrom) ** 3) < 1e-10
     ugrid = mol.grid
@@ -58,8 +61,8 @@ def test_load_chgcar_oxygen():
 
 
 def test_load_chgcar_water():
-    fn = get_fn('CHGCAR.water')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'CHGCAR.water') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.title == 'unknown system'
     assert (mol.numbers == [8, 1, 1]).all()
     coords = np.array([0.074983 * 15 + 0.903122 * 1, 0.903122 * 15, 0.000000])
@@ -73,8 +76,8 @@ def test_load_chgcar_water():
 
 
 def test_load_locpot_oxygen():
-    fn = get_fn('LOCPOT.oxygen')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'LOCPOT.oxygen') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.title == 'O atom in a box'
     assert (mol.numbers[0] == [8]).all()
     assert abs(volume(mol.rvecs) - (10 * angstrom) ** 3) < 1e-10
@@ -90,8 +93,8 @@ def test_load_locpot_oxygen():
 
 
 def test_load_poscar_water():
-    fn = get_fn('POSCAR.water')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'POSCAR.water') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.title == 'Water molecule in a box'
     assert (mol.numbers == [8, 1, 1]).all()
     coords = np.array([0.074983 * 15, 0.903122 * 15, 0.000000])
@@ -100,8 +103,8 @@ def test_load_poscar_water():
 
 
 def test_load_poscar_cubicbn_cartesian():
-    fn = get_fn('POSCAR.cubicbn_cartesian')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'POSCAR.cubicbn_cartesian') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.title == 'Cubic BN'
     assert (mol.numbers == [5, 7]).all()
     assert abs(mol.coordinates[1] - np.array([0.25] * 3) * 3.57 * angstrom).max() < 1e-10
@@ -109,8 +112,8 @@ def test_load_poscar_cubicbn_cartesian():
 
 
 def test_load_poscar_cubicbn_direct():
-    fn = get_fn('POSCAR.cubicbn_direct')
-    mol = IOData.from_file(fn)
+    with path('iodata.test.cached', 'POSCAR.cubicbn_direct') as fn:
+        mol = IOData.from_file(str(fn))
     assert mol.title == 'Cubic BN'
     assert (mol.numbers == [5, 7]).all()
     assert abs(mol.coordinates[1] - np.array([0.25] * 3) * 3.57 * angstrom).max() < 1e-10
@@ -118,7 +121,8 @@ def test_load_poscar_cubicbn_direct():
 
 
 def test_load_dump_consistency():
-    mol0 = IOData.from_file(get_fn('water_element.xyz'))
+    with path('iodata.test.cached', 'water_element.xyz') as fn:
+        mol0 = IOData.from_file(str(fn))
     mol0.rvecs = get_random_cell(5.0, 3)
     mol0.gvecs = np.linalg.inv(mol0.rvecs).T
 

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Test iodata.wfn module."""
 
 
@@ -38,8 +39,10 @@ except ImportError:
 
 def test_load_wfn_low_he_s():
     with path('iodata.test.cached', 'he_s_orbital.wfn') as fn_wfn:
-        title, numbers, coordinates, centers, type_assignment, exponents, \
-        mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(str(fn_wfn))
+        data = load_wfn_low(str(fn_wfn))
+    # unpack data
+    title, numbers, coordinates, centers, type_assignment = data[:5]
+    exponents, mo_count, occ_num, mo_energy, coefficients, energy = data[5:]
     assert title == 'He atom - decontracted 6-31G basis set'
     assert numbers.shape == (1,)
     assert numbers == [2]
@@ -65,8 +68,10 @@ def test_load_wfn_low_he_s():
 
 def test_load_wfn_low_h2o():
     with path('iodata.test.cached', 'h2o_sto3g.wfn') as fn_wfn:
-        title, numbers, coordinates, centers, type_assignment, exponents, \
-        mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(str(fn_wfn))
+        data = load_wfn_low(str(fn_wfn))
+    # unpack data
+    title, numbers, coordinates, centers, type_assignment = data[:5]
+    exponents, mo_count, occ_num, mo_energy, coefficients, energy = data[5:]
     assert title == 'H2O Optimization'
     assert numbers.shape == (3,)
     assert (numbers == np.array([8, 1, 1])).all()

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -22,20 +22,24 @@
 
 
 import numpy as np
-from .common import compute_mulliken_charges, get_fn, check_normalization
+from .common import compute_mulliken_charges, check_normalization
 from ..wfn import load_wfn_low, get_permutation_basis, get_permutation_orbital, get_mask
 from ..iodata import IOData
 from ..overlap import compute_overlap
 from ..utils import shells_to_nbasis
 
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 # TODO: removed density, kin, nucnuc checks
 
 
 def test_load_wfn_low_he_s():
-    fn_wfn = get_fn('he_s_orbital.wfn')
-    title, numbers, coordinates, centers, type_assignment, exponents, \
-    mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(fn_wfn)
+    with path('iodata.test.cached', 'he_s_orbital.wfn') as fn_wfn:
+        title, numbers, coordinates, centers, type_assignment, exponents, \
+        mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(str(fn_wfn))
     assert title == 'He atom - decontracted 6-31G basis set'
     assert numbers.shape == (1,)
     assert numbers == [2]
@@ -60,9 +64,9 @@ def test_load_wfn_low_he_s():
 
 
 def test_load_wfn_low_h2o():
-    fn_wfn = get_fn('h2o_sto3g.wfn')
-    title, numbers, coordinates, centers, type_assignment, exponents, \
-    mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(fn_wfn)
+    with path('iodata.test.cached', 'h2o_sto3g.wfn') as fn_wfn:
+        title, numbers, coordinates, centers, type_assignment, exponents, \
+        mo_count, occ_num, mo_energy, coefficients, energy = load_wfn_low(str(fn_wfn))
     assert title == 'H2O Optimization'
     assert numbers.shape == (3,)
     assert (numbers == np.array([8, 1, 1])).all()
@@ -182,8 +186,8 @@ def test_get_mask():
 
 
 def check_wfn(fn_wfn, restricted, nbasis, energy, charges):
-    fn_wfn = get_fn(fn_wfn)
-    mol = IOData.from_file(fn_wfn)
+    with path('iodata.test.cached', fn_wfn) as file_wfn:
+        mol = IOData.from_file(str(file_wfn))
     assert shells_to_nbasis(mol.obasis["shell_types"]) == nbasis
     olp = compute_overlap(**mol.obasis)
     if restricted:
@@ -259,8 +263,8 @@ def test_load_wfn_li_sp_virtual():
 
 
 def test_load_wfn_li_sp():
-    fn_wfn = get_fn('li_sp_orbital.wfn')
-    mol = IOData.from_file(fn_wfn)
+    with path('iodata.test.cached', 'li_sp_orbital.wfn') as fn_wfn:
+        mol = IOData.from_file(str(fn_wfn))
     assert mol.title == 'Li atom - using s & p orbitals'
     assert mol.orb_alpha[1] == 2
     assert mol.orb_beta[1] == 1

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -24,21 +24,26 @@
 
 import numpy as np
 
-from .common import get_fn, tmpdir
-
+from .common import tmpdir
 from ..iodata import IOData
 from ..utils import angstrom
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
 
 
 def test_load_water_number():
     # test xyz with atomic numbers
-    mol = IOData.from_file(get_fn('water_number.xyz'))
+    with path('iodata.test.cached', 'water_number.xyz') as fn_xyz:
+        mol = IOData.from_file(str(fn_xyz))
     check_water(mol)
 
 
 def test_load_water_element():
     # test xyz file with atomic symbols
-    mol = IOData.from_file(get_fn('water_element.xyz'))
+    with path('iodata.test.cached', 'water_element.xyz') as fn_xyz:
+        mol = IOData.from_file(str(fn_xyz))
     check_water(mol)
 
 
@@ -55,7 +60,8 @@ def check_water(mol):
 
 
 def test_load_dump_consistency():
-    mol0 = IOData.from_file(get_fn('ch3_hf_sto3g.fchk'))
+    with path('iodata.test.cached', 'ch3_hf_sto3g.fchk') as fn_fchk:
+        mol0 = IOData.from_file(str(fn_fchk))
     # write xyz file in a temporary folder & then read it
     with tmpdir('io.test.test_xyz.test_load_dump_consistency') as dn:
         mol0.to_file('%s/test.xyz' % dn)
@@ -67,7 +73,8 @@ def test_load_dump_consistency():
 
 
 def test_dump_xyz_water_element():
-    mol0 = IOData.from_file(get_fn('water_element.xyz'))
+    with path('iodata.test.cached', 'water_element.xyz') as fn_xyz:
+        mol0 = IOData.from_file(str(fn_xyz))
     with tmpdir('io.test.test_xyz.test_dump_xyz_water_element') as dn:
         mol0.to_file('%s/test.xyz' % dn)
         mol1 = IOData.from_file('%s/test.xyz' % dn)
@@ -78,7 +85,8 @@ def test_dump_xyz_water_element():
 
 
 def test_dump_xyz_water_number():
-    mol0 = IOData.from_file(get_fn('water_number.xyz'))
+    with path('iodata.test.cached', 'water_number.xyz') as fn_xyz:
+        mol0 = IOData.from_file(str(fn_xyz))
     with tmpdir('io.test.test_xyz.test_dump_xyz_water_number') as dn:
         mol0.to_file('%s/test.xyz' % dn)
         mol1 = IOData.from_file('%s/test.xyz' % dn)

--- a/iodata/vasp.py
+++ b/iodata/vasp.py
@@ -18,6 +18,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pragma pylint: disable=invalid-name
 """Module for handling VASP POSCAR, CHGCAR and POTCAR file formats."""
 
 

--- a/setup.py
+++ b/setup.py
@@ -47,5 +47,6 @@ setup(
     ],
     zip_safe=False,
     setup_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy'],
-    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'nose>=0.11'],
+    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'nose>=0.11',
+                      'importlib_resources; python_version < "3.7"'],
 )

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -21,6 +21,7 @@ requirements:
   run:
     - python
     - scipy
+    - importlib_resources
 test:
   requires:
     - python


### PR DESCRIPTION
1. Remove get_fn function in common
2. Use importlib.resources (3.7) or import_resources (<3.7)
3. Add importlib_resources to dependence
Ref:https://github.com/theochem/iodata/issues/17