### PR TITLE
Rename cell to cellvecs and related changes

### DIFF
--- a/iodata/formats/locpot.py
+++ b/iodata/formats/locpot.py
@@ -40,7 +40,7 @@ def load(lit: LineIterator) -> dict:
     Returns
     -------
     out
-        Ouput dictionary containing ``title``, ``atcoords``, ``numbers``, ``rvecs``,
+        Ouput dictionary containing ``title``, ``atcoords``, ``numbers``, ``cellvecs``,
         ``grid`` & ``cube_data`` keys and corresponding values.
 
     """

--- a/iodata/formats/poscar.py
+++ b/iodata/formats/poscar.py
@@ -45,17 +45,17 @@ def load(lit: LineIterator) -> dict:
     Returns
     -------
     out
-        Output dictionary containing ``title``, ``atcoords``, ``atnums`` & ``rvecs`` keys
+        Output dictionary containing ``title``, ``atcoords``, ``atnums`` & ``cellvecs`` keys
         and their corresponding values.
 
     """
     # Load header
-    title, rvecs, atnums, atcoords = _load_vasp_header(lit)
+    title, cellvecs, atnums, atcoords = _load_vasp_header(lit)
     return {
         'title': title,
         'atcoords': atcoords,
         'atnums': atnums,
-        'rvecs': rvecs,
+        'cellvecs': cellvecs,
     }
 
 
@@ -67,7 +67,7 @@ def dump(f: TextIO, data: 'IOData'):
     f
         A file to write to.
     data
-        An IOData instance which must contain ``atcoords``, ``atnums``, ``rvecs`` &
+        An IOData instance which must contain ``atcoords``, ``atnums``, ``cellvecs`` &
         ``cell_frac`` attributes. It may contain ``title`` attribute.
 
     """
@@ -75,8 +75,8 @@ def dump(f: TextIO, data: 'IOData'):
     print('   1.00000000000000', file=f)
 
     # Write cell vectors, each row is one vector in angstrom:
-    rvecs = data.rvecs
-    for rvec in rvecs:
+    cellvecs = data.cellvecs
+    for rvec in cellvecs:
         r = rvec / angstrom
         print(f'{r[0]: 21.16f} {r[1]: 21.16f} {r[2]: 21.16f}', file=f)
 

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -163,9 +163,11 @@ class IOData:
 
     **Unspecified type (duck typing):**
 
-    cell
-         A Cell object that describes the (generally triclinic) periodic
-         boundary conditions.
+    cellvecs
+         A (NP, 3) array containing the (real-space) cell vectors describing
+         periodic boundary conditions. A single vector corresponds to a 1D cell,
+         e.g. for a wire. Two vectors describe a 2D cell, e.g. for a membrane.
+         Three vectors describe a 3D cell, e.g. a crystalline solid.
 
     core_energy
          The Hartree-Fock energy due to the core orbitals
@@ -181,9 +183,6 @@ class IOData:
 
     orb_beta
          The beta orbitals (coefficients, occupations and energies).
-
-    esp_charges
-         Charges fitted to the electrostatic potential
 
     dm_full (optionally with a suffix like _mp2, _mp3, _cc, _ci, _scf).
          The spin-summed first-order density matrix.
@@ -230,6 +229,14 @@ class IOData:
 
     two_mo
          Two-electron integrals in the (Hartree-Fock) molecular-orbital basis
+
+    ugrid
+         A dictionary describing the uniform grid (typically from a cube file).
+         It contains the following fields: ``origin``, a 3D vector with the
+         origin of the axes frame. ``axes`` a 3x3 array where each row
+         represents the spacing between two neighboring grid points along the
+         first, second and third axis, respectively. ``shape`` A three-tuple
+         with the number of points along each axis, respectively.
 
     """
 

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -35,17 +35,17 @@ def test_load_chgcar_oxygen():
     with path('iodata.test.data', 'CHGCAR.oxygen') as fn:
         mol = load_one(str(fn))
     assert_equal(mol.atnums, 8)
-    assert_allclose(volume(mol.rvecs), (10 * angstrom) ** 3, atol=1.e-10)
-    ugrid = mol.grid
+    assert_allclose(volume(mol.cellvecs), (10 * angstrom) ** 3, atol=1.e-10)
+    ugrid = mol.ugrid
     assert_equal(ugrid['shape'], [2, 2, 2])
     assert abs(ugrid['origin']).max() < 1e-10
 
-    assert_allclose(ugrid['grid_rvecs'], mol.rvecs / 2, atol=1.e-10)
+    assert_allclose(ugrid['axes'], mol.cellvecs / 2, atol=1.e-10)
     d = mol.cube_data
     assert_allclose(d[0, 0, 0],
-                    0.78406017013E+04 / volume(mol.rvecs), atol=1.e-10)
-    assert_allclose(d[-1, -1, -1], 0.10024522914E+04 / volume(mol.rvecs), atol=1.e-10)
-    assert_allclose(d[1, 0, 0], 0.76183317989E+04 / volume(mol.rvecs), atol=1.e-10)
+                    0.78406017013E+04 / volume(mol.cellvecs), atol=1.e-10)
+    assert_allclose(d[-1, -1, -1], 0.10024522914E+04 / volume(mol.cellvecs), atol=1.e-10)
+    assert_allclose(d[1, 0, 0], 0.76183317989E+04 / volume(mol.cellvecs), atol=1.e-10)
 
 
 def test_load_chgcar_water():
@@ -56,9 +56,9 @@ def test_load_chgcar_water():
     coords = np.array(
         [0.074983 * 15 + 0.903122 * 1, 0.903122 * 15, 0.000000])
     assert_allclose(mol.atcoords[1], coords, atol=1.e-7)
-    assert_allclose(volume(mol.rvecs), 15 ** 3, atol=1.e-4)
-    ugrid = mol.grid
+    assert_allclose(volume(mol.cellvecs), 15 ** 3, atol=1.e-4)
+    ugrid = mol.ugrid
     assert_equal(len(ugrid['shape']), 3)
     assert_equal(ugrid['shape'], 3)
-    assert_allclose(ugrid['grid_rvecs'], mol.rvecs / 3, atol=1.e-10)
+    assert_allclose(ugrid['axes'], mol.cellvecs / 3, atol=1.e-10)
     assert abs(ugrid['origin']).max() < 1e-10

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -38,18 +38,18 @@ def test_load_aelta():
     assert_equal(mol.natom, 72)
     assert_allclose(mol.atcoords[5, 0], 27.275511, atol=1.e-5)
     assert_allclose(mol.atcoords[-2, 2], 26.460812, atol=1.e-5)
-    assert_equal(mol.grid['shape'], 12)
-    rvecs = mol.cell
-    my_rvecs = np.array([[1.8626, 0.1, 0.0],
-                         [0.0, 1.8626, 0.0],
-                         [0.0, 0.0, 1.8626]], dtype=np.float) * 12
-    assert_allclose(rvecs, my_rvecs, atol=1.e-5)
-    rvecs = mol.grid['grid_rvecs']
-    my_rvecs = np.array([[1.8626, 0.1, 0.0],
-                         [0.0, 1.8626, 0.0],
-                         [0.0, 0.0, 1.8626]], dtype=np.float)
-    assert_allclose(rvecs, my_rvecs, atol=1.e-5)
-    assert_allclose(mol.grid['origin'], np.array([0.0, 1.2, 0.0]), atol=1.e-10)
+    assert_equal(mol.ugrid['shape'], 12)
+    cellvecs = mol.cellvecs
+    my_cellvecs = np.array([[1.8626, 0.1, 0.0],
+                            [0.0, 1.8626, 0.0],
+                            [0.0, 0.0, 1.8626]], dtype=np.float) * 12
+    assert_allclose(cellvecs, my_cellvecs, atol=1.e-5)
+    cellvecs = mol.ugrid['axes']
+    my_cellvecs = np.array([[1.8626, 0.1, 0.0],
+                            [0.0, 1.8626, 0.0],
+                            [0.0, 0.0, 1.8626]], dtype=np.float)
+    assert_allclose(cellvecs, my_cellvecs, atol=1.e-5)
+    assert_allclose(mol.ugrid['origin'], np.array([0.0, 1.2, 0.0]), atol=1.e-10)
 
     assert_allclose(mol.cube_data[0, 0, 0], 9.49232e-06, atol=1.e-12)
     assert_allclose(mol.cube_data[-1, -1, -1], 2.09856e-04, atol=1.e-10)
@@ -71,9 +71,9 @@ def test_load_dump_load_aelta(tmpdir):
     assert mol1.title == mol2.title
     assert_allclose(mol1.atcoords, mol2.atcoords, atol=1.e-4)
     assert_equal(mol1.atnums, mol2.atnums)
-    ugrid1 = mol1.grid
-    ugrid2 = mol2.grid
-    assert_allclose(ugrid1["grid_rvecs"], ugrid2["grid_rvecs"], atol=1.e-4)
+    ugrid1 = mol1.ugrid
+    ugrid2 = mol2.ugrid
+    assert_allclose(ugrid1["axes"], ugrid2["axes"], atol=1.e-4)
     assert_equal(ugrid1["shape"], ugrid2["shape"])
     assert_allclose(mol1.cube_data, mol2.cube_data, atol=1.e-4)
     assert_allclose(mol1.atcorenums, mol2.atcorenums, atol=1.e-4)

--- a/iodata/test/test_locpot.py
+++ b/iodata/test/test_locpot.py
@@ -34,8 +34,8 @@ def test_load_locpot_oxygen():
         mol = load_one(str(fn))
     assert mol.title == 'O atom in a box'
     assert_equal(mol.atnums[0], 8)
-    assert_allclose(volume(mol.rvecs), (10 * angstrom) ** 3, atol=1.e-10)
-    ugrid = mol.grid
+    assert_allclose(volume(mol.cellvecs), (10 * angstrom) ** 3, atol=1.e-10)
+    ugrid = mol.ugrid
     assert_equal(len(ugrid['shape']), 3)
     assert_equal(ugrid['shape'], [1, 4, 2])
     assert abs(ugrid['origin']).max() < 1e-10

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -40,7 +40,7 @@ def test_load_poscar_water():
     assert_equal(mol.atnums, [8, 1, 1])
     coords = np.array([0.074983 * 15, 0.903122 * 15, 0.000000])
     assert_allclose(mol.atcoords[1], coords, atol=1e-7)
-    assert_allclose(volume(mol.rvecs), 15 ** 3, atol=1.e-4)
+    assert_allclose(volume(mol.cellvecs), 15 ** 3, atol=1.e-4)
 
 
 def test_load_poscar_cubicbn_cartesian():
@@ -50,7 +50,7 @@ def test_load_poscar_cubicbn_cartesian():
     assert_equal(mol.atnums, [5, 7])
     assert_allclose(mol.atcoords[1],
                     np.array([0.25] * 3) * 3.57 * angstrom, atol=1.e-10)
-    assert_allclose(volume(mol.rvecs), (3.57 * angstrom) ** 3 / 4, atol=1.e-10)
+    assert_allclose(volume(mol.cellvecs), (3.57 * angstrom) ** 3 / 4, atol=1.e-10)
 
 
 def test_load_poscar_cubicbn_direct():
@@ -60,17 +60,17 @@ def test_load_poscar_cubicbn_direct():
     assert_equal(mol.atnums, [5, 7])
     assert_allclose(mol.atcoords[1],
                     np.array([0.25] * 3) * 3.57 * angstrom, atol=1.e-10)
-    assert_allclose(volume(mol.rvecs), (3.57 * angstrom) ** 3 / 4, 1.e-10)
+    assert_allclose(volume(mol.cellvecs), (3.57 * angstrom) ** 3 / 4, 1.e-10)
 
 
 def test_load_dump_consistency(tmpdir):
     with path('iodata.test.data', 'water_element.xyz') as fn:
         mol0 = load_one(str(fn))
     # random matrix generated from a uniform distribution on [0., 5.0)
-    mol0.rvecs = np.array([[2.05278155, 0.23284023, 1.59024118],
-                           [4.96430141, 4.73044423, 4.67590975],
-                           [3.48374425, 0.67931228, 0.66281160]])
-    mol0.gvecs = np.linalg.inv(mol0.rvecs).T
+    mol0.cellvecs = np.array([[2.05278155, 0.23284023, 1.59024118],
+                              [4.96430141, 4.73044423, 4.67590975],
+                              [3.48374425, 0.67931228, 0.66281160]])
+    mol0.gvecs = np.linalg.inv(mol0.cellvecs).T
 
     fn_tmp = os.path.join(tmpdir, 'POSCAR')
     dump_one(mol0, fn_tmp)
@@ -81,4 +81,4 @@ def test_load_dump_consistency(tmpdir):
     assert_allclose(mol0.atcoords[1], mol1.atcoords[0], atol=1.e-10)
     assert_allclose(mol0.atcoords[0], mol1.atcoords[1], atol=1.e-10)
     assert_allclose(mol0.atcoords[2], mol1.atcoords[2], atol=1.e-10)
-    assert_allclose(mol0.rvecs, mol1.rvecs, atol=1.e-10)
+    assert_allclose(mol0.cellvecs, mol1.cellvecs, atol=1.e-10)

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -140,23 +140,30 @@ def set_four_index_element(four_index_object: np.ndarray, i: int, j: int, k: int
     four_index_object[l, i, j, k] = value
 
 
-def volume(rvecs: np.ndarray) -> float:
-    """Calculate the cell volume.
+def volume(cellvecs: np.ndarray) -> float:
+    """Calculate the (generalized) cell volume.
 
     Parameters
     ----------
-    rvecs
-        a numpy matrix of shape (x,3) where x is in {1,2,3}
+    cellvecs
+        A numpy matrix of shape (x,3) where x is in {1,2,3}. Each row is one
+        cellvector.
+
+    Returns
+    -------
+    volume
+        In case of 3D, the cell volume. In case of 2D, the cell area. In case of
+        1D, the cell length.
 
     """
-    nvecs = rvecs.shape[0]
-    if len(rvecs.shape) == 1 or nvecs == 1:
-        return np.linalg.norm(rvecs)
+    nvecs = cellvecs.shape[0]
+    if len(cellvecs.shape) == 1 or nvecs == 1:
+        return np.linalg.norm(cellvecs)
     if nvecs == 2:
-        return np.linalg.norm(np.cross(rvecs[0], rvecs[1]))
+        return np.linalg.norm(np.cross(cellvecs[0], cellvecs[1]))
     if nvecs == 3:
-        return np.linalg.det(rvecs)
-    raise ValueError("Argument rvecs should be of shape (x, 3), where x is in {1, 2, 3}")
+        return np.linalg.det(cellvecs)
+    raise ValueError("Argument cellvecs should be of shape (x, 3), where x is in {1, 2, 3}")
 
 
 def derive_naturals(dm: np.ndarray, overlap: np.ndarray) \


### PR DESCRIPTION
- Rename grid to ugrid (needs better solution for which I'll open an
  issue).
- Rename also rvecs to cellvecs (another name in use for the same thing)
- Rename grid_rvecs to axes (common terminology for cube file).
- Drop pbc field from ugrid (no longer used).

(This is one of the bullet points in #41.)