### PR TITLE
Add load_one & dump_one to be public

### DIFF
--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -33,7 +33,7 @@ import numpy as np
 from .utils import LineIterator
 
 
-__all__ = ['IOData']
+__all__ = ['IOData', 'load_one', 'dump_one']
 
 
 def find_format_modules():


### PR DESCRIPTION
I think `load_one` and `dump_one` should be added to the __all__ set. Please close this PR if that is not the case.