### PR TITLE
Use pytest instead of nosetests

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+codecov:
+  notify:
+    require_ci_to_pass: no

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,8 +117,8 @@ install:
 # Install conda tools for packaging and uploading
 - conda install -q python=${MYCONDAPY} anaconda-client numpy setuptools cython
 - if ! [[ $TRAVIS_TAG ]]; then
-    conda install -q ${CONDA_DEPENDENCIES};
-    pip install --upgrade pylint codecov coverage pycodestyle pydocstyle;
+    conda install -q ${CONDA_DEPENDENCIES} pytest-cov;
+    pip install --upgrade pylint codecov pycodestyle pydocstyle;
   fi
 # Show conda info for debugging
 - conda info -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,10 +141,8 @@ script:
     conda build -q tools/conda.recipe;
   else
     python setup.py build_ext -i --define CYTHON_TRACE_NOGIL &&
-    nosetests ${PROJECT_NAME}
-         -v --detailed-errors --with-coverage --cover-package=${PROJECT_NAME}
-         --cover-tests --cover-inclusive --cover-branches &&
-    coverage xml -i &&
+    pytest ${PROJECT_NAME} -v --cov=${PROJECT_NAME} --cov-report xml
+           --cov-report term --cov-branch
 
     if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
        cardboardlinter --refspec $TRAVIS_BRANCH -f 'dynamic';

--- a/.travis.yml
+++ b/.travis.yml
@@ -146,8 +146,8 @@ script:
 - if ! [[ $TRAVIS_TAG ]]; then
     python setup.py build_ext -i --define CYTHON_TRACE_NOGIL &&
     pytest ${PROJECT_NAME} -v --cov=${PROJECT_NAME} --cov-report xml
-           --cov-report term --cov-branch
-    codecov -f coverage.xml
+           --cov-report term --cov-branch &&
+    codecov -f coverage.xml;
   fi
 
 # Dynamic linting

--- a/.travis.yml
+++ b/.travis.yml
@@ -130,36 +130,37 @@ install:
 
 script:
 # Static linting
-# --------------
+# ~~~~~~~~~~~~~~
 - if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
     cardboardlinter --refspec $TRAVIS_BRANCH -f static;
   fi
 
-# Unit tests and dynamic linting
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Conda package build
+# ~~~~~~~~~~
 - if [[ $TRAVIS_TAG ]]; then
     conda build -q tools/conda.recipe;
-  else
+  fi
+
+# Unit tests
+# ~~~~~~~~~~
+- if ! [[ $TRAVIS_TAG ]]; then
     python setup.py build_ext -i --define CYTHON_TRACE_NOGIL &&
     pytest ${PROJECT_NAME} -v --cov=${PROJECT_NAME} --cov-report xml
            --cov-report term --cov-branch
+    codecov -f coverage.xml
+  fi
 
-    if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
-       cardboardlinter --refspec $TRAVIS_BRANCH -f 'dynamic';
-    fi
+# Dynamic linting
+# ~~~~~~~~~~~~~~~
+- if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then
+     cardboardlinter --refspec $TRAVIS_BRANCH -f 'dynamic';
   fi
 
 # Make CPP and PY source package for github deployment
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 - if [[ $TRAVIS_TAG ]]; then
     python setup.py sdist;
   fi
-
-# Some other stuff
-# ----------------
-
-after_success:
-# Upload the coverage analysis
-- codecov -f coverage.xml
 
 before_deploy:
 # Try to set some env vars to configure deployment.

--- a/README.rst
+++ b/README.rst
@@ -50,8 +50,9 @@ The following dependencies will be necessary for IOData to build properly,
 * Python >= 3.6: http://www.python.org/
 * SciPy >= 0.11.0: http://www.scipy.org/
 * NumPy >= 1.9.1: http://www.numpy.org/
-* Nosetests >= 1.1.2: http://readthedocs.org/docs/nose/en/latest/
+* pytest >= 4.2.0: https://docs.pytest.org/
 * Cython
+* gcc/clang
 
 
 Installation

--- a/doc/dev_building.rst
+++ b/doc/dev_building.rst
@@ -53,7 +53,7 @@ making sure your code complies with PEP-8, PEP-257, and so forth. Use the
 code refactoring features.
 
 You will also find that testing locally can save you some time.
-Run nosetests on your own machine before submitting your PR.
+Run pytest on your own machine before submitting your PR.
 
 Building with Conda on your own machine will emulate lots of the build
 tests and give you a virtualenv that will be more reliable.
@@ -107,7 +107,8 @@ C/C++ dependencies.
     - cython >=0.24.1
     - numpy
     - setuptools
-    - nose
+    - pytest
+    - pytest-cov
 
 The ``run`` section is for installing dependencies on the user's machine. This is for Python
 dependencies. This is also for libraries which need to be dynamically linked. In theory the Conda
@@ -120,7 +121,8 @@ the process is not reliable. You are advised to add them in as well.
     - python >=3
     - numpy
     - scipy
-    - nose
+    - pytest
+    - pytest-cov
     - libint
 
 For details on the ``meta.yaml`` file, read the

--- a/doc/dev_building.rst
+++ b/doc/dev_building.rst
@@ -108,7 +108,6 @@ C/C++ dependencies.
     - numpy
     - setuptools
     - pytest
-    - pytest-cov
 
 The ``run`` section is for installing dependencies on the user's machine. This is for Python
 dependencies. This is also for libraries which need to be dynamically linked. In theory the Conda
@@ -122,7 +121,6 @@ the process is not reliable. You are advised to add them in as well.
     - numpy
     - scipy
     - pytest
-    - pytest-cov
     - libint
 
 For details on the ``meta.yaml`` file, read the

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -65,12 +65,12 @@ but the procedure is entirely unsupported.
 
 The following dependencies will be necessary for IOData to build properly,
 
-* Python >= 3.7
-* NumPy >= 1.9.1
-* Scipy
-* Nosetests
-* gcc/clang
+* Python >= 3.6: http://www.python.org/
+* SciPy >= 0.11.0: http://www.scipy.org/
+* NumPy >= 1.9.1: http://www.numpy.org/
+* pytest >= 4.2.0: https://docs.pytest.org/
 * Cython
+* gcc/clang
 
 
 Testing
@@ -81,7 +81,7 @@ them again on your own machine:
 
 .. code-block:: bash
 
-    $ nosetests -v iodata
+    $ pytest -v iodata
 
 Building Docs
 -------------

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -87,6 +87,7 @@ def truncated_file(fn_orig, nline, nadd, tmpdir):
         The number of empty lines to add.
     tmpdir : str
         A temporary directory where the truncated file is stored.
+
     """
     fn_truncated = '%s/truncated_%i_%s' % (tmpdir, nline, path.basename(fn_orig))
     with open(fn_orig) as f_orig, open(fn_truncated, 'w') as f_truncated:

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -74,39 +74,31 @@ def compute_mulliken_charges(iodata, pseudo_numbers=None):
 
 
 @contextmanager
-def tmpdir(name):
-    dn = tempfile.mkdtemp(name)
-    try:
-        yield dn
-    finally:
-        shutil.rmtree(dn)
-
-
-@contextmanager
-def truncated_file(name, fn_orig, nline, nadd):
+def truncated_file(name, fn_orig, nline, nadd, tmpdir):
     """Make a temporary truncated copy of a file.
 
     Parameters
     ----------
     name : str
-           The name of test, used to make a unique temporary directory
+        The name of test, used to make a unique temporary directory
     fn_orig : str
-              The file to be truncated.
+        The file to be truncated.
     nline : int
-            The number of lines to retain.
+        The number of lines to retain.
     nadd : int
-           The number of empty lines to add.
+        The number of empty lines to add.
+    tmpdir : str
+        A temporary directory where the truncated file is stored.
     """
-    with tmpdir(name) as dn:
-        fn_truncated = '%s/truncated_%i_%s' % (dn, nline, path.basename(fn_orig))
-        with open(fn_orig) as f_orig, open(fn_truncated, 'w') as f_truncated:
-            for counter, line in enumerate(f_orig):
-                if counter >= nline:
-                    break
-                f_truncated.write(line)
-            for _ in range(nadd):
-                f_truncated.write('\n')
-        yield fn_truncated
+    fn_truncated = '%s/truncated_%i_%s' % (tmpdir, nline, path.basename(fn_orig))
+    with open(fn_orig) as f_orig, open(fn_truncated, 'w') as f_truncated:
+        for counter, line in enumerate(f_orig):
+            if counter >= nline:
+                break
+            f_truncated.write(line)
+        for _ in range(nadd):
+            f_truncated.write('\n')
+    yield fn_truncated
 
 
 def compare_mols(mol1, mol2):

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -74,13 +74,11 @@ def compute_mulliken_charges(iodata, pseudo_numbers=None):
 
 
 @contextmanager
-def truncated_file(name, fn_orig, nline, nadd, tmpdir):
+def truncated_file(fn_orig, nline, nadd, tmpdir):
     """Make a temporary truncated copy of a file.
 
     Parameters
     ----------
-    name : str
-        The name of test, used to make a unique temporary directory
     fn_orig : str
         The file to be truncated.
     nline : int

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -22,7 +22,7 @@
 # pragma pylint: disable=invalid-name
 """Test iodata.cp2k module."""
 
-from nose.tools import assert_raises
+import pytest
 
 from . common import truncated_file, check_orthonormal
 
@@ -176,21 +176,21 @@ def test_carbon_sc_pp_uncontracted():
     check_orthonormality(mol)
 
 
-def test_errors():
+def test_errors(tmpdir):
     with path('iodata.test.data', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_test:
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 0, 0) as fn:
-            with assert_raises(IOError):
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 0, 0, tmpdir) as fn:
+            with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 107, 10) as fn:
-            with assert_raises(IOError):
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 107, 10, tmpdir) as fn:
+            with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 357, 10) as fn:
-            with assert_raises(IOError):
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 357, 10, tmpdir) as fn:
+            with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 405, 10) as fn:
-            with assert_raises(IOError):
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 405, 10, tmpdir) as fn:
+            with pytest.raises(IOError):
                 IOData.from_file(fn)
     with path('iodata.test.data', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_test:
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 456, 10) as fn:
-            with assert_raises(IOError):
+        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 456, 10, tmpdir) as fn:
+            with pytest.raises(IOError):
                 IOData.from_file(fn)

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -178,19 +178,19 @@ def test_carbon_sc_pp_uncontracted():
 
 def test_errors(tmpdir):
     with path('iodata.test.data', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_test:
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 0, 0, tmpdir) as fn:
+        with truncated_file(fn_test, 0, 0, tmpdir) as fn:
             with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 107, 10, tmpdir) as fn:
+        with truncated_file(fn_test, 107, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 357, 10, tmpdir) as fn:
+        with truncated_file(fn_test, 357, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 IOData.from_file(fn)
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 405, 10, tmpdir) as fn:
+        with truncated_file(fn_test, 405, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 IOData.from_file(fn)
     with path('iodata.test.data', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_test:
-        with truncated_file('io.test.test_cp2k.test_errors', str(fn_test), 456, 10, tmpdir) as fn:
+        with truncated_file(fn_test, 456, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 IOData.from_file(fn)

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -25,8 +25,6 @@
 
 import numpy as np
 
-from . common import tmpdir
-
 from .. iodata import IOData
 
 try:
@@ -59,21 +57,20 @@ def test_load_aelta():
     assert abs(pn[-1] - mol.numbers[-1]) < 1e-10
 
 
-def test_load_dump_load_aelta():
+def test_load_dump_load_aelta(tmpdir):
     with path('iodata.test.data', 'aelta.cube') as fn_cube1:
         mol1 = IOData.from_file(str(fn_cube1))
 
-    with tmpdir('io.test.test_cube.test_load_dump_load_aelta') as dn:
-        fn_cube2 = '%s/%s' % (dn, 'aelta.cube')
-        mol1.to_file(fn_cube2)
-        mol2 = IOData.from_file(fn_cube2)
+    fn_cube2 = '%s/%s' % (tmpdir, 'aelta.cube')
+    mol1.to_file(fn_cube2)
+    mol2 = IOData.from_file(fn_cube2)
 
-        assert mol1.title == mol2.title
-        assert abs(mol1.coordinates - mol2.coordinates).max() < 1e-4
-        assert (mol1.numbers == mol2.numbers).all()
-        ugrid1 = mol1.grid
-        ugrid2 = mol2.grid
-        assert abs(ugrid1["grid_rvecs"] - ugrid2["grid_rvecs"]).max() < 1e-4
-        assert (ugrid1["shape"] == ugrid2["shape"]).all()
-        assert abs(mol1.cube_data - mol2.cube_data).max() < 1e-4
-        assert abs(mol1.pseudo_numbers - mol2.pseudo_numbers).max() < 1e-4
+    assert mol1.title == mol2.title
+    assert abs(mol1.coordinates - mol2.coordinates).max() < 1e-4
+    assert (mol1.numbers == mol2.numbers).all()
+    ugrid1 = mol1.grid
+    ugrid2 = mol2.grid
+    assert abs(ugrid1["grid_rvecs"] - ugrid2["grid_rvecs"]).max() < 1e-4
+    assert (ugrid1["shape"] == ugrid2["shape"]).all()
+    assert abs(mol1.cube_data - mol2.cube_data).max() < 1e-4
+    assert abs(mol1.pseudo_numbers - mol2.pseudo_numbers).max() < 1e-4

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -25,7 +25,7 @@
 
 import numpy as np
 
-from nose.tools import assert_raises
+import pytest
 
 from .. fchk import load
 from .. iodata import IOData
@@ -41,7 +41,7 @@ except ImportError:
 
 
 def test_load_fchk_nonexistent():
-    with assert_raises(IOError):
+    with pytest.raises(IOError):
         with path('iodata.test.data', 'fubar_crap.fchk') as fn:
             load(str(fn))
 

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -177,6 +177,7 @@ def check_load_dump_consistency(fn, tmpdir):
         The Molden filename to load
     tmpdir : str
         The temporary directory to dump and load the file.
+
     """
     with path('iodata.test.data', fn) as file_name:
         mol1 = IOData.from_file(str(file_name))

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -169,6 +169,15 @@ def test_load_molden_nh3_turbomole():
 
 
 def check_load_dump_consistency(fn, tmpdir):
+    """Check if data is preserved after dumping and loading a Molden file.
+
+    Parameters
+    ----------
+    fn : str
+        The Molden filename to load
+    tmpdir : str
+        The temporary directory to dump and load the file.
+    """
     with path('iodata.test.data', fn) as file_name:
         mol1 = IOData.from_file(str(file_name))
     fn_tmp = os.path.join(tmpdir, 'foo.molden')

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -26,7 +26,7 @@
 import os
 import numpy as np
 
-from . common import compute_mulliken_charges, tmpdir, compare_mols, check_orthonormal
+from . common import compute_mulliken_charges, compare_mols, check_orthonormal
 from .. iodata import IOData
 from .. overlap import compute_overlap
 try:
@@ -168,31 +168,30 @@ def test_load_molden_nh3_turbomole():
     assert abs(charges - molden_charges).max() < 1e-3
 
 
-def check_load_dump_consistency(fn):
+def check_load_dump_consistency(fn, tmpdir):
     with path('iodata.test.data', fn) as file_name:
         mol1 = IOData.from_file(str(file_name))
-    with tmpdir('io.test.test_molden.check_load_dump_consistency.%s' % fn) as dn:
-        fn_tmp = os.path.join(dn, 'foo.molden')
-        mol1.to_file(fn_tmp)
-        mol2 = IOData.from_file(fn_tmp)
+    fn_tmp = os.path.join(tmpdir, 'foo.molden')
+    mol1.to_file(fn_tmp)
+    mol2 = IOData.from_file(fn_tmp)
     compare_mols(mol1, mol2)
 
 
-def test_load_dump_consistency_h2o():
-    check_load_dump_consistency('h2o.molden.input')
+def test_load_dump_consistency_h2o(tmpdir):
+    check_load_dump_consistency('h2o.molden.input', tmpdir)
 
 
-def test_load_dump_consistency_li2():
-    check_load_dump_consistency('li2.molden.input')
+def test_load_dump_consistency_li2(tmpdir):
+    check_load_dump_consistency('li2.molden.input', tmpdir)
 
 
-def test_load_dump_consistency_f():
-    check_load_dump_consistency('F.molden')
+def test_load_dump_consistency_f(tmpdir):
+    check_load_dump_consistency('F.molden', tmpdir)
 
 
-def test_load_dump_consistency_nh3_molden_pure():
-    check_load_dump_consistency('nh3_molden_pure.molden')
+def test_load_dump_consistency_nh3_molden_pure(tmpdir):
+    check_load_dump_consistency('nh3_molden_pure.molden', tmpdir)
 
 
-def test_load_dump_consistency_nh3_molden_cart():
-    check_load_dump_consistency('nh3_molden_cart.molden')
+def test_load_dump_consistency_nh3_molden_cart(tmpdir):
+    check_load_dump_consistency('nh3_molden_cart.molden', tmpdir)

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -22,9 +22,10 @@
 # pragma pylint: disable=invalid-name
 """Test iodata.molpro module."""
 
+import os
+
 import numpy as np
 
-from .common import tmpdir
 from ..iodata import IOData
 
 try:
@@ -82,7 +83,7 @@ def test_load_fcidump_molpro_h2():
     assert mol.two_mo[3, 3, 3, 3] == 0.7484308847738417E+00
 
 
-def test_dump_load_fcidimp_consistency_ao():
+def test_dump_load_fcidimp_consistency_ao(tmpdir):
     # Setup IOData
     with path('iodata.test.data', 'water.xyz') as fn:
         mol0 = IOData.from_file(str(fn))
@@ -94,9 +95,9 @@ def test_dump_load_fcidimp_consistency_ao():
         mol0.two_mo = np.load(str(fn))
 
     # Dump to a file and load it again
-    with tmpdir('io.test.test_molpro.test_dump_load_fcidump_consistency_ao') as dn:
-        mol0.to_file('%s/FCIDUMP' % dn)
-        mol1 = IOData.from_file('%s/FCIDUMP' % dn)
+    fn_tmp = os.path.join(tmpdir, 'FCIDUMP')
+    mol0.to_file(fn_tmp)
+    mol1 = IOData.from_file(fn_tmp)
 
     # Compare results
     np.testing.assert_equal(mol0.nelec, mol1.nelec)

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -22,9 +22,10 @@
 """Test iodata.poscar module."""
 
 
+import os
+
 import numpy as np
 
-from . common import tmpdir
 from .. utils import angstrom, volume
 from .. iodata import IOData
 try:
@@ -61,7 +62,7 @@ def test_load_poscar_cubicbn_direct():
     assert abs(volume(mol.rvecs) - (3.57 * angstrom) ** 3 / 4) < 1e-10
 
 
-def test_load_dump_consistency():
+def test_load_dump_consistency(tmpdir):
     with path('iodata.test.data', 'water_element.xyz') as fn:
         mol0 = IOData.from_file(str(fn))
     # random matrix generated from a uniform distribution on [0., 5.0)
@@ -70,9 +71,9 @@ def test_load_dump_consistency():
                            [3.48374425, 0.67931228, 0.66281160]])
     mol0.gvecs = np.linalg.inv(mol0.rvecs).T
 
-    with tmpdir('io.test.test_vasp.test_load_dump_consistency') as dn:
-        mol0.to_file('%s/POSCAR' % dn)
-        mol1 = IOData.from_file('%s/POSCAR' % dn)
+    fn_tmp = os.path.join(tmpdir, 'POSCAR')
+    mol0.to_file(fn_tmp)
+    mol1 = IOData.from_file(fn_tmp)
 
     assert mol0.title == mol1.title
     assert (mol1.numbers == [8, 1, 1]).all()

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -22,10 +22,10 @@
 # pragma pylint: disable=invalid-name,no-member
 """Test iodata.xyz module."""
 
+import os
 
 import numpy as np
 
-from .common import tmpdir
 from ..iodata import IOData
 from ..utils import angstrom
 try:
@@ -60,37 +60,37 @@ def check_water(mol):
     assert abs(np.linalg.norm(mol.coordinates[0] - mol.coordinates[2]) / angstrom - 1.568) < 1e-3
 
 
-def test_load_dump_consistency():
+def test_load_dump_consistency(tmpdir):
     with path('iodata.test.data', 'ch3_hf_sto3g.fchk') as fn_fchk:
         mol0 = IOData.from_file(str(fn_fchk))
     # write xyz file in a temporary folder & then read it
-    with tmpdir('io.test.test_xyz.test_load_dump_consistency') as dn:
-        mol0.to_file('%s/test.xyz' % dn)
-        mol1 = IOData.from_file('%s/test.xyz' % dn)
+    fn_tmp = os.path.join(tmpdir, 'test.xyz')
+    mol0.to_file(fn_tmp)
+    mol1 = IOData.from_file(fn_tmp)
     # check two xyz files
     assert mol0.title == mol1.title
     assert (mol0.numbers == mol1.numbers).all()
     assert abs(mol0.coordinates - mol1.coordinates).max() < 1e-5
 
 
-def test_dump_xyz_water_element():
+def test_dump_xyz_water_element(tmpdir):
     with path('iodata.test.data', 'water_element.xyz') as fn_xyz:
         mol0 = IOData.from_file(str(fn_xyz))
-    with tmpdir('io.test.test_xyz.test_dump_xyz_water_element') as dn:
-        mol0.to_file('%s/test.xyz' % dn)
-        mol1 = IOData.from_file('%s/test.xyz' % dn)
+    fn_tmp = os.path.join(tmpdir, 'test.xyz')
+    mol0.to_file(fn_tmp)
+    mol1 = IOData.from_file(fn_tmp)
     # check two xyz file
     assert mol0.title == mol1.title
     assert (mol0.numbers == mol1.numbers).all()
     assert abs(mol0.coordinates - mol1.coordinates).max() < 1e-5
 
 
-def test_dump_xyz_water_number():
+def test_dump_xyz_water_number(tmpdir):
     with path('iodata.test.data', 'water_number.xyz') as fn_xyz:
         mol0 = IOData.from_file(str(fn_xyz))
-    with tmpdir('io.test.test_xyz.test_dump_xyz_water_number') as dn:
-        mol0.to_file('%s/test.xyz' % dn)
-        mol1 = IOData.from_file('%s/test.xyz' % dn)
+    fn_tmp = os.path.join(tmpdir, 'test.xyz')
+    mol0.to_file(fn_tmp)
+    mol1 = IOData.from_file(fn_tmp)
     # check two xyz file
     assert mol0.title == mol1.title
     assert (mol0.numbers == mol1.numbers).all()

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
     ],
     zip_safe=False,
     setup_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy'],
-    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'pytest>=0.11',
-                      'pytest-cov', 'importlib_resources; python_version < "3.7"'],
+    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'pytest>=4.2.0',
+                      'importlib_resources; python_version < "3.7"'],
 )

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,6 @@ setup(
     ],
     zip_safe=False,
     setup_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy'],
-    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'nose>=0.11',
-                      'importlib_resources; python_version < "3.7"'],
+    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'pytest>=0.11',
+                      'pytest-cov', 'importlib_resources; python_version < "3.7"'],
 )

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -17,7 +17,8 @@ requirements:
     - numpy
     - cython >=0.24.1
     - setuptools
-    - nose
+    - pytest
+    - pytest-cov
   run:
     - python
     - scipy
@@ -25,10 +26,11 @@ requirements:
 test:
   requires:
     - python
-    - nose
+    - pytest
+    - pytest-cov
   commands:
     - conda inspect linkages iodata
-    - nosetests -v iodata
+    - pytest -v iodata
 
 about:
   home: https://github.com/theochem/iodata

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -18,7 +18,6 @@ requirements:
     - cython >=0.24.1
     - setuptools
     - pytest
-    - pytest-cov
   run:
     - python
     - scipy
@@ -27,7 +26,6 @@ test:
   requires:
     - python
     - pytest
-    - pytest-cov
   commands:
     - conda inspect linkages iodata
     - pytest -v iodata


### PR DESCRIPTION
Relevant changes:
- Update .travis.yml file to use pytest
- Drop our own tmpdir implementation and use built-in pytest fixtures.
- Use `pytest.raises` instead of `assert_raises`.