### PR TITLE
New MolecularBasis API

### DIFF
--- a/.pycodestylerc
+++ b/.pycodestylerc
@@ -1,3 +1,3 @@
 [pycodestyle]
 max-line-length=100
-ignore=E741
+ignore=E741,W503

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -1,0 +1,306 @@
+# -*- coding: utf-8 -*-
+# IODATA is an input and output module for quantum chemistry.
+#
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Utility functions for working with basis sets."""
+
+from functools import wraps
+from numbers import Integral
+from typing import List, Dict, NamedTuple, Tuple
+
+import numpy as np
+
+__all__ = ['angmom_sti', 'angmom_its', 'Shell', 'MolecularBasis',
+           'convert_convention_shell', 'convert_conventions']
+
+ANGMOM_CHARS = 'spdfghiklmnoqrtuvwxyzabce'
+
+
+def _alsolist(f):
+    """Wrap a function to accepts also list as first argument and then return list."""
+    @wraps(f)
+    def wrapper(firsts, *args, **kwargs):
+        if isinstance(firsts, (Integral, str)):
+            return f(firsts, *args, **kwargs)
+        return [f(first, *args, **kwargs) for first in firsts]
+    return wrapper
+
+
+@_alsolist
+def angmom_sti(char: str) -> int:
+    """Convert an angular momentum from string to integer format.
+
+    Parameters
+    ----------
+    char
+        Character representation of angular momentum, (s, p, d, ...)
+
+    Returns
+    -------
+    angmom
+        An integer representation of the angular momentum. A list, if a list of
+        words was given.
+
+    """
+    return ANGMOM_CHARS.index(char.lower())
+
+
+@_alsolist
+def angmom_its(angmom: int) -> Dict:
+    """Convert an angular momentum from integer to string representation.
+
+    Parameters
+    ----------
+    angmom
+        The integer representation of the angular momentum.
+
+    Returns
+    -------
+    char
+        The string representation of the angular momentum.
+
+    """
+    if angmom < 0:
+        raise ValueError("Angmom cannot be negative.")
+    return ANGMOM_CHARS[angmom]
+
+
+class Shell(NamedTuple):
+    """Desribe a single shell in a molecular basis set.
+
+    Attributes
+    ----------
+    icenter
+        An integer referring to a row in the centers array
+    angmoms
+        An integer array of angular momentum quantum numbers, non-negative, with
+        shape (ncon,).
+    kinds
+        List of strings describing the kind of contraction: 'c' for Cartesian
+        and 'p' for pure. Pure functions are only allowed for angmom>1.
+        The length equals the number of contractions: len(angmoms)=ncon.
+    exponents
+        an array of exponents of primitives, with shape (nprim,).
+    coeffs
+        an array with contraction coefficients, with shape (nprim, ncon). These
+        coefficients assume that the primitives are L2 (orbitals) or L1
+        (densities) normalized, but contractions are not necessarily normalized.
+        (This depends on the code which generated the contractions.)
+
+    """
+
+    icenter: int
+    angmoms: List[int]
+    kinds: List[str]
+    exponents: np.ndarray
+    coeffs: np.ndarray
+
+    @property
+    def nbasis(self) -> int:
+        """Return the number of basis functions."""
+        result = 0
+        for angmom, kind in zip(self.angmoms, self.kinds):
+            if kind == 'c':  # Cartesian
+                result += int((angmom + 1) * (angmom + 2) / 2)
+            elif kind == 'p' and angmom >= 2:
+                result += 2 * angmom + 1
+            else:
+                raise TypeError('Unknown shell kind \'{}\'.'.format(kind))
+        return result
+
+    @property
+    def nprim(self) -> int:
+        """Return the number of primitives. Also known as the contraction length."""
+        return len(self.exponents)
+
+    @property
+    def ncon(self) -> int:
+        """Return the number of contractions."""
+        return len(self.angmoms)
+
+
+class MolecularBasis(NamedTuple):
+    """Describe a complete molecular orbital or density basis set.
+
+    Attributes
+    ----------
+    centers
+        an array with of shape (ncenter, 3). Must be the same as the array
+        of atomic positions (real atoms, ghost atoms and extra point charges)
+        elsewhere in IOData.
+        # TODO: this could be dropped as soon as the atomic positions in IOData
+        # are allowed to contain ghost atoms.
+    shells
+        a list of objects of the type Shell
+    conventions
+        a dictionary with as key a typle of angular momentum integer and kind
+        character, and as value a list of basis function strings, e.g.
+
+        .. code-block:: python
+
+            {
+                (0, 'c'): ['1'],
+                (1, 'c'): ['x', 'y', 'z'],
+                # alphabetically ordered Cartesian functions
+                (2, 'c'): ['xx', 'xy', 'xz', 'yy', 'yz', 'zz'],
+                # or Wikipedia-ordered real solid spherical harmonics
+                # c = cosine-like
+                # s = sine-like
+                (2, 'p'): ['dc2', 'dc1', 'dc0', '-ds1', '-ds2'],
+                ...
+            }
+
+    primitive_normalization
+        Either 'L1' or 'L2'.
+
+    """
+
+    centers: np.ndarray
+    shells: tuple
+    conventions: Dict[str, str]
+    primitive_normalization: str
+
+    @property
+    def nbasis(self) -> int:
+        """Return the number of basis functions."""
+        return sum(shell.nbasis for shell in self.shells)
+
+    def get_segmented(self):
+        """Unroll generalized contractions."""
+        shells = []
+        for shell in self.shells:
+            for angmom, kind, coeffs in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
+                shells.append(Shell(shell.icenter, [angmom], [kind],
+                                    shell.exponents, coeffs.reshape(-1, 1)))
+        # pylint: disable=no-member
+        return self._replace(shells=shells)
+
+
+def convert_convention_shell(conv1: List[str], conv2: List[str], reverse=False) \
+        -> Tuple[np.ndarray, np.ndarray]:
+    """Return a permutation vector and sign changes to convert from 1 to 2.
+
+    The transformation from convention 1 to convention 2 can be done applying
+    the results of this function as follows:
+
+    .. code-block:: python
+
+        vector2 = vector1[permutation]*signs
+
+    When using the option ``reverse=True``, one can use the results to convert
+    in the opposite sense:
+
+    .. code-block:: python
+
+        vector1 = vector2[permutation]*signs
+
+    Parameters
+    ----------
+    conv1, conv2
+        Two lists, with the same strings (in different order), where each string
+        may be prefixed with a '-'.
+    reverse:
+        When, true the conversion from 2 to 1 is returned.
+
+    Returns
+    -------
+    permutation
+        An integer array that permutes basis function from 1 to 2.
+    signs
+        Sign changes when going from 1 to 2, must be applied after permutation
+
+    """
+    if len(conv1) != len(conv2):
+        raise TypeError('conv1 and conv2 must contain the same number of elements.')
+    # Get signs from both
+    signs1 = [1 - 2 * el1.startswith('-') for el1 in conv1]
+    signs2 = [1 - 2 * el2.startswith('-') for el2 in conv2]
+    # Strip signs from both
+    conv1 = [el1.lstrip('-') for el1 in conv1]
+    conv2 = [el2.lstrip('-') for el2 in conv2]
+    if len(conv1) != len(set(conv1)):
+        raise TypeError('Argument conv1 contains duplicates.')
+    if len(conv2) != len(set(conv2)):
+        raise TypeError('Argument conv2 contains duplicates.')
+    if set(conv1) != set(conv2):
+        print(sorted(conv1))
+        print(sorted(conv2))
+        raise TypeError('Without the minus signs, conv1 and conv2 must contain '
+                        'the same elements.')
+    # Get the permutation
+    if reverse:
+        permutation = [conv2.index(el1) for el1 in conv1]
+        signs = [signs2[i] * sign1 for i, sign1 in zip(permutation, signs1)]
+    else:
+        permutation = [conv1.index(el2) for el2 in conv2]
+        signs = [signs1[i] * sign2 for i, sign2 in zip(permutation, signs2)]
+    return permutation, signs
+
+
+def convert_conventions(molbasis: MolecularBasis, new_conventions: Dict[str, List[str]],
+                        reverse=False) -> Tuple[np.ndarray, np.ndarray]:
+    """Return a permutation vector and sign changes to convert from 1 to 2.
+
+    The transformation from molbasis.convention to the new convention can be done
+    applying the results of this function as follows:
+
+    .. code-block:: python
+
+        vector2 = vector1[permutation]*signs
+
+    When using the option ``reverse=True``, one can use the results to convert
+    in the opposite sense:
+
+    .. code-block:: python
+
+        vector1 = vector2[permutation]*signs
+
+
+    Parameters
+    ----------
+    molbasis
+        The description of a molecular basis set.
+    new_conventions
+        The new conventions for ordering and signs, to which data for the
+        orbital basis needs to be converted.
+    reverse:
+        When, true the conversion from 2 to 1 is returned.
+
+    Returns
+    -------
+    permutation
+        An integer array that permutes basis function from 1 to 2.
+    signs
+        Sign changes when going from 1 to 2, must be applied after permutation
+
+    """
+    permutation = []
+    signs = []
+    for shell in molbasis.shells:
+        for angmom, kind in zip(shell.angmoms, shell.kinds):
+            key = (angmom, kind)
+            conv1 = molbasis.conventions[key]
+            conv2 = new_conventions[key]
+            shell_permutation, shell_signs = convert_convention_shell(conv1, conv2, reverse)
+            offset = len(permutation)
+            for i in shell_permutation:
+                permutation.append(i + offset)
+            signs.extend(shell_signs)
+    return np.array(permutation), np.array(signs)

--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -27,7 +27,7 @@ from typing import Dict, Union, List, Tuple
 import numpy as np
 from scipy.special import factorialk
 
-from ..basis import angmom_sti, MolecularBasis, Shell
+from ..basis import angmom_sti, MolecularBasis, Shell, HORTON2_CONVENTIONS
 from ..utils import LineIterator
 
 
@@ -38,10 +38,10 @@ patterns = ['*.cp2k.out']
 
 
 CONVENTIONS = {
-    (0, 'c'): ['1'],
-    (1, 'c'): ['x', 'y', 'z'],
-    (2, 'p'): ['dc0', 'dc1', 'ds1', 'dc2', 'ds2'],
-    (3, 'p'): ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', 'fc3', 'fs3'],
+    (0, 'c'): HORTON2_CONVENTIONS[(0, 'c')],
+    (1, 'c'): HORTON2_CONVENTIONS[(1, 'c')],
+    (2, 'p'): HORTON2_CONVENTIONS[(2, 'p')],
+    (3, 'p'): HORTON2_CONVENTIONS[(3, 'p')],
 }
 
 def _get_cp2k_norm_corrections(l: int, alphas: Union[float, np.ndarray]) \

--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -27,7 +27,8 @@ from typing import Dict, Union, List, Tuple
 import numpy as np
 from scipy.special import factorialk
 
-from ..utils import shells_to_nbasis, str_to_shell_types, LineIterator
+from ..basis import angmom_sti, MolecularBasis, Shell
+from ..utils import LineIterator
 
 
 __all__ = ['load']
@@ -36,12 +37,20 @@ __all__ = ['load']
 patterns = ['*.cp2k.out']
 
 
+CONVENTIONS = {
+    (0, 'c'): ['1'],
+    (1, 'c'): ['x', 'y', 'z'],
+    (2, 'p'): ['dc0', 'dc1', 'ds1', 'dc2', 'ds2'],
+    (3, 'p'): ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', 'fc3', 'fs3'],
+}
+
 def _get_cp2k_norm_corrections(l: int, alphas: Union[float, np.ndarray]) \
         -> Union[float, np.ndarray]:
     """Compute the corrections for the normalization of the basis functions.
 
-    This correction is needed because the CP2K atom code works with non-normalized basis
-    functions. HORTON assumes Gaussian primitives are always normalized.
+    This correction is needed because the CP2K atom code works with a different
+    type of normalization for the primitives. IOData assumes Gaussian primitives
+    are always L2-normalized.
 
     Parameters
     ----------
@@ -65,7 +74,7 @@ def _get_cp2k_norm_corrections(l: int, alphas: Union[float, np.ndarray]) \
     return zeta ** expzet / prefac
 
 
-def _read_cp2k_contracted_obasis(lit: LineIterator) -> Dict:
+def _read_cp2k_contracted_obasis(lit: LineIterator) -> MolecularBasis:
     """Read a contracted basis set from an open CP2K ATOM output file.
 
     Parameters
@@ -76,60 +85,41 @@ def _read_cp2k_contracted_obasis(lit: LineIterator) -> Dict:
     Returns
     -------
     obasis
-        The orbital basis parameters read from the file. Can be used to
-        initialize a GOBasis object.
+        The orbital basis.
 
     """
-    # Load the relevant data from the file
-    basis_desc = []
-    for line in lit:
-        if line.startswith(' *******************'):
+    shells = []
+    while True:
+        line = next(lit)
+        if line[3:12] != 'Functions':
             break
-        elif line[3:12] == 'Functions':
-            shell_type = str_to_shell_types(line[1:2], pure=True)[0]
-            a = []  # exponents (alpha)
-            c = []  # contraction coefficients
-            basis_desc.append((shell_type, a, c))
-        else:
+        angmom = angmom_sti(line[1:2])
+        exponents = []
+        coeffs = []
+        for line in lit:
+            if line[3:12] == 'Functions' or line.startswith(' *******************'):
+                break
             values = [float(w) for w in line.split()]
-            a.append(values[0])  # one exponent per line
-            c.append(values[1:])  # many contraction coefficients per line
+            # one exponent per line
+            exponents.append(values[0])
+            # many contraction coefficients per line, all corresponding to the
+            # same primitive, so rows in coeffs
+            coeffs.append(
+                np.array(values[1:]) / _get_cp2k_norm_corrections(angmom, values[0]))
+        # Push back the last line for the next iteration
+        lit.back(line)
+        # Build the shell
+        exponents = np.array(exponents)
+        coeffs = np.array(coeffs)
+        kind = 'c' if angmom < 2 else 'p'
+        shells.append(Shell(0, np.array([angmom] * coeffs.shape[1]),
+                            [kind] * coeffs.shape[1],
+                            exponents, coeffs))
 
-    # Convert the basis into HORTON format
-    shell_map = []
-    shell_types = []
-    nprims = []
-    alphas = []
-    con_coeffs = []
-
-    for shell_type, a, c in basis_desc:
-        # get correction to contraction coefficients. CP2K uses different normalization
-        # conventions.
-        corrections = _get_cp2k_norm_corrections(abs(shell_type), np.array(a))
-        c = np.array(c) / corrections.reshape(-1, 1)
-        # fill in arrays
-        for col in c.T:
-            shell_map.append(0)
-            shell_types.append(shell_type)
-            nprims.append(len(col))
-            alphas.extend(a)
-            con_coeffs.extend(col)
-
-    # Create the basis object
-    coordinates = np.zeros((1, 3))
-    shell_map = np.array(shell_map)
-    nprims = np.array(nprims)
-    shell_types = np.array(shell_types)
-    alphas = np.array(alphas)
-    con_coeffs = np.array(con_coeffs)
-
-    obasis = {"centers": coordinates, "shell_map": shell_map, "nprims": nprims,
-              "shell_types": shell_types, "alphas": alphas, "con_coeffs": con_coeffs}
-
-    return obasis
+    return MolecularBasis(np.zeros((1, 3)), shells, CONVENTIONS, 'L2')
 
 
-def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> Dict:
+def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> MolecularBasis:
     """Read an uncontracted basis set from an open CP2K ATOM output file.
 
     Parameters
@@ -145,46 +135,32 @@ def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> Dict:
 
     """
     # Load the relevant data from the file
-    basis_desc = []
-    shell_type = None
-    for line in lit:
-        if line.startswith(' *******************'):
+    shells = []
+    next(lit)
+    while True:
+        line = next(lit)
+        if line[3:13] != 'Exponents:':
             break
-        elif line[3:13] == 'Exponents:':
-            shell_type = str_to_shell_types(line[1:2], pure=True)[0]
-        words = line.split()
-        if len(words) >= 2:
+        angmom = angmom_sti(line[1:2])
+        exponents = []
+        coeffs = []
+        while True:
+            if line.strip() == "" or "*****" in line:
+                break
+            words = line.split()
             # read the exponent
-            alpha = float(words[-1])
-            basis_desc.append((shell_type, alpha))
+            exponent = float(words[-1])
+            exponents.append(exponent)
+            coeffs.append([1.0 / _get_cp2k_norm_corrections(angmom, exponent)])
+            line = next(lit)
+        # Build the shell
+        kind = 'c' if angmom < 2 else 'p'
+        for exponent, coeff in zip(exponents, coeffs):
+            shells.append(Shell(
+                0, np.array([angmom]), [kind],
+                np.array([exponent]), np.array([[coeff]])))
 
-    # Convert the basis into HORTON format
-    shell_map = []
-    shell_types = []
-    nprims = []
-    alphas = []
-    con_coeffs = []
-
-    # fill in arrays
-    for shell_type, alpha in basis_desc:
-        correction = _get_cp2k_norm_corrections(abs(shell_type), alpha)
-        shell_map.append(0)
-        shell_types.append(shell_type)
-        nprims.append(1)
-        alphas.append(alpha)
-        con_coeffs.append(1.0 / correction)
-
-    # Create the basis object
-    centers = np.zeros((1, 3))
-    shell_map = np.array(shell_map)
-    nprims = np.array(nprims)
-    shell_types = np.array(shell_types)
-    alphas = np.array(alphas)
-    con_coeffs = np.array(con_coeffs)
-
-    obasis = {"centers": centers, "shell_map": shell_map, "nprims": nprims,
-              "shell_types": shell_types, "alphas": alphas, "con_coeffs": con_coeffs}
-    return obasis
+    return MolecularBasis(np.zeros((1, 3)), shells, CONVENTIONS, 'L2')
 
 
 # pylint: disable=inconsistent-return-statements
@@ -221,7 +197,7 @@ def _read_cp2k_occupations_energies(lit: LineIterator, restricted: bool) \
     Parameters
     ----------
     lit
-        LineIterator
+        The line iterator to read the data from.
     restricted
         If ``True`` the wave-function is considered to be restricted. If
         ``False`` the unrestricted wave-function is assumed.
@@ -273,21 +249,21 @@ def _read_cp2k_orbital_coeffs(lit: LineIterator, oe: List[Tuple[int, int, float,
         Key is an (l, s) pair and value is an array with orbital coefficients.
 
     """
-    coeffs = {}
+    allcoeffs = {}
     next(lit)
-    while len(coeffs) < len(oe):
+    while len(allcoeffs) < len(oe):
         line = next(lit)
         assert line.startswith("    ORBITAL      L =")
         words = line.split()
-        l = int(words[3])
-        s = int(words[6])
-        c = []
+        angmom = int(words[3])
+        state = int(words[6])
+        coeffs = []
         for line in lit:
             if line.strip() == "":
                 break
-            c.append(float(line))
-        coeffs[(l, s)] = np.array(c)
-    return coeffs
+            coeffs.append(float(line))
+        allcoeffs[(angmom, state)] = np.array(coeffs)
+    return allcoeffs
 
 
 def _get_norb_nel(oe: List[Tuple[int, int, float, float]]) -> Tuple[int, float]:
@@ -313,9 +289,12 @@ def _get_norb_nel(oe: List[Tuple[int, int, float, float]]) -> Tuple[int, float]:
     return norb, nel
 
 
-def _fill_orbitals(orb_coeffs: np.ndarray, orb_energies: np.ndarray, orb_occupations: np.ndarray,
+def _fill_orbitals(orb_coeffs: np.ndarray,
+                   orb_energies: np.ndarray,
+                   orb_occupations: np.ndarray,
                    oe: List[Tuple[int, int, float, float]],
-                   coeffs: Dict[Tuple[int, int], np.ndarray], shell_types: np.ndarray,
+                   coeffs: Dict[Tuple[int, int], np.ndarray],
+                   obasis: MolecularBasis,
                    restricted: bool):
     """Fill in orbital coefficients, energies and occupation numbers.
 
@@ -334,8 +313,8 @@ def _fill_orbitals(orb_coeffs: np.ndarray, orb_energies: np.ndarray, orb_occupat
         ``_read_cp2k_occupations_energies``.
     coeffs
         The orbital coefficients read with ``_read_cp2k_orbital_coeffs``.
-    shell_types
-        The array with shell types of the GOBasis instance.
+    obasis
+        The molecular basis set
     restricted
         Is wavefunction restricted or unrestricted?
 
@@ -343,7 +322,7 @@ def _fill_orbitals(orb_coeffs: np.ndarray, orb_energies: np.ndarray, orb_occupat
     # Find the offsets for each angular momentum
     offset = 0
     offsets = []
-    ls = abs(shell_types)
+    ls = np.concatenate([shell.angmoms for shell in obasis.shells])
     for l in sorted(set(ls)):
         offsets.append(offset)
         offset += (2 * l + 1) * (l == ls).sum()
@@ -351,11 +330,10 @@ def _fill_orbitals(orb_coeffs: np.ndarray, orb_energies: np.ndarray, orb_occupat
 
     # Fill in the coefficients
     iorb = 0
-    for l, s, occ, ener in oe:
-        cs = coeffs.get((l, s))
+    for l, state, occ, ener in oe:
+        cs = coeffs.get((l, state))
         stride = 2 * l + 1
-        for m in range(-l, l + 1):
-            im = m + l
+        for im in range(2 * l + 1):
             orb_energies[iorb] = ener
             orb_occupations[iorb] = occ / float((restricted + 1) * (2 * l + 1))
             for ic, c in enumerate(cs):
@@ -470,33 +448,32 @@ def load(lit: LineIterator) -> Dict:
         coeffs_beta = _read_cp2k_orbital_coeffs(lit, oe_beta)
 
     # Turn orbital data into a HORTON orbital expansions
-    nbasis = shells_to_nbasis(obasis['shell_types'])
     if restricted:
         norb, nel = _get_norb_nel(oe_alpha)
         assert nel % 2 == 0
-        orb_alpha = (nbasis, norb)
+        orb_alpha = (obasis.nbasis, norb)
         orb_beta = None
-        orb_alpha_coeffs = np.zeros([nbasis, norb])
+        orb_alpha_coeffs = np.zeros([obasis.nbasis, norb])
         orb_alpha_energies = np.zeros(norb)
         orb_alpha_occs = np.zeros(norb)
         _fill_orbitals(orb_alpha_coeffs, orb_alpha_energies, orb_alpha_occs,
-                       oe_alpha, coeffs_alpha, obasis["shell_types"], restricted)
+                       oe_alpha, coeffs_alpha, obasis, restricted)
     else:
         norb_alpha = _get_norb_nel(oe_alpha)[0]
         norb_beta = _get_norb_nel(oe_beta)[0]
         assert norb_alpha == norb_beta
-        orb_alpha = (nbasis, norb_alpha)
-        orb_alpha_coeffs = np.zeros([nbasis, norb_alpha])
+        orb_alpha = (obasis.nbasis, norb_alpha)
+        orb_alpha_coeffs = np.zeros([obasis.nbasis, norb_alpha])
         orb_alpha_energies = np.zeros(norb_alpha)
         orb_alpha_occs = np.zeros(norb_alpha)
-        orb_beta = (nbasis, norb_beta)
-        orb_beta_coeffs = np.zeros([nbasis, norb_beta])
+        orb_beta = (obasis.nbasis, norb_beta)
+        orb_beta_coeffs = np.zeros([obasis.nbasis, norb_beta])
         orb_beta_energies = np.zeros(norb_beta)
         orb_beta_occs = np.zeros(norb_beta)
         _fill_orbitals(orb_alpha_coeffs, orb_alpha_energies, orb_alpha_occs,
-                       oe_alpha, coeffs_alpha, obasis["shell_types"], restricted)
+                       oe_alpha, coeffs_alpha, obasis, restricted)
         _fill_orbitals(orb_beta_coeffs, orb_beta_energies, orb_beta_occs,
-                       oe_beta, coeffs_beta, obasis["shell_types"], restricted)
+                       oe_beta, coeffs_beta, obasis, restricted)
 
     result = {
         'obasis': obasis,
@@ -504,7 +481,7 @@ def load(lit: LineIterator) -> Dict:
         'orb_alpha_coeffs': orb_alpha_coeffs,
         'orb_alpha_energies': orb_alpha_energies,
         'orb_alpha_occs': orb_alpha_occs,
-        'coordinates': obasis["centers"],
+        'coordinates': obasis.centers,
         'numbers': np.array([number]),
         'energy': energy,
         'pseudo_numbers': np.array([pseudo_number]),

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -26,8 +26,7 @@ from typing import Dict, List, Tuple
 
 import numpy as np
 
-from ..basis import MolecularBasis, Shell
-from ..overlap import OVERLAP_CONVENTIONS
+from ..basis import MolecularBasis, Shell, HORTON2_CONVENTIONS
 from ..utils import LineIterator
 
 
@@ -38,24 +37,24 @@ patterns = ['*.fchk']
 
 
 CONVENTIONS = {
-    (9, 'p'): OVERLAP_CONVENTIONS[(9, 'p')],
-    (8, 'p'): OVERLAP_CONVENTIONS[(8, 'p')],
-    (7, 'p'): OVERLAP_CONVENTIONS[(7, 'p')],
-    (6, 'p'): OVERLAP_CONVENTIONS[(6, 'p')],
-    (5, 'p'): OVERLAP_CONVENTIONS[(5, 'p')],
-    (4, 'p'): OVERLAP_CONVENTIONS[(4, 'p')],
-    (3, 'p'): OVERLAP_CONVENTIONS[(3, 'p')],
-    (2, 'p'): OVERLAP_CONVENTIONS[(2, 'p')],
+    (9, 'p'): HORTON2_CONVENTIONS[(9, 'p')],
+    (8, 'p'): HORTON2_CONVENTIONS[(8, 'p')],
+    (7, 'p'): HORTON2_CONVENTIONS[(7, 'p')],
+    (6, 'p'): HORTON2_CONVENTIONS[(6, 'p')],
+    (5, 'p'): HORTON2_CONVENTIONS[(5, 'p')],
+    (4, 'p'): HORTON2_CONVENTIONS[(4, 'p')],
+    (3, 'p'): HORTON2_CONVENTIONS[(3, 'p')],
+    (2, 'p'): HORTON2_CONVENTIONS[(2, 'p')],
     (0, 'c'): ['1'],
     (1, 'c'): ['x', 'y', 'z'],
     (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'yz', 'xz'],
     (3, 'c'): ['xxx', 'yyy', 'zzz', 'xyy', 'xxy', 'xxz', 'xzz', 'yzz', 'yyz', 'xyz'],
-    (4, 'c'): OVERLAP_CONVENTIONS[(4, 'c')][::-1],
-    (5, 'c'): OVERLAP_CONVENTIONS[(5, 'c')][::-1],
-    (6, 'c'): OVERLAP_CONVENTIONS[(6, 'c')][::-1],
-    (7, 'c'): OVERLAP_CONVENTIONS[(7, 'c')][::-1],
-    (8, 'c'): OVERLAP_CONVENTIONS[(8, 'c')][::-1],
-    (9, 'c'): OVERLAP_CONVENTIONS[(9, 'c')][::-1],
+    (4, 'c'): HORTON2_CONVENTIONS[(4, 'c')][::-1],
+    (5, 'c'): HORTON2_CONVENTIONS[(5, 'c')][::-1],
+    (6, 'c'): HORTON2_CONVENTIONS[(6, 'c')][::-1],
+    (7, 'c'): HORTON2_CONVENTIONS[(7, 'c')][::-1],
+    (8, 'c'): HORTON2_CONVENTIONS[(8, 'c')][::-1],
+    (9, 'c'): HORTON2_CONVENTIONS[(9, 'c')][::-1],
 }
 
 

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -23,13 +23,15 @@
 
 
 from typing import Tuple, Dict, Union, TextIO
+import copy
 
 import numpy as np
 
+from ..basis import (angmom_its, angmom_sti, MolecularBasis, Shell,
+                     convert_conventions)
 from ..periodic import sym2num, num2sym
-from ..overlap import compute_overlap, get_shell_nbasis, gob_cart_normalization
-from ..utils import (angstrom, str_to_shell_types, shell_type_to_str, shells_to_nbasis,
-                     LineIterator)
+from ..overlap import compute_overlap, OVERLAP_CONVENTIONS, gob_cart_normalization
+from ..utils import angstrom, LineIterator
 
 
 __all__ = ['load', 'dump']
@@ -37,26 +39,178 @@ __all__ = ['load', 'dump']
 
 patterns = ['*.molden.input', '*.molden']
 
+# From the Molden format documentation:
+#    5D: D 0, D+1, D-1, D+2, D-2
+#    6D: xx, yy, zz, xy, xz, yz
+#
+#    7F: F 0, F+1, F-1, F+2, F-2, F+3, F-3
+#   10F: xxx, yyy, zzz, xyy, xxy, xxz, xzz, yzz, yyz, xyz
+#
+#    9G: G 0, G+1, G-1, G+2, G-2, G+3, G-3, G+4, G-4
+#   15G: xxxx yyyy zzzz xxxy xxxz yyyx yyyz zzzx zzzy,
+#        xxyy xxzz yyzz xxyz yyxz zzxy
 
-def _get_molden_permutation(shell_types: np.ndarray, reverse=False) -> np.ndarray:
-    # Reorder the Cartesian basis functions to obtain the HORTON standard ordering.
-    permutation_rules = {
-        2: np.array([0, 3, 4, 1, 5, 2]),
-        3: np.array([0, 4, 5, 3, 9, 6, 1, 8, 7, 2]),
-        4: np.array([0, 3, 4, 9, 12, 10, 5, 13, 14, 7, 1, 6, 11, 8, 2]),
+CONVENTIONS = {
+    (0, 'c'): ['1'],
+    (1, 'c'): ['x', 'y', 'z'],
+    (2, 'p'): OVERLAP_CONVENTIONS[(2, 'p')],
+    (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'xz', 'yz'],
+    (3, 'p'): OVERLAP_CONVENTIONS[(3, 'p')],
+    (3, 'c'): ['xxx', 'yyy', 'zzz', 'xyy', 'xxy', 'xxz', 'xzz', 'yzz', 'yyz', 'xyz'],
+    (4, 'p'): OVERLAP_CONVENTIONS[(4, 'p')],
+    (4, 'c'): ['xxxx', 'yyyy', 'zzzz', 'xxxy', 'xxxz', 'xyyy', 'yyyz', 'xzzz',
+               'yzzz', 'xxyy', 'xxzz', 'yyzz', 'xxyz', 'xyyz', 'xyzz'],
+}
+
+
+def load(lit: LineIterator) -> Dict:
+    """Load data from a MOLDEN input file format.
+
+    Parameters
+    ----------
+    lit
+        The line iterator to read the data from.
+
+    Returns
+    -------
+    out : dict
+        output dictionary containing ``coordinates``, ``numbers``, ``pseudo_numbers``,
+        ``obasis``, ``orb_alpha`` & ``signs`` keys and corresponding values. It may contain
+        ``title`` and ``orb_beta`` keys and their values as well.
+
+    """
+    result = _load_low(lit)
+    _fix_molden_from_buggy_codes(result, lit.filename)
+    return result
+
+
+# pylint: disable=too-many-branches,too-many-statements
+def _load_low(lit: LineIterator) -> Dict:
+    """Load data from a MOLDEN input file format, without trying to fix errors.
+
+    Parameters
+    ----------
+    lit
+        The line iterator to read the data from.
+
+    Returns
+    -------
+    out : dict
+        output dictionary containing ``coordinates``, ``numbers``, ``pseudo_numbers``,
+        ``obasis``, ``orb_alpha`` & ``signs`` keys and corresponding values. It may contain
+        ``title`` and ``orb_beta`` keys and their values as well.
+
+    """
+    pure_angmoms = set([])
+    numbers = None
+    coordinates = None
+    obasis = None
+    coeff_alpha = None
+    ener_alpha = None
+    occ_alpha = None
+    coeff_beta = None
+    ener_beta = None
+    occ_beta = None
+    title = None
+
+    line = next(lit)
+    if line != '[Molden Format]\n':
+        lit.error('Molden header not found')
+    # The order of sections, denoted by "[...]", is not fixed in the Molden
+    # format, so we need a loop that checks for all possible sections at
+    # each iteration. If needed, the contents of the section is read.
+    while True:
+        try:
+            line = next(lit).lower().strip()
+        except StopIteration:
+            # This means we continue reading till the end of the file.
+            # There is no real way to know when a Molden file has ended, other
+            # than reaching the end of the file.
+            break
+        # settings for pure or Cartesian shells.
+        if line.startswith('[5d]') or line.startswith('[5d7f]'):
+            pure_angmoms.add(2)
+            pure_angmoms.add(3)
+        elif line.lower().startswith('[7f]'):
+            pure_angmoms.add(3)
+        elif line.lower().startswith('[5d10f]'):
+            pure_angmoms.add(2)
+        elif line.lower().startswith('[9g]'):
+            pure_angmoms.add(4)
+        # title
+        elif line == '[title]':
+            title = next(lit).strip()
+        # atoms
+        elif line.startswith('[atoms]'):
+            if 'au' in line:
+                cunit = 1.0
+            elif 'angs' in line:
+                cunit = angstrom
+            numbers, pseudo_numbers, coordinates = _load_helper_coordinates(lit, cunit)
+        # we only support Gaussian-type orbitals (gto's)
+        elif line == '[gto]':
+            obasis = _load_helper_obasis(lit)
+        elif line == '[sto]':
+            lit.error('Slater-type orbitals are not supported by IODATA.')
+        # molecular-orbital coefficients.
+        elif line == '[mo]':
+            data_alpha, data_beta = _load_helper_coeffs(lit)
+            coeff_alpha, ener_alpha, occ_alpha = data_alpha
+            coeff_beta, ener_beta, occ_beta = data_beta
+
+    # Assign pure and Cartesian correctly. This needs to be done after reading
+    # because the tags for pure functions may come after the basis set.
+    for shell in obasis.shells:
+        # Code only has to work for segmented contractions
+        if shell.angmoms[0] in pure_angmoms:
+            shell.kinds[0] = 'p'
+    # Fix the centers.
+    obasis.centers[:] = coordinates
+
+    if coeff_beta is None:
+        if coeff_alpha.shape[0] != obasis.nbasis:
+            lit.error("Number of alpha orbital coefficients does not match the size of the basis.")
+        orb_alpha = (obasis.nbasis, coeff_alpha.shape[1])
+        orb_alpha_coeffs = coeff_alpha
+        orb_alpha_energies = ener_alpha
+        orb_alpha_occs = occ_alpha / 2
+        orb_beta = None
+    else:
+        if coeff_beta.shape[0] != obasis.nbasis:
+            lit.error("Number of beta orbital coefficients does not match the size of the basis.")
+        orb_alpha = (obasis.nbasis, coeff_alpha.shape[1])
+        orb_alpha_coeffs = coeff_alpha
+        orb_alpha_energies = ener_alpha
+        orb_alpha_occs = occ_alpha
+        orb_beta = (obasis.nbasis, coeff_beta.shape[1])
+        orb_beta_coeffs = coeff_beta
+        orb_beta_energies = ener_beta
+        orb_beta_occs = occ_beta
+
+    # filter out ghost atoms
+    mask = pseudo_numbers != 0
+    coordinates = coordinates[mask]
+    numbers = numbers[mask]
+    pseudo_numbers = pseudo_numbers[mask]
+
+    result = {
+        'coordinates': coordinates,
+        'orb_alpha': orb_alpha,
+        'orb_alpha_coeffs': orb_alpha_coeffs,
+        'orb_alpha_energies': orb_alpha_energies,
+        'orb_alpha_occs': orb_alpha_occs,
+        'numbers': numbers,
+        'obasis': obasis,
+        'pseudo_numbers': pseudo_numbers,
     }
-    permutation = []
-    for shell_type in shell_types:
-        rule = permutation_rules.get(shell_type)
-        if reverse and rule is not None:
-            reverse_rule = np.zeros(len(rule), int)
-            for i, j in enumerate(rule):
-                reverse_rule[j] = i
-            rule = reverse_rule
-        if rule is None:
-            rule = np.arange(get_shell_nbasis(shell_type))
-        permutation.extend(rule + len(permutation))
-    return np.array(permutation, dtype=int)
+    if title is not None:
+        result['title'] = title
+    if orb_beta is not None:
+        result['orb_beta'] = orb_beta
+        result['orb_beta_coeffs'] = orb_beta_coeffs
+        result['orb_beta_energies'] = orb_beta_energies
+        result['orb_beta_occs'] = orb_beta_occs
+    return result
 
 
 def _load_helper_coordinates(lit: LineIterator, cunit: float) -> \
@@ -82,58 +236,40 @@ def _load_helper_coordinates(lit: LineIterator, cunit: float) -> \
     return numbers, pseudo_numbers, coordinates
 
 
-def _load_helper_obasis(lit: LineIterator, coordinates: np.ndarray) -> Tuple[Dict, int]:
+def _load_helper_obasis(lit: LineIterator) -> MolecularBasis:
     """Load the orbital basis."""
-    shell_labels = []
-    shell_map = []
-    nprims = []
-    alphas = []
-    con_coeffs = []
-
-    icenter = 0
-    in_atom = False
-    in_shell = False
-    # Don't take this code as a good example. The structure with in_shell and
-    # in_atom flags is not very transparent.
+    shells = []
     while True:
         line = next(lit)
         words = line.split()
-        if not words:
-            in_atom = False
-            in_shell = False
-        elif len(words) == 2 and not in_atom:
-            icenter = int(words[0]) - 1
-            in_atom = True
-            in_shell = False
-        elif len(words) == 3:
-            in_shell = True
-            shell_map.append(icenter)
-            shell_label = words[0].lower()
-            shell_labels.append(shell_label)
-            nprims.append(int(words[1]))
-        elif len(words) == 2 and in_atom:
-            assert in_shell
-            alpha = float(words[0].replace('D', 'E'))
-            alphas.append(alpha)
-            con_coeff = float(words[1].replace('D', 'E'))
-            con_coeffs.append(con_coeff)
-        else:
-            # done, go back one line
+        # Normally a new atom section begins with one or two integers,
+        # of which the second is zero if present. If not, we are done
+        # and have to push one line back.
+        if not (words and words[0].isdigit()):
             lit.back(line)
             break
+        icenter = int(words[0]) - 1
+        # Loop over all shells until reaching an empty line
+        while True:
+            words = next(lit).split()
+            if not words:
+                break
+            # Read a new shell
+            angmom = angmom_sti(words[0])
+            nprim = int(words[1])
+            exponents = np.zeros(nprim)
+            coeffs = np.zeros((nprim, 1))
+            for iprim in range(nprim):
+                words = next(lit).split()
+                exponents[iprim] = float(words[0].replace('D', 'E'))
+                coeffs[iprim, 0] = float(words[1].replace('D', 'E'))
+            # Unless changed later, all shells are assumed to be Cartesian.
+            shells.append(Shell(icenter, [angmom], ['c'], exponents, coeffs))
+    # Create an empty array for centers, which will be filled in later.
+    centers = np.zeros((icenter + 1, 3))
+    return MolecularBasis(centers, shells, CONVENTIONS, 'L2')
 
-    shell_map = np.array(shell_map)
-    nprims = np.array(nprims)
-    alphas = np.array(alphas)
-    con_coeffs = np.array(con_coeffs)
 
-    obasis = {"centers": coordinates, "shell_map": shell_map, "nprims": nprims,
-              "shell_labels": shell_labels, "alphas": alphas, "con_coeffs": con_coeffs}
-
-    return obasis
-
-
-# pylint: disable=too-many-branches,too-many-statements
 def _load_helper_coeffs(lit: LineIterator) -> Tuple:
     """Load the orbital coefficients."""
     coeff_alpha = []
@@ -189,7 +325,6 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
                 break
             col.append(float(words[1]))
 
-    print(coeff_alpha)
     coeff_alpha = np.array(coeff_alpha).T
     ener_alpha = np.array(ener_alpha)
     occ_alpha = np.array(occ_alpha)
@@ -204,136 +339,8 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
     return (coeff_alpha, ener_alpha, occ_alpha), (coeff_beta, ener_beta, occ_beta)
 
 
-# pylint: disable=too-many-branches,too-many-statements
-def load(lit: LineIterator) -> Dict:
-    """Load data from a MOLDEN input file format.
-
-    Parameters
-    ----------
-    lit
-        The line iterator to read the data from.
-
-    Returns
-    -------
-    out : dict
-        output dictionary containing ``coordinates``, ``numbers``, ``pseudo_numbers``,
-        ``obasis``, ``orb_alpha`` & ``signs`` keys and corresponding values. It may contain
-        ``title`` and ``orb_beta`` keys and their values as well.
-
-    """
-    pure = {'d': False, 'f': False, 'g': False}
-    numbers = None
-    coordinates = None
-    obasis = None
-    coeff_alpha = None
-    ener_alpha = None
-    occ_alpha = None
-    coeff_beta = None
-    ener_beta = None
-    occ_beta = None
-    title = None
-
-    line = next(lit)
-    if line != '[Molden Format]\n':
-        lit.error('Molden header not found')
-    while True:
-        try:
-            line = next(lit).lower().strip()
-        except StopIteration:
-            # This means we continue reading till the end of the file.
-            # There is no real way to know when a Molden file has ended, other
-            # than reaching the end of the file.
-            break
-        if line.startswith('[5d]') or line.startswith('[5d7f]'):
-            pure['d'] = True
-            pure['f'] = True
-        elif line.lower().startswith('[7f]'):
-            pure['f'] = True
-        elif line.lower().startswith('[5d10f]'):
-            pure['d'] = True
-            pure['f'] = False
-        elif line.lower().startswith('[9g]'):
-            pure['g'] = True
-        elif line == '[title]':
-            title = next(lit).strip()
-        elif line.startswith('[atoms]'):
-            if 'au' in line:
-                cunit = 1.0
-            elif 'angs' in line:
-                cunit = angstrom
-            numbers, pseudo_numbers, coordinates = _load_helper_coordinates(lit, cunit)
-        elif line == '[gto]':
-            obasis = _load_helper_obasis(lit, coordinates)
-        elif line == '[sto]':
-            lit.error('Slater-type orbitals are not supported by IODATA.')
-        elif line == '[mo]':
-            data_alpha, data_beta = _load_helper_coeffs(lit)
-            coeff_alpha, ener_alpha, occ_alpha = data_alpha
-            coeff_beta, ener_beta, occ_beta = data_beta
-
-    # Convert shell_labels to shell_types.
-    # This needs to be done after reading because the tags for pure functions
-    # may come at the end.
-    obasis['shell_types'] = np.array([
-        str_to_shell_types(shell_label, pure.get(shell_label, False))[0]
-        for shell_label in obasis['shell_labels']])
-    del obasis['shell_labels']
-    nbasis = shells_to_nbasis(obasis['shell_types'])
-
-    if coeff_beta is None:
-        if coeff_alpha.shape[0] != nbasis:
-            lit.error("Number of alpha orbital coefficients does not match the size of the basis.")
-        orb_alpha = (nbasis, coeff_alpha.shape[1])
-        orb_alpha_coeffs = coeff_alpha
-        orb_alpha_energies = ener_alpha
-        orb_alpha_occs = occ_alpha / 2
-        orb_beta = None
-    else:
-        if coeff_beta.shape[0] != nbasis:
-            lit.error("Number of beta orbital coefficients does not match the size of the basis.")
-        orb_alpha = (nbasis, coeff_alpha.shape[1])
-        orb_alpha_coeffs = coeff_alpha
-        orb_alpha_energies = ener_alpha
-        orb_alpha_occs = occ_alpha
-        orb_beta = (nbasis, coeff_beta.shape[1])
-        orb_beta_coeffs = coeff_beta
-        orb_beta_energies = ener_beta
-        orb_beta_occs = occ_beta
-
-    permutation = _get_molden_permutation(obasis["shell_types"])
-
-    # filter out ghost atoms
-    mask = pseudo_numbers != 0
-    coordinates = coordinates[mask]
-    numbers = numbers[mask]
-    pseudo_numbers = pseudo_numbers[mask]
-
-    result = {
-        'coordinates': coordinates,
-        'orb_alpha': orb_alpha,
-        'orb_alpha_coeffs': orb_alpha_coeffs,
-        'orb_alpha_energies': orb_alpha_energies,
-        'orb_alpha_occs': orb_alpha_occs,
-        'numbers': numbers,
-        'obasis': obasis,
-        'permutation': permutation,
-        'pseudo_numbers': pseudo_numbers,
-    }
-    if title is not None:
-        result['title'] = title
-    if orb_beta is not None:
-        result['orb_beta'] = orb_beta
-        result['orb_beta_coeffs'] = orb_beta_coeffs
-        result['orb_beta_energies'] = orb_beta_energies
-        result['orb_beta_occs'] = orb_beta_occs
-
-    _fix_molden_from_buggy_codes(result, lit.filename)
-    return result
-
-
-def _is_normalized_properly(obasis: Dict, permutation: np.ndarray, orb_alpha: np.ndarray,
-                            orb_beta: np.ndarray, signs: np.ndarray = None,
-                            threshold: float = 1e-4):
+def _is_normalized_properly(obasis: MolecularBasis, orb_alpha: np.ndarray,
+                            orb_beta: np.ndarray, threshold: float = 1e-4):
     """Test the normalization of the occupied and virtual orbitals.
 
     Parameters
@@ -354,11 +361,10 @@ def _is_normalized_properly(obasis: Dict, permutation: np.ndarray, orb_alpha: np
         the function returns False. True is returned otherwise.
 
     """
-    # Set default value for signs
-    if signs is None:
-        signs = np.ones(orb_alpha.shape[0], int)
-    # Compute the overlap matrix.
-    olp = compute_overlap(**obasis)
+    # Compute the overlap matrix. Unfortunately, we have to recalculate it at
+    # every attempt because also the primitive normalization may differ in
+    # different cases.
+    olp = compute_overlap(obasis)
 
     # Convenient code for debugging files coming from crappy QC codes.
     # np.set_printoptions(linewidth=5000, precision=2, suppress=True, threshold=100000)
@@ -370,162 +376,168 @@ def _is_normalized_properly(obasis: Dict, permutation: np.ndarray, orb_alpha: np
     # print np.dot(coeffs.T, np.dot(olp._array, coeffs))
     # print
 
-    # Compute the norm of each occupied and virtual orbital. Keep track of
-    # the largest deviation from unity
+    # Convert the orbitals to the conventions of the overlap matrix.
+    # permutation, signs = convert_conventions(obasis, OVERLAP_CONVENTIONS)
     orbs = [orb_alpha]
     if orb_beta is not None:
         orbs.append(orb_beta)
+    # Compute the norm of each occupied and virtual orbital. Keep track of
+    # the largest deviation from unity
     error_max = 0.0
     for orb in orbs:
         for iorb in range(orb.shape[1]):
             vec = orb[:, iorb].copy()
-            if signs is not None:
-                vec *= signs
-            if permutation is not None:
-                vec = vec[permutation]
             norm = np.dot(vec, np.dot(olp, vec))
-            # print iorb, norm
+            # print(iorb, norm)
             error_max = max(error_max, abs(norm - 1))
 
     # final judgement
     return error_max <= threshold
 
 
-def _get_orca_signs(shell_types: np.ndarray) -> np.ndarray:
-    """Return an array with sign corrections for orbitals read from ORCA.
+def _fix_obasis_orca(obasis: MolecularBasis) -> MolecularBasis:
+    """Return a new MolecularBasis correcting for errors from ORCA.
 
-    Parameters
-    ----------
-    shell_types
-        An array with integer shell types.
-
-    Returns
-    -------
-    signs
-        An array with sign flips.
-
+    Orca has different normalization conventions for the primitives and also
+    different sign conventions for some of the pure functions.
     """
-    sign_rules = {
-        -4: [1, 1, 1, 1, 1, -1, -1, -1, -1],
-        -3: [1, 1, 1, 1, 1, -1, -1],
-        -2: [1, 1, 1, 1, 1],
-        0: [1],
-        1: [1, 1, 1],
+    orca_conventions = {
+        (0, 'c'): ['1'],
+        (1, 'c'): ['x', 'y', 'z'],
+        (2, 'p'): ['dc0', 'dc1', 'ds1', 'dc2', 'ds2'],
+        (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'xz', 'yz'],
+        (3, 'p'): ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', '-fc3', '-fs3'],
+        (3, 'c'): ['xxx', 'yyy', 'zzz', 'xyy', 'xxy', 'xxz', 'xzz', 'yzz', 'yyz', 'xyz'],
+        (4, 'p'): ['gc0', 'gc1', 'gs1', 'gc2', 'gs2', '-gc3', '-gs3', '-gc4', '-gs4'],
+        (4, 'c'): ['xxxx', 'yyyy', 'zzzz', 'xxxy', 'xxxz', 'xyyy', 'yyyz', 'xzzz',
+                   'yzzz', 'xxyy', 'xxzz', 'yyzz', 'xxyz', 'xyyz', 'xyzz'],
     }
-    signs = []
-    for shell_type in shell_types:
-        if shell_type in sign_rules:
-            signs.extend(sign_rules[shell_type])
-        else:
-            signs.extend([1] * get_shell_nbasis(shell_type))
-    return np.array(signs, dtype=int)
-
-
-# pylint: disable=too-many-branches
-def _get_fixed_con_coeffs(nprims: np.ndarray, shell_types: np.ndarray, alphas: np.ndarray,
-                          con_coeffs: np.ndarray, code: str) -> Union[np.ndarray, None]:
-    """Return corrected contraction coefficients, assuming they came from a broken QC code.
-
-    The arguments here are the same as the ones that are given from ``helper_obasis``.
-
-    Parameters
-    ----------
-    nprims
-        Number of primitives in each shell
-    shell_types
-        Shell angular momenta
-    alphas
-        Gaussian basis exponents
-    con_coeffs
-        Contraction coefficients
-    code
-        Name of code: 'orca', 'psi4' or 'turbomole'.
-
-    Returns
-    -------
-    fixed_con_coeffs
-        Corrected contraction coefficients, or None if corrections were not applicable.
-
-    """
-    assert code in ['orca', 'psi4', 'turbomole']
-    fixed_con_coeffs = con_coeffs.copy()
-    iprim = 0
-    corrected = False
-    for ishell in range(shell_types.size):
-        shell_type = shell_types[ishell]
-        for _ialpha in range(nprims[ishell]):
-            alpha = alphas[iprim]
+    fixed_shells = []
+    for shell in obasis.shells:
+        fixed_shell = copy.deepcopy(shell)
+        fixed_shells.append(fixed_shell)
+        # We can safely assume segmented shells.
+        angmom = shell.angmoms[0]
+        kind = shell.kinds[0]
+        for iprim, exponent in enumerate(shell.exponents):
             # Default 1.0: do not to correct anything, unless we know how to correct.
             correction = 1.0
-            if code == 'turbomole':
-                if shell_type == 2:
-                    correction = 1.0 / np.sqrt(3.0)
-                elif shell_type == 3:
-                    correction = 1.0 / np.sqrt(15.0)
-                elif shell_type == 4:
-                    correction = 1.0 / np.sqrt(105.0)
-            elif code == 'orca':
-                if shell_type == 0:
-                    correction = gob_cart_normalization(alpha, np.array([0, 0, 0]))
-                elif shell_type == 1:
-                    correction = gob_cart_normalization(alpha, np.array([1, 0, 0]))
-                elif shell_type == -2:
-                    correction = gob_cart_normalization(alpha, np.array([1, 1, 0]))
-                elif shell_type == -3:
-                    correction = gob_cart_normalization(alpha, np.array([1, 1, 1]))
-                elif shell_type == -4:
-                    correction = gob_cart_normalization(alpha, np.array([2, 1, 1]))
-            elif code == 'psi4':
-                if shell_type == 0:
-                    correction = gob_cart_normalization(alpha, np.array([0, 0, 0]))
-                elif shell_type == 1:
-                    correction = gob_cart_normalization(alpha, np.array([1, 0, 0]))
-                elif shell_type == -2:
-                    correction = gob_cart_normalization(alpha, np.array([1, 1, 0])) / np.sqrt(3.0)
-                elif shell_type == -3:
-                    correction = gob_cart_normalization(alpha, np.array([1, 1, 1])) / np.sqrt(15.0)
-                # elif shell_type == -4: ##  ! Not tested
-                #     correction = gob_cart_normalization(alpha, np.array([2, 1, 1]))/np.sqrt(105.0)
-            fixed_con_coeffs[iprim] /= correction
+            if angmom == 0:
+                correction = gob_cart_normalization(exponent, np.array([0, 0, 0]))
+            elif angmom == 1:
+                correction = gob_cart_normalization(exponent, np.array([1, 0, 0]))
+            elif angmom == 2 and kind == 'p':
+                correction = gob_cart_normalization(exponent, np.array([1, 1, 0]))
+            elif angmom == 3 and kind == 'p':
+                correction = gob_cart_normalization(exponent, np.array([1, 1, 1]))
+            elif angmom == 4 and kind == 'p':
+                correction = gob_cart_normalization(exponent, np.array([2, 1, 1]))
+            if correction != 1.0:
+                fixed_shell.coeffs[iprim, 0] /= correction
+            iprim += 1
+    return MolecularBasis(obasis.centers, fixed_shells, orca_conventions,
+                          obasis.primitive_normalization)
+
+
+def _fix_obasis_psi4(obasis: MolecularBasis) -> Union[MolecularBasis, None]:
+    """Return a new MolecularBasis correcting for errors from old PSI4 versions.
+
+    Old PSI4 version used a different normalization of the primitives.
+    """
+    fixed_shells = []
+    corrected = False
+    for shell in obasis.shells:
+        # We can safely assume segmented shells.
+        fixed_shell = copy.deepcopy(shell)
+        fixed_shells.append(fixed_shell)
+        angmom = shell.angmoms[0]
+        kind = shell.kinds[0]
+        for iprim, exponent in enumerate(shell.exponents):
+            # Default 1.0: do not to correct anything, unless we know how to correct.
+            correction = 1.0
+            if angmom == 0:
+                correction = gob_cart_normalization(exponent, np.array([0, 0, 0]))
+            elif angmom == 1:
+                correction = gob_cart_normalization(exponent, np.array([1, 0, 0]))
+            elif angmom == 2 and kind == 'p':
+                correction = gob_cart_normalization(exponent, np.array([1, 1, 0])) / np.sqrt(3.0)
+            elif angmom == 3 and kind == 'p':
+                correction = gob_cart_normalization(exponent, np.array([1, 1, 1])) / np.sqrt(15.0)
+            # elif angmom == 4 and kind == 'p': ##  ! Not tested
+            #     correction = gob_cart_normalization(exponent, np.array([2, 1, 1]))/np.sqrt(105.0)
             if correction != 1.0:
                 corrected = True
-            iprim += 1
+                fixed_shell.coeffs[iprim, 0] /= correction
     if corrected:
-        return fixed_con_coeffs
+        return MolecularBasis(obasis.centers, fixed_shells, obasis.conventions,
+                              obasis.primitive_normalization)
     return None
 
 
-def _normalized_contractions(obasis_dict: Dict):
-    """Return contraction coefficients of normalized contractions."""
-    # Files written by Molden don't need this and have properly normalized contractions.
-    # When Molden reads files in the Molden format, it does renormalize the contractions
-    # and other programs than Molden may generate Molden files with unnormalized
-    # contractions. Note: this renormalization is only a last resort in HORTON. If we
-    # would do it up-front, like Molden, we would not be able to fix errors in files from
-    # ORCA and older PSI-4 versions.
-    iprim = 0
-    new_con_coeffs = obasis_dict['con_coeffs'].copy()
-    for nprim, shell_type in zip(obasis_dict['nprims'], obasis_dict['shell_types']):
-        centers = np.array([[0.0, 0.0, 0.0]])
-        shell_map = np.array([0])
-        shell_types = np.array([shell_type])
-        alphas = obasis_dict['alphas'][iprim:iprim + nprim]
-        nprims = np.array([len(alphas)])
-        con_coeffs = new_con_coeffs[iprim:iprim + nprim]
+def _fix_obasis_turbomole(obasis: MolecularBasis) -> Union[MolecularBasis, None]:
+    """Return a new MolecularBasis correcting for errors from turbomole.
 
+    Turbomole uses a different normalization of the primitives.
+    """
+    fixed_shells = []
+    corrected = False
+    for shell in obasis.shells:
+        # We can safely assume segmented shells.
+        fixed_shell = copy.deepcopy(shell)
+        fixed_shells.append(fixed_shell)
+        angmom = shell.angmoms[0]
+        kind = shell.kinds[0]
+        for iprim in range(shell.nprim):
+            # Default 1.0: do not to correct anything, unless we know how to correct.
+            correction = 1.0
+            if angmom == 2 and kind == 'c':
+                correction = 1.0 / np.sqrt(3.0)
+            elif angmom == 3 and kind == 'c':
+                correction = 1.0 / np.sqrt(15.0)
+            elif angmom == 4 and kind == 'c':
+                correction = 1.0 / np.sqrt(105.0)
+            if correction != 1.0:
+                corrected = True
+                fixed_shell.coeffs[iprim, 0] /= correction
+    if corrected:
+        return MolecularBasis(obasis.centers, fixed_shells, obasis.conventions,
+                              obasis.primitive_normalization)
+    return None
+
+
+def _fix_obasis_normalize_contractions(obasis: MolecularBasis) -> MolecularBasis:
+    """Return a basis with normalized contractions.
+
+    Files written by Molden don't need this fix and have properly normalized
+    contractions. When Molden reads files in the Molden format, it does
+    renormalize the contractions and other programs than Molden may generate
+    Molden files with unnormalized contractions. This renormalization is only a
+    last resort in IOData. If we would do it up-front, like Molden, we would not
+    be able to fix errors in files from ORCA and older PSI4 versions.
+    """
+    fixed_shells = []
+    for shell in obasis.shells:
+        shell_obasis = MolecularBasis(
+            obasis.centers,
+            [shell],
+            obasis.conventions,
+            obasis.primitive_normalization
+        )
         # 2) Get the first diagonal element of the overlap matrix
-        olpdiag = compute_overlap(centers, shell_map, nprims, shell_types, alphas, con_coeffs)[0, 0]
+        olpdiag = compute_overlap(shell_obasis)[0, 0]
         # 3) Normalize the contraction
-        con_coeffs /= np.sqrt(olpdiag)
-        iprim += nprim
-    return new_con_coeffs
+        fixed_shell = copy.deepcopy(shell)
+        fixed_shell.coeffs[:] /= np.sqrt(olpdiag)
+        fixed_shells.append(fixed_shell)
+    return MolecularBasis(obasis.centers, fixed_shells, obasis.conventions,
+                          obasis.primitive_normalization)
 
 
 def _fix_molden_from_buggy_codes(result: Dict, filename: str):
-    """Detect errors in the data loaded from a molden/mkl/... file and correct.
+    """Detect errors in the data loaded from a molden or mkl file and correct.
 
-    This function can recognize erroneous files created by PSI4, ORCA and Turbomole. The
-    values in `results` for the `obasis` and `signs` keys will be updated accordingly.
+    This function can recognize erroneous files created by PSI4, ORCA and
+    Turbomole. The value `results['obasis']` will be updated accordingly.
 
     Parameters
     ----------
@@ -535,80 +547,56 @@ def _fix_molden_from_buggy_codes(result: Dict, filename: str):
         The name of the molden/mkl/... file.
 
     """
-    obasis_dict = result['obasis']
-    permutation = result.get('permutation', None)
-    if _is_normalized_properly(obasis_dict, permutation, result['orb_alpha_coeffs'],
+    obasis = result['obasis']
+    if _is_normalized_properly(obasis, result['orb_alpha_coeffs'],
                                result.get('orb_beta_coeffs')):
-        # The file is good. No need to change data.
+        # The file is good. No need to change obasis.
         return
-    print('5:Detected incorrect normalization of orbitals loaded from a file.')
+    print('5:Detected incorrect normalization of orbitals loaded from a Molden or MKL file.')
 
     # --- ORCA
     print('5:Trying to fix it as if it was a file generated by ORCA.')
-    orca_signs = _get_orca_signs(obasis_dict['shell_types'])
-    orca_con_coeffs = _get_fixed_con_coeffs(obasis_dict["nprims"], obasis_dict["shell_types"],
-                                            obasis_dict["alphas"], obasis_dict["con_coeffs"],
-                                            code='orca')
-    if orca_con_coeffs is not None:
-        # Only try if some changes were made to the contraction coefficients.
-        obasis_dict_orca = obasis_dict.copy()
-        obasis_dict_orca["con_coeffs"] = orca_con_coeffs
-        if _is_normalized_properly(obasis_dict_orca, permutation,
-                                   result['orb_alpha_coeffs'], result.get('orb_beta_coeffs'),
-                                   orca_signs):
-            print('5:Detected typical ORCA errors in file. Fixing them...')
-            result['obasis'] = obasis_dict_orca
-            result['signs'] = orca_signs
-            return
+    orca_obasis = _fix_obasis_orca(obasis)
+    if _is_normalized_properly(orca_obasis, result['orb_alpha_coeffs'],
+                               result.get('orb_beta_coeffs')):
+        print('5:Detected typical ORCA errors in file. Fixing them...')
+        result['obasis'] = orca_obasis
+        return
 
     # --- PSI4
     print('5:Trying to fix it as if it was a file generated by PSI4 (pre 1.0).')
-    psi4_con_coeffs = _get_fixed_con_coeffs(obasis_dict["nprims"], obasis_dict["shell_types"],
-                                            obasis_dict["alphas"], obasis_dict["con_coeffs"],
-                                            code='psi4')
-    if psi4_con_coeffs is not None:
-        # Only try if some changes were made to the contraction coefficients.
-        obasis_dict_psi4 = obasis_dict.copy()
-        obasis_dict_psi4["con_coeffs"] = psi4_con_coeffs
-        if _is_normalized_properly(obasis_dict_psi4, permutation,
-                                   result['orb_alpha_coeffs'], result.get('orb_beta_coeffs')):
-            print('5:Detected typical PSI4 errors in file. Fixing them...')
-            result['obasis'] = obasis_dict_psi4
-            return
+    psi4_obasis = _fix_obasis_psi4(obasis)
+    if psi4_obasis is not None and _is_normalized_properly(
+            psi4_obasis, result['orb_alpha_coeffs'], result.get('orb_beta_coeffs')):
+        print('5:Detected typical PSI4 errors in file. Fixing them...')
+        result['obasis'] = psi4_obasis
+        return
 
     # -- Turbomole
     print('5:Trying to fix it as if it was a file generated by Turbomole.')
-    tb_con_coeffs = _get_fixed_con_coeffs(obasis_dict["nprims"], obasis_dict["shell_types"],
-                                          obasis_dict["alphas"], obasis_dict["con_coeffs"],
-                                          code='turbomole')
-    if tb_con_coeffs is not None:
-        # Only try if some changes were made to the contraction coefficients.
-        obasis_dict_tb = obasis_dict.copy()
-        obasis_dict_tb["con_coeffs"] = tb_con_coeffs
-        if _is_normalized_properly(obasis_dict_tb, permutation,
-                                   result['orb_alpha_coeffs'], result.get('orb_beta_coeffs')):
-            print('5:Detected typical Turbomole errors in file. Fixing them...')
-            result['obasis'] = obasis_dict_tb
-            return
+    turbomole_obasis = _fix_obasis_turbomole(obasis)
+    if turbomole_obasis is not None and _is_normalized_properly(
+            turbomole_obasis, result['orb_alpha_coeffs'], result.get('orb_beta_coeffs')):
+        print('5:Detected typical Turbomole errors in file. Fixing them...')
+        result['obasis'] = turbomole_obasis
+        return
 
     # --- Renormalized contractions
     print('5:Last resort: trying by renormalizing all contractions')
-    normed_con_coeffs = _normalized_contractions(obasis_dict)
-    obasis_dict_norm = obasis_dict.copy()
-    obasis_dict_norm["con_coeffs"] = normed_con_coeffs
-    if _is_normalized_properly(obasis_dict_norm, permutation,
-                               result['orb_alpha_coeffs'], result.get('orb_beta_coeffs')):
+    normed_obasis = _fix_obasis_normalize_contractions(obasis)
+    if _is_normalized_properly(normed_obasis, result['orb_alpha_coeffs'],
+                               result.get('orb_beta_coeffs')):
         print('5:Detected unnormalized contractions in file. Fixing them...')
-        result['obasis'] = obasis_dict_norm
+        result['obasis'] = normed_obasis
         return
 
-    raise IOError(('Could not correct the data read from %s. The molden or '
+    raise IOError(('Could not correct the data read from {}. The molden or '
                    'mkl file you are trying to load contains errors. Please '
-                   'report this problem to Toon.Verstraelen@UGent.be, so he '
-                   'can fix it.') % filename)
+                   'make an issue here: https://github.com/theochem/iodata/issues, '
+                   'and attach a this file. Please provide one or more small '
+                   'files causing this error'.format(filename)))
 
 
-# pylint: disable=too-many-branches,too-many-statements
 def dump(f: TextIO, data: 'IOData'):
     """Write data into a MOLDEN input file format.
 
@@ -623,116 +611,102 @@ def dump(f: TextIO, data: 'IOData'):
 
     """
     # Print the header
-    print('[Molden Format]', file=f)
-    print('[Title]', file=f)
-    print(' %s' % getattr(data, 'title', 'Created with HORTON'), file=f)
-    print(file=f)
+    f.write('[Molden Format]\n')
+    f.write('[Title]\n')
+    f.write(' {}\n'.format(getattr(data, 'title', 'Created with HORTON')))
 
     # Print the elements numbers and the coordinates
-    print('[Atoms] AU', file=f)
+    f.write('[Atoms] AU\n')
     for iatom in range(data.natom):
         number = data.numbers[iatom]
         pseudo_number = data.pseudo_numbers[iatom]
         x, y, z = data.coordinates[iatom]
-        print('%2s %3i %3i  %25.18f %25.18f %25.18f' % (
+        f.write('{:2s} {:3d} {:3.0f}  {:25.18f} {:25.18f} {:25.18f}\n'.format(
             num2sym[number].ljust(2), iatom + 1, pseudo_number, x, y, z
-        ), file=f)
+        ))
+    f.write('\n')
 
     # Print the basis set
-    if isinstance(data.obasis, dict):
-        # Figure out the pure/Cartesian situation. Note that the Molden
-        # format does not support mixed Cartesian and pure functions in the
-        # way HORTON does. In practice, such combinations are too unlikely
-        # to be relevant.
-        pure = {'d': None, 'f': None, 'g': None}
-        try:
-            for shell_type in data.obasis["shell_types"]:
-                if shell_type == 2:
-                    assert pure['d'] is None or not pure['d']
-                    pure['d'] = False
-                elif shell_type == -2:
-                    assert pure['d'] is None or pure['d']
-                    pure['d'] = True
-                elif shell_type == 3:
-                    assert pure['f'] is None or not pure['f']
-                    pure['f'] = False
-                elif shell_type == -3:
-                    assert pure['f'] is None or pure['f']
-                    pure['f'] = True
-                elif shell_type == 4:
-                    assert pure['g'] is None or not pure['g']
-                    pure['g'] = False
-                elif shell_type == -4:
-                    assert pure['g'] is None or pure['g']
-                    pure['g'] = True
-                else:
-                    assert abs(shell_type) < 2
-        except AssertionError:
-            raise IOError('The basis set is not supported by the Molden format.')
+    if not hasattr(data, 'obasis'):
+        raise IOError('A Gaussian orbital basis is required to write a molden input file.')
+    obasis = data.obasis
 
-        # Write out the Cartesian/Pure conventions. What a messy format...
-        if pure['d']:
-            if pure['f']:
-                print('[5D]', file=f)
+    # Figure out the pure/Cartesian situation. Note that the Molden
+    # format does not support mixed Cartesian and pure functions for the,
+    # same angular momentum. In practice, such combinations are too unlikely
+    # to be relevant. If it happens, an error is raised.
+    angmom_kinds = {}
+    for shell in obasis.shells:
+        for angmom, kind in zip(shell.angmoms, shell.kinds):
+            if angmom in angmom_kinds:
+                if kind != angmom_kinds[angmom]:
+                    raise IOError('Molden format does not support mixed '
+                                  'pure+Cartesian functions for one '
+                                  'angular momentum.')
             else:
-                print('[5D10F]', file=f)
+                angmom_kinds[angmom] = kind
+
+    # Fill in some defaults (Cartesian) for angmom kinds if needed.
+    angmom_kinds.setdefault(2, 'c')
+    angmom_kinds.setdefault(3, 'c')
+    angmom_kinds.setdefault(4, 'c')
+
+    # Write out the Cartesian/Pure conventions. What a messy format...
+    if angmom_kinds[2] == 'p':
+        if angmom_kinds[3] == 'p':
+            f.write('[5D]\n')
         else:
-            if pure['f']:
-                print('[7F]', file=f)
-        if pure['g']:
-            print('[9G]', file=f)
-
-        # First convert it to a format that is amenable for printing. The molden
-        # format assumes that every basis function is centered on one of the atoms.
-        # (This may not always be the case.)
-        centers = [list() for _ in range(data.obasis["centers"].shape[0])]
-        begin_prim = 0
-        for ishell in range(data.obasis["shell_types"].size):
-            icenter = data.obasis["shell_map"][ishell]
-            shell_type = data.obasis["shell_types"][ishell]
-            sts = shell_type_to_str(shell_type)
-            end_prim = begin_prim + data.obasis["nprims"][ishell]
-            prims = []
-            for iprim in range(begin_prim, end_prim):
-                alpha = data.obasis["alphas"][iprim]
-                con_coeff = data.obasis["con_coeffs"][iprim]
-                prims.append((alpha, con_coeff))
-            centers[icenter].append((sts, prims))
-            begin_prim = end_prim
-
-        print('[GTO]', file=f)
-        for icenter in range(data.obasis["centers"].shape[0]):
-            print('%3i 0' % (icenter + 1), file=f)
-            for sts, prims in centers[icenter]:
-                print('%1s %3i 1.0' % (sts, len(prims)), file=f)
-                for alpha, con_coeff in prims:
-                    print('%20.10f %20.10f' % (alpha, con_coeff), file=f)
-            print(file=f)
+            f.write('[5D10F]\n')
     else:
-        raise NotImplementedError(
-            'A Gaussian orbital basis is required to write a molden input file.')
+        if angmom_kinds[3] == 'p':
+            f.write('[7F]\n')
+    if angmom_kinds[4] == 'p':
+        f.write('[9G]\n')
 
-    def helper_orb(spin, occ_scale=1.0):
-        orb_coeffs = getattr(data, f'orb_{spin}_coeffs')
-        orb_energies = getattr(data, f'orb_{spin}_energies')
-        orb_occupations = getattr(data, f'orb_{spin}_occs')
-        for ifn in range(orb_coeffs.shape[1]):
-            print(' Sym=     1a', file=f)
-            print(f' Ene= {orb_energies[ifn]:20.14E}', file=f)
-            print(f' Spin= {spin.capitalize()}', file=f)
-            print(f' Occup= {orb_occupations[ifn] * occ_scale:8.6f}', file=f)
-            for ibasis in range(orb_coeffs.shape[0]):
-                print('%3i %20.12f' % (ibasis + 1, orb_coeffs[permutation[ibasis], ifn]),
-                      file=f)
+    # The molden format assumes that every basis function is centered on one
+    # of the atoms. (This may not always be the case, e.g. for ghost atoms.)
+    # TODO: we need better ways to handle ghost atoms and raise errors here.
+    f.write('[GTO]\n')
+    last_icenter = -1
+    # The shells must be sorted by center.
+    for shell in sorted(obasis.shells, key=(lambda s: s.icenter)):
+        if shell.icenter != last_icenter:
+            if last_icenter != -1:
+                f.write("\n")
+            last_icenter = shell.icenter
+            f.write('%3i 0\n' % (shell.icenter + 1))
+        # Decontract the basis
+        for iangmom, angmom in enumerate(shell.angmoms):
+            f.write(' {:1s}  {:3d} 1.00\n'.format(angmom_its(angmom), shell.nprim))
+            for exponent, coeff in zip(shell.exponents, shell.coeffs[:, iangmom]):
+                f.write('{:20.10f} {:20.10f}\n'.format(exponent, coeff))
+    f.write("\n")
 
-    # Construct the permutation of the basis functions
-    permutation = _get_molden_permutation(data.obasis["shell_types"], reverse=True)
+    # Get the permutation to convert the orbital coefficients to Molden conventions.
+    permutation, signs = convert_conventions(obasis, CONVENTIONS)
 
     # Print the mean-field orbitals
     if hasattr(data, 'orb_beta_coeffs'):
-        print('[MO]', file=f)
-        helper_orb('alpha')
-        helper_orb('beta')
+        f.write('[MO]\n')
+        _dump_helper_orb(f, 'Alpha', data.orb_alpha_energies, data.orb_alpha_occs,
+                         data.orb_alpha_coeffs[permutation] * signs.reshape(-1, 1))
+        _dump_helper_orb(f, 'Beta', data.orb_beta_energies, data.orb_beta_occs,
+                         data.orb_beta_coeffs[permutation] * signs.reshape(-1, 1))
     else:
-        print('[MO]', file=f)
-        helper_orb('alpha', 2.0)
+        f.write('[MO]\n')
+        _dump_helper_orb(f, 'Alpha', data.orb_alpha_energies, data.orb_alpha_occs,
+                         data.orb_alpha_coeffs[permutation] * signs.reshape(-1, 1), 2.0)
+
+
+def _dump_helper_orb(f, spin, orb_energies, orb_occs, orb_coeffs, occ_scale=1.0):
+    for ifn in range(orb_coeffs.shape[1]):
+        f.write(f' Ene= {orb_energies[ifn]:.17e}\n')
+        f.write(' Sym=     1a\n')
+        f.write(f' Spin= {spin}\n')
+        f.write(f' Occup= {orb_occs[ifn] * occ_scale:.17e}\n')
+        for ibasis in range(orb_coeffs.shape[0]):
+            # The original molden floating-point formatting is too low
+            # precision. Molden also reads high-precision, so we use this
+            # instead.
+            # f.write('{:4d} {:10.6f}\n'.format(ibasis + 1, orb_coeffs[ibasis, ifn]))
+            f.write('{:4d} {:.17e}\n'.format(ibasis + 1, orb_coeffs[ibasis, ifn]))

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -28,9 +28,9 @@ import copy
 import numpy as np
 
 from ..basis import (angmom_its, angmom_sti, MolecularBasis, Shell,
-                     convert_conventions)
+                     convert_conventions, HORTON2_CONVENTIONS)
 from ..periodic import sym2num, num2sym
-from ..overlap import compute_overlap, OVERLAP_CONVENTIONS, gob_cart_normalization
+from ..overlap import compute_overlap, gob_cart_normalization
 from ..utils import angstrom, LineIterator
 
 
@@ -53,11 +53,11 @@ patterns = ['*.molden.input', '*.molden']
 CONVENTIONS = {
     (0, 'c'): ['1'],
     (1, 'c'): ['x', 'y', 'z'],
-    (2, 'p'): OVERLAP_CONVENTIONS[(2, 'p')],
+    (2, 'p'): HORTON2_CONVENTIONS[(2, 'p')],
     (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'xz', 'yz'],
-    (3, 'p'): OVERLAP_CONVENTIONS[(3, 'p')],
+    (3, 'p'): HORTON2_CONVENTIONS[(3, 'p')],
     (3, 'c'): ['xxx', 'yyy', 'zzz', 'xyy', 'xxy', 'xxz', 'xzz', 'yzz', 'yyz', 'xyz'],
-    (4, 'p'): OVERLAP_CONVENTIONS[(4, 'p')],
+    (4, 'p'): HORTON2_CONVENTIONS[(4, 'p')],
     (4, 'c'): ['xxxx', 'yyyy', 'zzzz', 'xxxy', 'xxxz', 'xyyy', 'yyyz', 'xzzz',
                'yzzz', 'xxyy', 'xxzz', 'yyzz', 'xxyz', 'xyyz', 'xyzz'],
 }
@@ -377,7 +377,7 @@ def _is_normalized_properly(obasis: MolecularBasis, orb_alpha: np.ndarray,
     # print
 
     # Convert the orbitals to the conventions of the overlap matrix.
-    # permutation, signs = convert_conventions(obasis, OVERLAP_CONVENTIONS)
+    # permutation, signs = convert_conventions(obasis, HORTON2_CONVENTIONS)
     orbs = [orb_alpha]
     if orb_beta is not None:
         orbs.append(orb_beta)

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -26,7 +26,8 @@ from typing import Tuple, List, Dict
 
 import numpy as np
 
-from ..overlap import init_scales
+from ..basis import MolecularBasis, Shell
+from ..overlap import gob_cart_normalization
 from ..periodic import sym2num
 from ..utils import MolecularOrbitals, LineIterator
 
@@ -36,6 +37,83 @@ __all__ = ['load_wfn_low', 'get_permutation_orbital',
 
 
 patterns = ['*.wfn']
+
+
+# From the AIMALL documentation
+# 1 S
+# 2 PX
+# 3 PY
+# 4 PZ
+# 5 DXX
+# 6 DYY
+# 7 DZZ
+# 8 DXY
+# 9 DXZ
+# 10 DYZ
+# 11 FXXX
+# 12 FYYY
+# 13 FZZZ
+# 14 FXXY
+# 15 FXXZ
+# 16 FYYZ
+# 17 FXYY
+# 18 FXZZ
+# 19 FYZZ
+# 20 FXYZ
+# 21 GXXXX
+# 22 GYYYY
+# 23 GZZZZ
+# 24 GXXXY
+# 25 GXXXZ
+# 26 GXYYY
+# 27 GYYYZ
+# 28 GXZZZ
+# 29 GYZZZ
+# 30 GXXYY
+# 31 GXXZZ
+# 32 GYYZZ
+# 33 GXXYZ
+# 34 GXYYZ
+# 35 GXYZZ
+# 36 HZZZZZ (005)
+# 37 HYZZZZ (014)
+# 38 HYYZZZ (023)
+# 39 HYYYZZ (032)
+# 40 HYYYYZ (041)
+# 41 HYYYYY (050)
+# 42 HXZZZZ (104)
+# 43 HXYZZZ (113)
+# 44 HXYYZZ (122)
+# 45 HXYYYZ (131)
+# 46 HXYYYY (140)
+# 47 HXXZZZ (203)
+# 48 HXXYZZ (212)
+# 49 HXXYYZ (221)
+# 50 HXXYYY (230)
+# 51 HXXXZZ (302)
+# 52 HXXXYZ (311)
+# 53 HXXXYY (320)
+# 54 HXXXXZ (401)
+# 55 HXXXXY (410)
+# 56 HXXXXX (500)
+
+
+CONVENTIONS = {
+    (0, 'c'): ['1'],
+    (1, 'c'): ['x', 'y', 'z'],
+    (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'xz', 'yz'],
+    (3, 'c'): ['xxx', 'yyy', 'zzz', 'xxy', 'xxz', 'yyz', 'xyy', 'xzz', 'yzz', 'xyz'],
+    (4, 'c'): ['xxxx', 'yyyy', 'zzzz', 'xxxy', 'xxxz', 'xyyy', 'yyyz', 'xzzz',
+               'yzzz', 'xxyy', 'xxzz', 'yyzz', 'xxyz', 'xyyz', 'xyzz'],
+    (5, 'c'): ['zzzzz', 'yzzzz', 'yyzzz', 'yyyzz', 'yyyyz', 'yyyyy', 'xzzzz',
+               'xyzzz', 'xyyzz', 'xyyyz', 'xyyyy', 'xxzzz', 'xxyzz', 'xxyyz',
+               'xxyyy', 'xxxzz', 'xxxyz', 'xxxyy', 'xxxxz', 'xxxxy', 'xxxxx'],
+}
+
+
+# Definition of primitives in the WFN format. This is the order of the primitive
+# types as documented by aimall, used in the field TYPE ASSIGNMENTS.
+PRIMITIVE_NAMES = sum([CONVENTIONS[(angmom, 'c')] for angmom in range(6)], [])
 
 
 def _load_helper_num(lit: LineIterator) -> List[int]:
@@ -57,27 +135,27 @@ def _load_helper_coordinates(lit: LineIterator, num_atoms: int) -> Tuple[np.ndar
     return numbers, coordinates
 
 
-def _load_helper_section(lit: LineIterator, num_primitives: int, start: str, skip: int) -> List:
+def _load_helper_section(lit: LineIterator, nprim: int, start: str, skip: int,
+                         dtype: np.dtype) -> List:
     """Read CENTRE ASSIGNMENTS, TYPE ASSIGNMENTS, and EXPONENTS sections."""
     section = []
-    while len(section) < num_primitives:
+    while len(section) < nprim:
         line = next(lit)
         assert line.startswith(start)
         words = line.split()
         section.extend(words[skip:])
-    assert len(section) == num_primitives
-    return section
+    assert len(section) == nprim
+    return np.array([word.replace('D', 'E') for word in section]).astype(dtype)
 
 
-def _load_helper_mo(lit: LineIterator, num_primitives: int) -> Tuple[str, str, str, List[str]]:
+def _load_helper_mo(lit: LineIterator, nprim: int) -> Tuple[str, str, str, List[str]]:
     """Read one section of MO information."""
     line = next(lit)
     assert line.startswith('MO')
     words = line.split()
     count = words[1]
     occ, energy = words[-5], words[-1]
-    coeffs = _load_helper_section(lit, num_primitives, ' ', 0)
-    coeffs = [i.replace('D', 'E') for i in coeffs]
+    coeffs = _load_helper_section(lit, nprim, ' ', 0, float)
     return count, occ, energy, coeffs
 
 
@@ -101,108 +179,121 @@ def load_wfn_low(lit: LineIterator) -> Tuple:
     """
     # read sections of wfn file
     title = next(lit).strip()
-    num_mo, num_primitives, num_atoms = _load_helper_num(lit)
+    num_mo, nprim, num_atoms = _load_helper_num(lit)
     numbers, coordinates = _load_helper_coordinates(lit, num_atoms)
     # centers are indexed from zero in HORTON
-    centers = np.array([
-        int(i) - 1 for i in
-        _load_helper_section(lit, num_primitives, 'CENTRE ASSIGNMENTS', 2)])
-    type_assignment = np.array([
-        int(i) for i in
-        _load_helper_section(lit, num_primitives, 'TYPE ASSIGNMENTS', 2)])
-    exponent = np.array([
-        float(i.replace('D', 'E')) for i in
-        _load_helper_section(lit, num_primitives, 'EXPONENTS', 1)])
+    icenters = _load_helper_section(lit, nprim, 'CENTRE ASSIGNMENTS', 2, int) - 1
+    # The type assignments are integer indices for individual basis functions,
+    # while in IOData, only the order within shells is fixed by configurable
+    # conventions. In principle, the wfn format makes it possible for two
+    # shells with the same angular momentum to have a different ordering of
+    # the basis functions.
+    type_assignments = _load_helper_section(lit, nprim, 'TYPE ASSIGNMENTS', 2, int) - 1
+    exponent = _load_helper_section(lit, nprim, 'EXPONENTS', 1, float)
     mo_count = np.empty(num_mo, int)
     mo_occ = np.empty(num_mo, float)
     mo_energy = np.empty(num_mo, float)
-    coefficients = np.empty([num_primitives, num_mo], float)
+    mo_coefficients = np.empty([nprim, num_mo], float)
     for mo in range(num_mo):
-        mo_count[mo], mo_occ[mo], mo_energy[mo], coefficients[:, mo] = \
-            _load_helper_mo(lit, num_primitives)
+        mo_count[mo], mo_occ[mo], mo_energy[mo], mo_coefficients[:, mo] = \
+            _load_helper_mo(lit, nprim)
     energy = _load_helper_energy(lit)
-    return title, numbers, coordinates, centers, type_assignment, exponent, \
-        mo_count, mo_occ, mo_energy, coefficients, energy
+    return title, numbers, coordinates, icenters, type_assignments, exponent, \
+        mo_count, mo_occ, mo_energy, mo_coefficients, energy
 
 
-def get_permutation_orbital(type_assignment: np.ndarray) -> np.ndarray:
-    """Permute each type of orbital to get the proper order for HORTON."""
-    num_primitive = len(type_assignment)
-    permutation = np.arange(num_primitive)
-    # degeneracy of {s:1, p:3, d:6, f:10, g:15, h:21}
-    degeneracy = {1: 1, 2: 3, 5: 6, 11: 10, 23: 15, 36: 21}
-    index = 0
-    while index < num_primitive:
-        value = type_assignment[index]
-        length = degeneracy[value]
-        if value != 1 and value == type_assignment[index + 1]:
-            sub_count = 1
-            while index + sub_count < num_primitive and type_assignment[index + sub_count] == value:
-                sub_count += 1
-            sub_type = np.empty(sub_count, int)
-            sub_type[:] = permutation[index: index + sub_count]
-            for i in range(sub_count):
-                permutation[index: index + length] = sub_type[i] + np.arange(length) * sub_count
-                index += length
+# pylint: disable=too-many-branches
+def build_obasis(icenters: np.ndarray, type_assignments: np.ndarray,
+                 exponents: np.ndarray, coordinates: np.ndarray,
+                 lit: LineIterator) -> MolecularBasis:
+    """Construct a basis set using the arrays read from a WFN file.
+
+    Parameters
+    ----------
+    icenters
+        The center indices for all basis functions. shape=(nbasis,). Lowest
+        index is zero.
+    type_assignments
+        Integer codes for basis function names. shape=(nbasis,). Lowest index
+        is zero.
+    exponents
+        The Gaussian exponents of all basis functions. shape=(nbasis,)
+    coordinates
+        The positions of all atoms. shape=(natom, 3).
+
+    """
+    # Build the basis set, keeping track of permutations in case there are
+    # deviations from the default ordering of primitives in a WFN file.
+    shells = []
+    ibasis = 0
+    nbasis = len(icenters)
+    permutation = np.zeros(nbasis, dtype=int)
+    # Loop over all (batches of primitive) basis functions and extract shells.
+    while ibasis < nbasis:
+        # Determine the angular moment of the shell
+        type_assignment = type_assignments[ibasis]
+        if type_assignment == 0:
+            angmom = 0
         else:
-            index += length
-    assert (np.sort(permutation) == np.arange(num_primitive)).all()
-    return permutation
-
-
-def get_permutation_basis(type_assignment: np.ndarray) -> np.ndarray:
-    """
-    Permute the basis functions to get the proper order for HORTON.
-
-    Permutation conventions are as follows:
-
-     d orbitals:
-       wfn:     [5, 6, 7, 8, 9, 10]
-       HORTON:  [5, 8, 9, 6, 10, 7]
-       permute: [0, 3, 4, 1, 5, 2]
-
-     f orbitals:
-       wfn:     [11, 12, 13, 17, 14, 15, 18, 19, 16, 20]
-       HORTON:  [11, 14, 15, 17, 20, 18, 12, 16, 19, 13]
-       permute: [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
-
-     g orbital:
-       wfn:     [23, 29, 32, 27, 22, 28, 35, 34, 26, 31, 33, 30, 25, 24, 21]
-       HORTON:  [21, 24, 25, 30, 33, 31, 26, 34, 35, 28, 22, 27, 32, 29, 23]
-       permute: [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-
-     h orbital:
-       wfn:     [36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56]
-       HORTON:  [56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41, 40, 39, 38, 37, 36]
-       permute: [20, 19, 18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
-    """
-    permutation = get_permutation_orbital(type_assignment)
-    type_assignment = type_assignment[permutation]
-    for count, value in enumerate(type_assignment):
-        if value == 5:
-            # d-orbitals
-            permute = [0, 3, 4, 1, 5, 2]
-            permutation[count: count + 6] = permutation[count: count + 6][permute]
-        elif value == 11:
-            # f-orbitals
-            permute = [0, 4, 5, 3, 9, 6, 1, 8, 7, 2]
-            permutation[count: count + 10] = permutation[count: count + 10][permute]
-        elif value == 23:
-            # g-orbitals
-            permute = [14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0]
-            permutation[count: count + 15] = permutation[count:count + 15][permute]
-        elif value == 36:
-            # h-orbitals
-            permutation[count: count + 21] = permutation[count: count + 21][::-1]
-    return permutation
-
-
-def get_mask(type_assignment: np.ndarray) -> np.ndarray:
-    """Return array to mask orbital types other than s, 1st_p, 1st_d, 1st_f, 1st_g, 1st_h."""
-    # index of [s, 1st_p, 1st_d, 1st_f, 1st_g, 1st_h]
-    temp = [1, 2, 5, 11, 21, 36]
-    mask = np.array([i in temp for i in type_assignment])
-    return mask
+            # multiple different type assignments (codes for individual basis
+            # functions) can match one angular momentum.
+            angmom = len(PRIMITIVE_NAMES[type_assignments[ibasis]])
+        # The number of cartesian functions for the current angular momentum
+        ncart = len(CONVENTIONS[(angmom, 'c')])
+        # Determine how many shells are to be read in one batch. E.g. for a
+        # contracted p shell, the WFN format contains first all px basis
+        # functions, the all py, finally all pz. These need to be regrouped into
+        # shells.
+        # This pattern can almost be used to reverse-engineer contractions.
+        # One should also check (i) if the corresponding mo-coefficients are the
+        # same (after fixing them for normalization) and (ii) if the functions
+        # are centered on the same atom.
+        # For now, this implementation makes no attempt to reverse-engineer
+        # contractions, but it can be done.
+        ncon = 1  # the contraction length
+        if angmom > 0:
+            # batches for s-type functions are not necessary and may result in
+            # multiple centers being pulled into one batch.
+            while (ibasis + ncon < len(type_assignments)
+                   and type_assignments[ibasis + ncon] == type_assignment):
+                ncon += 1
+        # Check if the type assignment is consistent for remaining basis
+        # functions in this batch.
+        for ifn in range(ncart):
+            if not (type_assignments[ibasis + ncon * ifn: ibasis + ncon * (ifn + 1)]
+                    == type_assignments[ibasis + ncon * ifn]).all():
+                lit.error("Inconcsistent type assignments in current batch of shells.")
+        # Check if all basis functions in the current batch sit on
+        # the same center. If not, IOData cannot read this file.
+        icenter = icenters[ibasis]
+        if not (icenters[ibasis: ibasis + ncon * ncart] == icenter).all():
+            lit.error("Incomplete shells in WFN file not supported by IOData.")
+        # Check if the same exponent is used for corresponding basis functions.
+        batch_exponents = exponents[ibasis: ibasis + ncon]
+        for ifn in range(ncart):
+            if not (exponents[ibasis + ncon * ifn: ibasis + ncon * (ifn + 1)]
+                    == batch_exponents).all():
+                lit.error("Exponents must be the same for corresponding basis functions.")
+        # A permutation is needed because we need to regroup basis functions
+        # into shells.
+        batch_primitive_names = [
+            PRIMITIVE_NAMES[type_assignments[ibasis + ifn * ncon]]
+            for ifn in range(ncart)]
+        for irep in range(ncon):
+            for i, primitive_name in enumerate(batch_primitive_names):
+                ifn = CONVENTIONS[(angmom, 'c')].index(primitive_name)
+                permutation[ibasis + irep * ncart + ifn] = ibasis + irep + i * ncon
+        # WFN uses non-normalized primitives, which will be corrected for
+        # when processing the MO coefficients. Normalized primitives will
+        # be used here. No attempt is made here to reconstruct the contraction.
+        for exponent in batch_exponents:
+            shells.append(Shell(icenter, [angmom], ['c'], np.array([exponent]),
+                                np.array([[1.0]])))
+        # Move on to the next contraction
+        ibasis += ncart * ncon
+    obasis = MolecularBasis(coordinates, shells, CONVENTIONS, 'L2')
+    assert obasis.nbasis == nbasis
+    return obasis, permutation
 
 
 def load(lit: LineIterator) -> Dict:
@@ -221,31 +312,27 @@ def load(lit: LineIterator) -> Dict:
         ``orb_beta`` key and its value as well.
 
     """
-    (title, numbers, coordinates, centers, type_assignment, exponents,
-     mo_count, mo_occ, mo_energy, coefficients, energy) = load_wfn_low(lit)
-    permutation = get_permutation_basis(type_assignment)
-    # permute arrays containing wfn data
-    type_assignment = type_assignment[permutation]
-    mask = get_mask(type_assignment)
-    reduced_size = np.array(mask, int).sum()
-    num = coefficients.shape[1]
-    alphas = np.empty(reduced_size)
-    alphas[:] = exponents[permutation][mask]
-    assert (centers == centers[permutation]).all()
-    shell_map = centers[mask]
-    # cartesian basis: {S:0, P:1, D:2, F:3, G:4, H:5}
-    shell = {1: 0, 2: 1, 5: 2, 11: 3, 21: 4, 36: 5}
-    shell_types = type_assignment[mask]
-    shell_types = np.array([shell[i] for i in shell_types])
-    assert shell_map.size == shell_types.size == reduced_size
-    nprims = np.ones(reduced_size, int)
-    con_coeffs = np.ones(reduced_size)
-    # build basis set
-    obasis = {"centers": coordinates, "shell_map": shell_map, "nprims": nprims,
-              "shell_types": shell_types, "alphas": alphas, "con_coeffs": con_coeffs}
-    coefficients = coefficients[permutation]
-    scales, dummy = init_scales(obasis["alphas"], obasis["nprims"], obasis["shell_types"])
-    coefficients /= scales.reshape(-1, 1)
+    (title, numbers, coordinates, icenters, type_assignments, exponents,
+     mo_count, mo_occ, mo_energy, mo_coefficients, energy) = load_wfn_low(lit)
+    # Build the basis set and the permutation needed to regroup shells.
+    obasis, permutation = build_obasis(icenters, type_assignments, exponents, coordinates, lit)
+    # Re-order the mo coefficients.
+    mo_coefficients = mo_coefficients[permutation]
+    # Get the normalization of the un-normalized Cartesian basis functions.
+    # Use these to rescale the mo_coefficients.
+    scales = []
+    for shell in obasis.shells:
+        angmom = shell.angmoms[0]
+        for name in obasis.conventions[(angmom, 'c')]:
+            if name == '1':
+                nx, ny, nz = 0, 0, 0
+            else:
+                nx = name.count('x')
+                ny = name.count('y')
+                nz = name.count('z')
+            scales.append(gob_cart_normalization(shell.exponents[0], np.array([nx, ny, nz])))
+    scales = np.array(scales)
+    mo_coefficients /= scales.reshape(-1, 1)
     # make the wavefunction
     if mo_occ.max() > 1.0:
         # close shell system
@@ -257,12 +344,14 @@ def load(lit: LineIterator) -> Dict:
         mo_type = 'unrestricted'
         # counting the number of alpha and beta orbitals
         n = 1
-        while n < num and mo_energy[n] >= mo_energy[n - 1] and mo_count[n] == mo_count[n - 1] + 1:
+        while (n < mo_coefficients.shape[1]
+               and mo_energy[n] >= mo_energy[n - 1]
+               and mo_count[n] == mo_count[n - 1] + 1):
             n += 1
         na_orb = n
         nb_orb = len(mo_occ) - n
     # create a MO namedtuple
-    mo = MolecularOrbitals(mo_type, na_orb, nb_orb, mo_occ, coefficients, None, mo_energy)
+    mo = MolecularOrbitals(mo_type, na_orb, nb_orb, mo_occ, mo_coefficients, None, mo_energy)
 
     result = {
         'title': title,

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -227,12 +227,6 @@ class IOData:
     one_mo
          One-electron integrals in the (Hartree-Fock) molecular-orbital basis
 
-    permutation
-         The permutation applied to the basis functions.
-
-    signs
-         The sign changes applied to the basis functions.
-
     title
          A suitable name for the data.
 

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -29,166 +29,154 @@ from scipy.special import factorialk
 
 from .overlap_accel import add_overlap
 from .overlap_helper import tfs
+from .basis import angmom_its, convert_conventions
 
 
-__all__ = ['compute_overlap', 'gob_cart_normalization', 'get_shell_nbasis']
+__all__ = ['OVERLAP_CONVENTIONS', 'compute_overlap', 'gob_cart_normalization']
 
 
-def compute_overlap(centers: np.ndarray, shell_map: np.ndarray, nprims: np.ndarray,
-                    shell_types: np.ndarray, alphas: np.ndarray,
-                    con_coeffs: np.ndarray) -> np.ndarray:
-    r"""
-    Compute overlap matrix. Follows same parameter convention as horton.GOBasis.
+def _iter_pow(n: int) -> np.ndarray:
+    """Give the ordering within shells.
+
+    See http://theochem.github.io/horton/2.1.0b1/tech_ref_gaussian_basis.html
+    for details.
+    """
+    for nx in range(n, -1, -1):
+        for ny in range(n - nx, -1, -1):
+            nz = n - nx - ny
+            yield np.array((nx, ny, nz), dtype=int)
+
+
+def get_overlap_conventions():
+    """Produce a conventions dictionary compatible with HORTON2.
+
+    Do not change this!!! This is also used by several file formats from other
+    QC codes who happen to follow the same conventions.
+    """
+    result = {
+        (0, 'c'): ['1'],
+    }
+    for angmom in range(1, 25):
+        result[(angmom, 'c')] = list(
+            'x' * nx + 'y' * ny + 'z' * nz for nx, ny, nz
+            in _iter_pow(angmom))
+        if angmom > 1:
+            char = angmom_its(angmom)
+            convention = [char + 'c0']
+            for absm in range(1, angmom + 1):
+                convention.append('{}c{}'.format(char, absm))
+                convention.append('{}s{}'.format(char, absm))
+            result[(angmom, 'p')] = convention
+    return result
+
+
+OVERLAP_CONVENTIONS = get_overlap_conventions()
+
+
+def compute_overlap(obasis: 'MolecularBasis') -> np.ndarray:
+    r"""Compute overlap matrix for the given molecular basis set.
 
     .. math::
         \braket{\psi_{i}}{\psi_{j}}
 
-    Parameters
-    ----------
-    centers
-        A numpy array with centers for the basis functions.
-        shape = (ncenter, 3)
-    shell_map
-        An array with the center index for each shell.
-        shape = (nshell,)
-    nprims
-        The number of primitives in each shell.
-        shape = (nshell,)
-    shell_types
-        An array with contraction types: 0 = S, 1 = P, 2 = Cartesian D,
-        3 = Cartesian F, ..., -2 = pure D, -3 = pure F, ...
-        shape = (nshell,)
-    alphas
-        The exponents of the primitives in one shell.
-        shape = (sum(nprims),)
-    con_coeffs
-        The contraction coefficients of the primitives for each
-        contraction in a contiguous array. The coefficients are ordered
-        according to the shells. Within each shell, the coefficients are
-        grouped per exponent.
-        shape = (sum(nprims),)
+    This function takes into account the requested order of the basis functions
+    in ``obasis.conventions``. Note that only L2 normalized primitives are
+    supported at the moment.
 
     Returns
     -------
-    np.ndarray
-        The overlap integral.
+    overlap
+        The matrix with overlap integrals, shape=(obasis.nbasis, obasis.nbasis).
 
     """
-    # compute total number of shells
-    nshell = len(shell_types)
-    # compute number of basis functions in each shell
-    shell_nbasis = np.array([get_shell_nbasis(shell) for shell in shell_types])
-    # compute total number of basis functions
-    nbasis = np.sum(shell_nbasis)
-    # compute index offset of each shell
-    shell_offsets = np.cumsum(np.insert(shell_nbasis, 0, 0), dtype=int)
-
-    scales, scales_offsets = init_scales(alphas, nprims, shell_types)
+    if obasis.primitive_normalization != 'L2':
+        raise ValueError('The overlap integrals are only implemented for L2 '
+                         'normalization.')
 
     # Initialize result
-    integral = np.zeros((nbasis, nbasis))
+    overlap = np.zeros((obasis.nbasis, obasis.nbasis))
 
-    # Reorganize arrays in pythonic manner
-    alphas_split = _split_data_by_prims(alphas, nprims)
-    con_coeffs_split = _split_data_by_prims(con_coeffs, nprims)
-    scales_offsets_split = _split_data_by_prims(scales_offsets, nprims)
+    # Get a segmented basis, for simplicity
+    obasis = obasis.get_segmented()
+
+    # Compute the normalization constants of the primitives
+    scales = [_compute_cart_shell_normalizations(shell) for shell in obasis.shells]
 
     # Loop over shell0
-    for big_tuple0 in zip(list(range(nshell)), shell_map, shell_types, shell_offsets,
-                          shell_offsets[1:],
-                          alphas_split, con_coeffs_split, scales_offsets_split):
+    begin0 = 0
+    for i0, shell0 in enumerate(obasis.shells):
+        r0 = obasis.centers[shell0.icenter]
+        end0 = begin0 + shell0.nbasis
 
-        (ishell0, center0, shell_type0, start0,
-         end0, alphas0, con_coeffs0, scales_offsets0) = big_tuple0
-
-        r0 = centers[center0, :]
-
-        # Loop over shell1 (lower triangular only)
-        for big_tuple1 in zip(shell_map[:ishell0 + 1], shell_types[:ishell0 + 1], shell_offsets,
-                              shell_offsets[1:], alphas_split[:ishell0 + 1],
-                              con_coeffs_split[:ishell0 + 1], scales_offsets_split[:ishell0 + 1]):
-
-            center1, shell_type1, start1, end1, alphas1, con_coeffs1, scales_offsets1 = big_tuple1
-
-            r1 = centers[center1, :]
+        # Loop over shell1 (lower triangular only, including diagonal)
+        begin1 = 0
+        for i1, shell1 in enumerate(obasis.shells[:i0 + 1]):
+            r1 = obasis.centers[shell1.icenter]
+            end1 = begin1 + shell1.nbasis
 
             # START of Cartesian coordinates. Shell types are positive
-            result = np.zeros((get_shell_nbasis(abs(shell_type0)),
-                               get_shell_nbasis(abs(shell_type1))))
-            # print "shell type", shell_type0, shell_type1
+            result = np.zeros((len(scales[i0][0]), len(scales[i1][0])))
             # Loop over primitives in shell0 (Cartesian)
-            for a0, so0, cc0 in zip(alphas0, scales_offsets0, con_coeffs0):
-                s0 = scales[so0:]
+            for iexp0, (a0, cc0) in enumerate(zip(shell0.exponents, shell0.coeffs[:, 0])):
+                s0 = scales[i0][iexp0]
 
                 # Loop over primitives in shell1 (Cartesian)
-                for a1, so1, cc1 in zip(alphas1, scales_offsets1, con_coeffs1):
-                    s1 = scales[so1:]
-                    n0 = np.vstack(list(_get_iter_pow(abs(shell_type0))))
-                    n1 = np.vstack(list(_get_iter_pow(abs(shell_type1))))
+                for iexp1, (a1, cc1) in enumerate(zip(shell1.exponents, shell1.coeffs[:, 0])):
+                    s1 = scales[i1][iexp1]
+                    n0 = np.vstack(list(_iter_pow(shell0.angmoms[0])))
+                    n1 = np.vstack(list(_iter_pow(shell1.angmoms[0])))
                     add_overlap(cc0 * cc1, a0, a1, s0, s1, r0, r1, n0, n1, result)
 
             # END of Cartesian coordinate system (if going to pure coordinates)
 
             # cart to pure
-            if shell_type0 < -1:
-                result = np.dot(tfs[abs(shell_type0)], result)
-            if shell_type1 < -1:
-                result = np.dot(result, tfs[abs(shell_type1)].T)
+            if shell0.kinds[0] == 'p':
+                result = np.dot(tfs[shell0.angmoms[0]], result)
+            if shell1.kinds[0] == 'p':
+                result = np.dot(result, tfs[shell1.angmoms[0]].T)
 
             # store lower triangular result
-            integral[start0:end0, start1:end1] = result
-
+            overlap[begin0:end0, begin1:end1] = result
             # store upper triangular result
-            integral[start1:end1, start0:end0] = result.T
-    return integral
+            overlap[begin1:end1, begin0:end0] = result.T
+
+            begin1 = end1
+        begin0 = end0
+
+    permutation, signs = convert_conventions(obasis, OVERLAP_CONVENTIONS, reverse=True)
+    overlap = overlap[permutation] * signs.reshape(-1, 1)
+    overlap = overlap[:, permutation] * signs
+    return overlap
 
 
-def _split_data_by_prims(x: np.ndarray, nprims: np.ndarray) -> List[np.ndarray]:
-    """Return nested lists according to the number of primitives per shell."""
-    nprims = np.insert(nprims, 0, 0)
-    nprims = np.cumsum(nprims)
-    return [x[s:e] for s, e in zip(nprims, nprims[1:])]
-
-
-def init_scales(alphas: np.ndarray, nprims: np.ndarray, shell_types: np.ndarray) \
-        -> Tuple[np.ndarray, np.ndarray]:
-    """
-    Return normalization constants and offsets per shell.
+def _compute_cart_shell_normalizations(shell: 'Shell') -> np.ndarray:
+    """Return normalization constants for the primitives in a given shell.
 
     Parameters
     ----------
-    alphas
-        Gaussian basis exponents
-    nprims
-        Number of primitives in each shell
-    shell_types
-        The angular momentum of each shell
+    shell
+        The shell for which the normalization constants must be computed.
 
     Returns
     -------
-    Tuple[np.ndarray, np.ndarray]
-        The normalization factors for each shell
+    np.ndarray
+        The normalization constants, always for Cartesian functions, even when
+        shell is pure.
 
     """
-    counter, oprim = 0, 0
-    nscales = sum([get_shell_nbasis(abs(s)) * p for s, p in zip(shell_types, nprims)])
-    scales = np.zeros(nscales)
-    scales_offsets = np.zeros(sum(nprims), dtype=int)
-
-    for s, shell_type in enumerate(shell_types):
-        for p in range(nprims[s]):
-            scales_offsets[oprim + p] = counter
-            alpha = alphas[oprim + p]
-            for n in _get_iter_pow(abs(shell_type)):
-                scales[counter] = gob_cart_normalization(alpha, n)
-                counter += 1
-        oprim += nprims[s]
-
-    return scales, scales_offsets
+    shell = shell._replace(kinds=['c'] * shell.ncon)
+    result = []
+    for angmom in shell.angmoms:
+        for exponent in shell.exponents:
+            row = []
+            for n in _iter_pow(angmom):
+                row.append(gob_cart_normalization(exponent, n))
+            result.append(np.array(row))
+    return result
 
 
-def gob_cart_normalization(alpha: np.ndarray, n: np.ndarray) -> np.ndarray:  # from utils
-    """Check normalization of exponent.
+def gob_cart_normalization(alpha: np.ndarray, n: np.ndarray) -> np.ndarray:
+    """Compute normalization of exponent.
 
     Parameters
     ----------
@@ -204,40 +192,5 @@ def gob_cart_normalization(alpha: np.ndarray, n: np.ndarray) -> np.ndarray:  # f
 
     """
     vfac2 = np.vectorize(factorialk)
-    return np.sqrt((4 * alpha)**sum(n) * (2 * alpha / np.pi)**1.5 / np.prod(vfac2(2 * n - 1, 2)))
-
-
-def get_shell_nbasis(shell: int) -> int:
-    """Return number of basis functions within a shell.
-
-    Negative shell numbers refer to pure functions.
-
-    Parameters
-    ----------
-    shell
-        Angular momentum quantum number
-
-    Returns
-    -------
-    int
-        The number of basis functions in the shell
-
-    """
-    if shell > 0:  # Cartesian
-        return int((shell + 1) * (shell + 2) / 2)
-    if shell == -1:
-        raise ValueError("Argument shell={0} is not recognized.".format(shell))
-    # Pure
-    return -2 * shell + 1
-
-
-def _get_iter_pow(n: int) -> np.ndarray:
-    """Give the ordering within shells.
-
-    See http://theochem.github.io/horton/2.1.0b1/tech_ref_gaussian_basis.html
-    for details.
-    """
-    for nx in range(n, -1, -1):
-        for ny in range(n - nx, -1, -1):
-            nz = n - nx - ny
-            yield np.array((nx, ny, nz), dtype=int)
+    return np.sqrt((4 * alpha)**sum(n) * (2 * alpha / np.pi)**1.5
+                   / np.prod(vfac2(2 * n - 1, 2)))

--- a/iodata/overlap_accel.pyx
+++ b/iodata/overlap_accel.pyx
@@ -19,7 +19,7 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
-# cython: profile=True
+# cython: linetrace=True
 """Cython module to accelerate computation of overlap integrals."""
 
 

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -1,0 +1,228 @@
+# -*- coding: utf-8 -*-
+# IODATA is an input and output module for quantum chemistry.
+#
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+#
+# --
+"""Unit tests for iodata.obasis."""
+
+
+import numpy as np
+from numpy.testing import assert_equal
+from pytest import raises
+
+from ..basis import (angmom_sti, angmom_its, Shell, MolecularBasis,
+                     convert_convention_shell, convert_conventions)
+from ..formats.cp2k import CONVENTIONS as CP2K_CONVENTIONS
+
+
+def test_angmom_sti():
+    assert angmom_sti('s') == 0
+    assert angmom_sti('p') == 1
+    assert angmom_sti('f') == 3
+    assert angmom_sti(['s']) == [0]
+    assert angmom_sti(['s', 's']) == [0, 0]
+    assert angmom_sti(['s', 's', 's']) == [0, 0, 0]
+    assert angmom_sti(['p']) == [1]
+    assert angmom_sti(['s', 'p']) == [0, 1]
+    assert angmom_sti(['s', 'p', 'p']) == [0, 1, 1]
+    assert angmom_sti(['s', 'p', 'p', 'd', 'd', 's', 'f', 'i']) == \
+        [0, 1, 1, 2, 2, 0, 3, 6]
+    assert angmom_sti(['e', 't', 'k']) == [24, 14, 7]
+
+
+def test_angmom_its():
+    assert angmom_its(0) == 's'
+    assert angmom_its(1) == 'p'
+    assert angmom_its(2) == 'd'
+    assert angmom_its(3) == 'f'
+    assert angmom_its(24) == 'e'
+    assert angmom_its([0, 1, 3]) == ['s', 'p', 'f']
+    with raises(ValueError):
+        angmom_its(-1)
+
+
+def test_shell_info_propertes():
+    shells = [
+        Shell(0, [0], ['c'], np.zeros((6,)), None),
+        Shell(0, [0, 1], ['c', 'c'], np.zeros((3,)), None),
+        Shell(0, [0, 1], ['c', 'c'], np.zeros((1,)), None),
+        Shell(0, [2], ['p'], np.zeros((2,)), None),
+        Shell(0, [2, 3, 4], ['c', 'p', 'p'], np.zeros((1,)), None)]
+
+    assert shells[0].nbasis == 1
+    assert shells[1].nbasis == 4
+    assert shells[2].nbasis == 4
+    assert shells[3].nbasis == 5
+    assert shells[4].nbasis == 6 + 7 + 9
+    assert shells[0].nprim == 6
+    assert shells[1].nprim == 3
+    assert shells[2].nprim == 1
+    assert shells[3].nprim == 2
+    assert shells[4].nprim == 1
+    assert shells[0].ncon == 1
+    assert shells[1].ncon == 2
+    assert shells[2].ncon == 2
+    assert shells[3].ncon == 1
+    assert shells[4].ncon == 3
+    obasis = MolecularBasis(
+        None,
+        shells,
+        {(0, 'c'): ['s'],
+         (1, 'c'): ['x', 'z', '-y'],
+         (2, 'p'): ['dc0', 'dc1', '-ds1', 'dc2', '-ds2']},
+        'L2')
+    assert obasis.nbasis == 1 + 4 + 4 + 5 + 6 + 7 + 9
+
+
+def test_shell_exceptions():
+    with raises(TypeError):
+        _ = Shell(0, [0], ['e'], None, None).nbasis
+    with raises(TypeError):
+        _ = Shell(0, [0], ['p'], None, None).nbasis
+    with raises(TypeError):
+        _ = Shell(0, [1], ['p'], None, None).nbasis
+
+
+def test_nbasis1():
+    obasis = MolecularBasis(
+        np.zeros((1, 3)), [
+            Shell(0, [0], ['c'], np.zeros(16), None),
+            Shell(0, [1], ['c'], np.zeros(16), None),
+            Shell(0, [2], ['p'], np.zeros(16), None),
+        ], CP2K_CONVENTIONS, 'L2')
+    assert obasis.nbasis == 9
+
+
+def test_get_segmented():
+    obasis0 = MolecularBasis(
+        np.zeros((1, 3)), [
+            Shell(0, [0, 1], ['c', 'c'], np.random.uniform(0, 1, 5),
+                  np.random.uniform(-1, 1, (5, 2))),
+            Shell(1, [2, 3], ['p', 'p'], np.random.uniform(0, 1, 7),
+                  np.random.uniform(-1, 1, (7, 2))),
+        ], CP2K_CONVENTIONS, 'L2')
+    assert obasis0.nbasis == 16
+    obasis1 = obasis0.get_segmented()
+    assert len(obasis1.shells) == 4
+    assert obasis1.nbasis == 16
+    # shell 0
+    shell0 = obasis1.shells[0]
+    assert shell0.icenter == 0
+    assert_equal(shell0.angmoms, [0])
+    assert shell0.kinds == ['c']
+    assert_equal(shell0.exponents, obasis0.shells[0].exponents)
+    assert_equal(shell0.coeffs, obasis0.shells[0].coeffs[:, :1])
+    # shell 1
+    shell1 = obasis1.shells[1]
+    assert shell1.icenter == 0
+    assert_equal(shell1.angmoms, [1])
+    assert shell1.kinds == ['c']
+    assert_equal(shell1.exponents, obasis0.shells[0].exponents)
+    assert_equal(shell1.coeffs, obasis0.shells[0].coeffs[:, 1:])
+    # shell 2
+    shell2 = obasis1.shells[2]
+    assert shell2.icenter == 1
+    assert_equal(shell2.angmoms, [2])
+    assert shell2.kinds == ['p']
+    assert_equal(shell2.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell2.coeffs, obasis0.shells[1].coeffs[:, :1])
+    # shell 0
+    shell3 = obasis1.shells[3]
+    assert shell3.icenter == 1
+    assert_equal(shell3.angmoms, [3])
+    assert shell3.kinds == ['p']
+    assert_equal(shell3.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell3.coeffs, obasis0.shells[1].coeffs[:, 1:])
+
+
+def test_convert_convention_shell():
+    assert convert_convention_shell('abc', 'cba') == ([2, 1, 0], [1, 1, 1])
+    assert convert_convention_shell(['a', 'b', 'c'], ['c', 'b', 'a']) == ([2, 1, 0], [1, 1, 1])
+
+    permutation, signs = convert_convention_shell(['-a', 'b', 'c'], ['c', 'b', 'a'])
+    assert permutation == [2, 1, 0]
+    assert signs == [1, 1, -1]
+    vec1 = np.array([1, 2, 3])
+    vec2 = np.array([3, 2, -1])
+    assert_equal(vec1[permutation] * signs, vec2)
+    permutation, signs = convert_convention_shell(['-a', 'b', 'c'], ['c', 'b', 'a'], True)
+    assert_equal(vec2[permutation] * signs, vec1)
+
+    permutation, signs = convert_convention_shell(['a', 'b', 'c'], ['-c', 'b', 'a'])
+    assert permutation == [2, 1, 0]
+    assert signs == [-1, 1, 1]
+    vec1 = np.array([1, 2, 3])
+    vec2 = np.array([-3, 2, 1])
+    assert_equal(vec1[permutation] * signs, vec2)
+    permutation, signs = convert_convention_shell(['a', 'b', 'c'], ['-c', 'b', 'a'], True)
+
+    permutation, signs = convert_convention_shell(['a', '-b', '-c'], ['-c', 'b', 'a'])
+    assert permutation == [2, 1, 0]
+    assert signs == [1, -1, 1]
+    vec1 = np.array([1, 2, 3])
+    vec2 = np.array([3, -2, 1])
+    assert_equal(vec1[permutation] * signs, vec2)
+    permutation, signs = convert_convention_shell(['a', '-b', '-c'], ['-c', 'b', 'a'], True)
+    assert_equal(vec2[permutation] * signs, vec1)
+
+    permutation, signs = convert_convention_shell(['fo', 'ba', 'sp'], ['fo', '-sp', 'ba'])
+    assert permutation == [0, 2, 1]
+    assert signs == [1, -1, 1]
+    vec1 = np.array([1, 2, 3])
+    vec2 = np.array([1, -3, 2])
+    assert_equal(vec1[permutation] * signs, vec2)
+    permutation, signs = convert_convention_shell(['fo', 'ba', 'sp'], ['fo', '-sp', 'ba'], True)
+    assert_equal(vec2[permutation] * signs, vec1)
+
+
+def test_convert_convention_obasis():
+    obasis = MolecularBasis(
+        None,
+        [Shell(0, [0], ['c'], None, None),
+         Shell(0, [0, 1], ['c', 'c'], None, None),
+         Shell(0, [0, 1], ['c', 'c'], None, None),
+         Shell(0, [2], ['p'], None, None)],
+        {(0, 'c'): ['s'],
+         (1, 'c'): ['x', 'z', '-y'],
+         (2, 'p'): ['dc0', 'dc1', '-ds1', 'dc2', '-ds2']},
+        'L2')
+    new_convention = {(0, 'c'): ['-s'],
+                      (1, 'c'): ['x', 'y', 'z'],
+                      (2, 'p'): ['dc2', 'dc1', 'dc0', 'ds1', 'ds2']}
+    permutation, signs = convert_conventions(obasis, new_convention)
+    assert_equal(permutation, [0, 1, 2, 4, 3, 5, 6, 8, 7, 12, 10, 9, 11, 13])
+    assert_equal(signs, [-1, -1, 1, -1, 1, -1, 1, -1, 1, 1, 1, 1, -1, -1])
+    vec1 = np.random.uniform(-1, 1, obasis.nbasis)
+    vec2 = vec1[permutation] * signs
+    permutation, signs = convert_conventions(obasis, new_convention, reverse=True)
+    vec3 = vec2[permutation] * signs
+    assert_equal(vec1, vec3)
+
+
+def test_convert_exceptions():
+    with raises(TypeError):
+        convert_convention_shell('abc', 'cb')
+    with raises(TypeError):
+        convert_convention_shell('abc', 'cbb')
+    with raises(TypeError):
+        convert_convention_shell('aba', 'cba')
+    with raises(TypeError):
+        convert_convention_shell(['a', 'b', 'c'], ['a', 'b', 'd'])
+    with raises(TypeError):
+        convert_convention_shell(['a', 'b', 'c'], ['a', 'b', '-d'])

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -27,7 +27,8 @@ from numpy.testing import assert_equal
 from pytest import raises
 
 from ..basis import (angmom_sti, angmom_its, Shell, MolecularBasis,
-                     convert_convention_shell, convert_conventions)
+                     convert_convention_shell, convert_conventions,
+                     iter_cart_alphabet, HORTON2_CONVENTIONS, PSI4_CONVENTIONS)
 from ..formats.cp2k import CONVENTIONS as CP2K_CONVENTIONS
 
 
@@ -226,3 +227,28 @@ def test_convert_exceptions():
         convert_convention_shell(['a', 'b', 'c'], ['a', 'b', 'd'])
     with raises(TypeError):
         convert_convention_shell(['a', 'b', 'c'], ['a', 'b', '-d'])
+
+
+def test_iter_cart_alphabet():
+    assert np.array(list(iter_cart_alphabet(0))).tolist() == [[0, 0, 0]]
+    assert np.array(list(iter_cart_alphabet(1))).tolist() == [
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    assert np.array(list(iter_cart_alphabet(2))).tolist() == [
+        [2, 0, 0], [1, 1, 0], [1, 0, 1],
+        [0, 2, 0], [0, 1, 1], [0, 0, 2]]
+
+
+def test_conventions():
+    for angmom in range(24):
+        assert HORTON2_CONVENTIONS[(angmom, 'c')] == PSI4_CONVENTIONS[(angmom, 'c')]
+    assert HORTON2_CONVENTIONS[(0, 'c')] == ['1']
+    assert HORTON2_CONVENTIONS[(1, 'c')] == ['x', 'y', 'z']
+    assert HORTON2_CONVENTIONS[(2, 'c')] == ['xx', 'xy', 'xz', 'yy', 'yz', 'zz']
+    assert (0, 'p') not in HORTON2_CONVENTIONS
+    assert (0, 'p') not in PSI4_CONVENTIONS
+    assert (1, 'p') not in HORTON2_CONVENTIONS
+    assert (1, 'p') not in PSI4_CONVENTIONS
+    assert HORTON2_CONVENTIONS[(2, 'p')] == ['dc0', 'dc1', 'ds1', 'dc2', 'ds2']
+    assert PSI4_CONVENTIONS[(2, 'p')] == ['ds2', 'ds1', 'dc0', 'dc1', 'dc2']
+    assert HORTON2_CONVENTIONS[(3, 'p')] == ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', 'fc3', 'fs3']
+    assert PSI4_CONVENTIONS[(3, 'p')] == ['fs3', 'fs2', 'fs1', 'fc0', 'fc1', 'fc2', 'fc3']

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -42,7 +42,7 @@ except ImportError:
 
 def check_orthonormality(mol):
     """Test whether the orbitals are orthonormal."""
-    olp = compute_overlap(**mol.obasis)
+    olp = compute_overlap(mol.obasis)
     check_orthonormal(mol.orb_alpha_coeffs, olp)
     if hasattr(mol, 'orb_beta'):
         check_orthonormal(mol.orb_beta_coeffs, olp)
@@ -60,7 +60,12 @@ def test_atom_si_uks():
     assert_allclose(mol.orb_beta_energies,
                     [-0.334567, -0.092237, -0.092237, -0.092237], atol=1.e-4)
     assert_allclose(mol.energy, -3.761587698067, atol=1.e-10)
-    assert_equal(mol.obasis["shell_types"], [0, 0, 1, 1, -2])
+    assert len(mol.obasis.shells) == 3
+    assert mol.obasis.shells[0].kinds == ['c', 'c']
+    assert_equal(mol.obasis.shells[1].angmoms, [1, 1])
+    assert mol.obasis.shells[1].kinds == ['c', 'c']
+    assert_equal(mol.obasis.shells[2].angmoms, [2])
+    assert mol.obasis.shells[2].kinds == ['p']
     check_orthonormality(mol)
 
 
@@ -73,7 +78,13 @@ def test_atom_o_rks():
     assert_allclose(mol.orb_alpha_energies,
                     [0.102709, 0.606458, 0.606458, 0.606458], atol=1.e-4)
     assert_allclose(mol.energy, -15.464982778766, atol=1.e-10)
-    assert_equal(mol.obasis["shell_types"], [0, 0, 1, 1, -2])
+    assert_equal(mol.obasis.shells[0].angmoms, [0, 0])
+    assert len(mol.obasis.shells) == 3
+    assert mol.obasis.shells[0].kinds == ['c', 'c']
+    assert_equal(mol.obasis.shells[1].angmoms, [1, 1])
+    assert mol.obasis.shells[1].kinds == ['c', 'c']
+    assert_equal(mol.obasis.shells[2].angmoms, [2])
+    assert mol.obasis.shells[2].kinds == ['p']
     check_orthonormality(mol)
 
 

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -31,9 +31,6 @@ except ImportError:
     from importlib.resources import path
 
 
-# TODO: shells_to_nbasis(obasis["shell_types"]) replacement test
-
-
 def load_log_helper(fn_log):
     """Load a testing Gaussian log file with iodata.formats.gaussianlog.load."""
     with path('iodata.test.data', fn_log) as fn:

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -98,6 +98,6 @@ def test_dm_lih_sto3g_hf():
 def test_dm_ch3_rohf_g03():
     with path('iodata.test.data', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
         mol = load_one(str(fn_fchk))
-    olp = compute_overlap(**mol.obasis)
+    olp = compute_overlap(mol.obasis)
     dm = compute_1rdm(mol)
     assert_allclose(np.einsum('ab,ba', olp, dm), 9, atol=1.e-6)

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -28,27 +28,13 @@ from pytest import raises
 
 from ..basis import MolecularBasis, Shell
 from ..iodata import load_one
-from ..overlap import compute_overlap, OVERLAP_CONVENTIONS, _iter_pow
+from ..overlap import compute_overlap, OVERLAP_CONVENTIONS
 from ..overlap_accel import fac2, _binom
 
 try:
     from importlib_resources import path
 except ImportError:
     from importlib.resources import path
-
-
-def test_iter_pow():
-    assert np.array(list(_iter_pow(0))).tolist() == [[0, 0, 0]]
-    assert np.array(list(_iter_pow(1))).tolist() == [
-        [1, 0, 0], [0, 1, 0], [0, 0, 1]]
-    assert np.array(list(_iter_pow(2))).tolist() == [
-        [2, 0, 0], [1, 1, 0], [1, 0, 1],
-        [0, 2, 0], [0, 1, 1], [0, 0, 2]]
-
-
-def test_conventions():
-    # DO NOT TOUCH!!!
-    assert OVERLAP_CONVENTIONS[(2, 'p')] == ['dc0', 'dc1', 'ds1', 'dc2', 'ds2']
 
 
 def test_normalization_basics_segmented():

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -19,18 +19,54 @@
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 #
 # --
+# pylint: disable=no-member
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
+from pytest import raises
 
-from ..overlap import compute_overlap
+from ..basis import MolecularBasis, Shell
+from ..iodata import load_one
+from ..overlap import compute_overlap, OVERLAP_CONVENTIONS, _iter_pow
 from ..overlap_accel import fac2, _binom
 
 try:
     from importlib_resources import path
 except ImportError:
     from importlib.resources import path
+
+
+def test_iter_pow():
+    assert np.array(list(_iter_pow(0))).tolist() == [[0, 0, 0]]
+    assert np.array(list(_iter_pow(1))).tolist() == [
+        [1, 0, 0], [0, 1, 0], [0, 0, 1]]
+    assert np.array(list(_iter_pow(2))).tolist() == [
+        [2, 0, 0], [1, 1, 0], [1, 0, 1],
+        [0, 2, 0], [0, 1, 1], [0, 0, 2]]
+
+
+def test_conventions():
+    # DO NOT TOUCH!!!
+    assert OVERLAP_CONVENTIONS[(2, 'p')] == ['dc0', 'dc1', 'ds1', 'dc2', 'ds2']
+
+
+def test_normalization_basics_segmented():
+    for angmom in range(7):
+        shells = [Shell(0, [angmom], ['c'], np.array([0.23]), np.array([[1.0]]))]
+        if angmom >= 2:
+            shells.append(Shell(0, [angmom], ['p'], np.array([0.23]), np.array([[1.0]])))
+        obasis = MolecularBasis(np.zeros((3, 1)), shells, OVERLAP_CONVENTIONS, 'L2')
+        overlap = compute_overlap(obasis)
+        assert_allclose(np.diag(overlap), np.ones(obasis.nbasis))
+
+
+def test_normalization_basics_generalized():
+    for angmom in range(2, 7):
+        shells = [Shell(0, [angmom] * 2, ['c', 'p'], np.array([0.23]), np.array([[1.0, 1.0]]))]
+        obasis = MolecularBasis(np.zeros((3, 1)), shells, OVERLAP_CONVENTIONS, 'L2')
+        overlap = compute_overlap(obasis)
+        assert_allclose(np.diag(overlap), np.ones(obasis.nbasis))
 
 
 def test_fac2():
@@ -58,123 +94,31 @@ def test_binom():
 def test_load_fchk_hf_sto3g_num():
     with path('iodata.test.data', 'load_fchk_hf_sto3g_num.npy') as fn_npy:
         ref = np.load(str(fn_npy))
-    d = dict([('centers', np.array([[0., 0., 0.19048439],
-                                    [0., 0., -1.71435955]])),
-              ('shell_map', np.array([0, 0, 0, 1])),
-              ('nprims', np.array([3, 3, 3, 3])),
-              ('shell_types', np.array([0, 0, 1, 0])),
-              ('alphas',
-               np.array([166.679134, 30.3608123, 8.21682067, 6.46480325,
-                         1.50228124, 0.48858849, 6.46480325, 1.50228124,
-                         0.48858849, 3.42525091, 0.62391373, 0.1688554])),
-              ('con_coeffs', np.array([0.15432897, 0.53532814, 0.44463454,
-                                       -0.09996723, 0.39951283, 0.70011547,
-                                       0.15591627, 0.60768372, 0.39195739,
-                                       0.15432897, 0.53532814, 0.44463454]))])
-    assert_allclose(ref, compute_overlap(**d), rtol=1.e-5, atol=1.e-8)
+    with path('iodata.test.data', 'hf_sto3g.fchk') as fn_fchk:
+        data = load_one(fn_fchk)
+    assert_allclose(ref, compute_overlap(data.obasis), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
     with path('iodata.test.data',
               'load_fchk_o2_cc_pvtz_pure_num.npy') as fn_npy:
         ref = np.load(str(fn_npy))
-    d = dict(
-        [('centers',
-          np.array([[0.00000000e+00, 0.00000000e+00, 1.09122830e+00],
-                    [1.33636924e-16, 0.00000000e+00, -1.09122830e+00]])),
-         ('shell_map', np.array(
-             [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])),
-         ('nprims',
-          np.array(
-              [7, 7, 1, 1, 3, 1, 1, 1, 1, 1, 7, 7, 1, 1, 3, 1, 1, 1, 1, 1])),
-         ('shell_types',
-          np.array([0, 0, 0, 0, 1, 1, 1, -2, -2, -3,
-                    0, 0, 0, 0, 1, 1, 1, -2, -2, -3])),
-         ('alphas', np.array([1.53300000e+04, 2.29900000e+03, 5.22400000e+02,
-                              1.47300000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 1.53300000e+04, 2.29900000e+03,
-                              5.22400000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 6.88200000e-01, 1.75200000e+00,
-                              2.38400000e-01, 3.44600000e+01, 7.74900000e+00,
-                              2.28000000e+00, 7.15600000e-01, 2.14000000e-01,
-                              2.31400000e+00, 6.45000000e-01, 1.42800000e+00,
-                              1.53300000e+04, 2.29900000e+03, 5.22400000e+02,
-                              1.47300000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 1.53300000e+04, 2.29900000e+03,
-                              5.22400000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 6.88200000e-01, 1.75200000e+00,
-                              2.38400000e-01, 3.44600000e+01, 7.74900000e+00,
-                              2.28000000e+00, 7.15600000e-01, 2.14000000e-01,
-                              2.31400000e+00, 6.45000000e-01, 1.42800000e+00])),
-         ('con_coeffs', np.array(
-             [5.19808943e-04, 4.02025621e-03, 2.07128267e-02,
-              8.10105536e-02, 2.35962985e-01, 4.42653446e-01,
-              3.57064423e-01, 9.13376623e-06, 6.07362596e-05,
-              2.68782282e-04, -6.96940030e-03, -6.06456900e-02,
-              -1.65519536e-01, 1.07151369e+00, 1.00000000e+00,
-              1.00000000e+00, 4.11634896e-02, 2.57762836e-01,
-              8.02419274e-01, 1.00000000e+00, 1.00000000e+00,
-              1.00000000e+00, 1.00000000e+00, 1.00000000e+00,
-              5.19808943e-04, 4.02025621e-03, 2.07128267e-02,
-              8.10105536e-02, 2.35962985e-01, 4.42653446e-01,
-              3.57064423e-01, 9.13376623e-06, 6.07362596e-05,
-              2.68782282e-04, -6.96940030e-03, -6.06456900e-02,
-              -1.65519536e-01, 1.07151369e+00, 1.00000000e+00,
-              1.00000000e+00, 4.11634896e-02, 2.57762836e-01,
-              8.02419274e-01, 1.00000000e+00, 1.00000000e+00,
-              1.00000000e+00, 1.00000000e+00, 1.00000000e+00]))])
-    assert_allclose(ref, compute_overlap(**d), rtol=1.e-5, atol=1.e-8)
+    with path('iodata.test.data', 'o2_cc_pvtz_pure.fchk') as fn_fchk:
+        data = load_one(fn_fchk)
+    assert_allclose(ref, compute_overlap(data.obasis), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
     with path('iodata.test.data',
               'load_fchk_o2_cc_pvtz_cart_num.npy') as fn_npy:
         ref = np.load(str(fn_npy))
-    d = dict(
-        [('centers',
-          np.array([[0.00000000e+00, 0.00000000e+00, 1.09122830e+00],
-                    [1.33636924e-16, 0.00000000e+00, -1.09122830e+00]])),
-         ('shell_map',
-          np.array(
-              [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1])),
-         ('nprims',
-          np.array(
-              [7, 7, 1, 1, 3, 1, 1, 1, 1, 1, 7, 7, 1, 1, 3, 1, 1, 1, 1, 1])),
-         ('shell_types',
-          np.array(
-              [0, 0, 0, 0, 1, 1, 1, 2, 2, 3, 0, 0, 0, 0, 1, 1, 1, 2, 2, 3])),
-         ('alphas', np.array([1.53300000e+04, 2.29900000e+03, 5.22400000e+02,
-                              1.47300000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 1.53300000e+04, 2.29900000e+03,
-                              5.22400000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 6.88200000e-01, 1.75200000e+00,
-                              2.38400000e-01, 3.44600000e+01, 7.74900000e+00,
-                              2.28000000e+00, 7.15600000e-01, 2.14000000e-01,
-                              2.31400000e+00, 6.45000000e-01, 1.42800000e+00,
-                              1.53300000e+04, 2.29900000e+03, 5.22400000e+02,
-                              1.47300000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 1.53300000e+04, 2.29900000e+03,
-                              5.22400000e+02, 4.75500000e+01, 1.67600000e+01,
-                              6.20700000e+00, 6.88200000e-01, 1.75200000e+00,
-                              2.38400000e-01, 3.44600000e+01, 7.74900000e+00,
-                              2.28000000e+00, 7.15600000e-01, 2.14000000e-01,
-                              2.31400000e+00, 6.45000000e-01, 1.42800000e+00])),
-         ('con_coeffs',
-          np.array([5.19808943e-04, 4.02025621e-03, 2.07128267e-02,
-                    8.10105536e-02, 2.35962985e-01, 4.42653446e-01,
-                    3.57064423e-01, 9.13376623e-06, 6.07362596e-05,
-                    2.68782282e-04, -6.96940030e-03, -6.06456900e-02,
-                    -1.65519536e-01, 1.07151369e+00, 1.00000000e+00,
-                    1.00000000e+00, 4.11634896e-02, 2.57762836e-01,
-                    8.02419274e-01, 1.00000000e+00, 1.00000000e+00,
-                    1.00000000e+00, 1.00000000e+00, 1.00000000e+00,
-                    5.19808943e-04, 4.02025621e-03, 2.07128267e-02,
-                    8.10105536e-02, 2.35962985e-01, 4.42653446e-01,
-                    3.57064423e-01, 9.13376623e-06, 6.07362596e-05,
-                    2.68782282e-04, -6.96940030e-03, -6.06456900e-02,
-                    -1.65519536e-01, 1.07151369e+00, 1.00000000e+00,
-                    1.00000000e+00, 4.11634896e-02, 2.57762836e-01,
-                    8.02419274e-01, 1.00000000e+00, 1.00000000e+00,
-                    1.00000000e+00, 1.00000000e+00, 1.00000000e+00]))])
+    with path('iodata.test.data', 'o2_cc_pvtz_cart.fchk') as fn_fchk:
+        data = load_one(fn_fchk)
+    obasis = data.obasis._replace(conventions=OVERLAP_CONVENTIONS)
+    assert_allclose(ref, compute_overlap(obasis), rtol=1.e-5, atol=1.e-8)
 
-    assert_allclose(ref, compute_overlap(**d), atol=1e-8)
+
+def test_overlap_l1():
+    dbasis = MolecularBasis(np.zeros((3, 1)), [], {}, 'L1')
+    with raises(ValueError):
+        _ = compute_overlap(dbasis)

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -22,13 +22,11 @@
 """Utility functions module."""
 
 
-from typing import List, Dict, Tuple, NamedTuple
+from typing import Tuple, NamedTuple
 
 import numpy as np
 import scipy.constants as spc
 from scipy.linalg import eigh
-
-from .overlap import get_shell_nbasis
 
 
 __all__ = ['LineIterator', 'set_four_index_element', 'MolecularOrbitals']
@@ -97,7 +95,7 @@ class MolecularOrbitals(NamedTuple):
     occs : np.ndarray
         Molecular orbital occupation numbers.
     coeffs : np.ndarray
-        Molecular orbital basis coefficients.
+        Molecular orbital basis coefficients. shape = (nbasis, norb_a + norb_b)
     irreps : np.ndarray
         Irreducible representation.
     energies : np.ndarray
@@ -112,20 +110,6 @@ class MolecularOrbitals(NamedTuple):
     coeffs: np.ndarray
     irreps: np.ndarray
     energies: np.ndarray
-
-
-def str_to_shell_types(s: str, pure: bool = False) -> List[int]:
-    """Convert a string into a list of contraction types."""
-    if pure:
-        d = {'s': 0, 'p': 1, 'd': -2, 'f': -3, 'g': -4, 'h': -5, 'i': -6}
-    else:
-        d = {'s': 0, 'p': 1, 'd': 2, 'f': 3, 'g': 4, 'h': 5, 'i': 6}
-    return [d[c] for c in s.lower()]
-
-
-def shell_type_to_str(shell_type: np.ndarray) -> Dict:
-    """Convert a shell type into a character."""
-    return {0: 's', 1: 'p', 2: 'd', 3: 'f', 4: 'g', 5: 'h', 6: 'i'}[abs(shell_type)]
 
 
 def set_four_index_element(four_index_object: np.ndarray, i: int, j: int, k: int, l: int,
@@ -153,12 +137,6 @@ def set_four_index_element(four_index_object: np.ndarray, i: int, j: int, k: int
     four_index_object[l, k, j, i] = value
     four_index_object[j, k, l, i] = value
     four_index_object[l, i, j, k] = value
-
-
-def shells_to_nbasis(shell_types: np.ndarray) -> int:
-    """Compute the number of basis functions for a given list of shell_types."""
-    nbasis_shell = [get_shell_nbasis(i) for i in shell_types]
-    return sum(nbasis_shell)
 
 
 def volume(rvecs: np.ndarray) -> float:


### PR DESCRIPTION
Fixes #42.
Fixes #30.

Differences w.r.t. the plans dicsussed in #42:

- Class names: `MolecularBasis` instead of `OBasisInfo` and `Shell` instead of `ShellInfo`. The info suffix is somewhat redundant and the new datatype can also describe density basis sets.

- `basis.type` was dropped and was replaced by `Shell.kinds`. The original idea could not describe the common situation that some shells are pure while others are Cartesian. The new form is more general than what one may encounter in the supported file formats, similar to what we had in HORTON2. This is a little overkill, but it makes it easier to write algorithms with the new data structure. E.g. `zip(shell.angmoms, shell.kinds)` is convenient and used in several places.

- `shell.contractions` has become `shell.coeffs`. This was changed after David's comment that contractions can be many things, depending on who you ask. `concoeffs` was found too descriptive. The shape is transposed: `(nprim, ncon)` instead of `(ncon, nprim)` to correspond with the usual rows and columns found in practically all file formats.

- `shell.iatom` was dropped. We need to address this in future, but I'd like to postpone until #41 is fixed and ghost atoms are dealt with more sensibly by the `IOData` class. (An issue should be made for this.) Including it in this PR would have added more clutter, most likely to be removed again later.

- Related to the previous point, another issue should be opened for `MolecularBasis.centers`. It is nearly redundant and would become 100% redundant with #41.

- `shell.angmoms` has become a list or array of integers instead of characters, because integers are much easier to use in the rest of the code.

- `basis.primitive_normalization` to make the distinction between orbital and density basis sets.

Additional changes needed to make everything work:

- A new `iodata.basis` module was added, containing all the new data structures and related functions to convert between different ordering conventions.

- All `load` and `dump` functions for wavefunction files have been updated to use the new structure. It had a rather big impact on these modules, but always resulted in cleaner code. Permutation vectors must no longer be hard-coded.

- The routine for the overlap integrals was rewritten, at least the pure Python part, and became much simpler.

- `iodata.load_one` has become a lot simpler. It now only loads one file at a time. The old API, which allowed multiple related files to be loaded at once, is no longer needed. It used to be formally necessary, e.g. to convert integrals from a gaussian log file into the right order, which could only be done by loading a corresponding FCHK at the same time. Now we keep track of ordering conventions and such files can be loaded separately. (This will make it easier to add new features to `load_one` in future, e.g. to manually specify the file format when needed.)

-  `shell_types`, i.e. angular momenta with a sign convention (negative for pure functions) no longer exists. Instead angular momentum and the kind of basis function (Cartesian or pure) have become separate attributes in the `Shell` class.

- Lots of unit tests were added to increase the coverage. `iodata.overlap` and `iodata.basis` should have 100% coverage.

I know this is a big PR, not ideal, but the intermediate code was even worse because it had to keep both the old and the new API in the air.