### PR TITLE
Fix pycodestyle E302 expected 2 blank lines

### DIFF
--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -44,6 +44,7 @@ CONVENTIONS = {
     (3, 'p'): HORTON2_CONVENTIONS[(3, 'p')],
 }
 
+
 def _get_cp2k_norm_corrections(l: int, alphas: Union[float, np.ndarray]) \
         -> Union[float, np.ndarray]:
     """Compute the corrections for the normalization of the basis functions.


### PR DESCRIPTION
Fix pycodestyle E302 expected 2 blank lines