### PR TITLE
IOData attribute names: atforces, athessian, atfrozen, atmasses

### DIFF
--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -146,22 +146,36 @@ class IOData:
     Type checked array attributes (if present)
     ------------------------------------------
 
-    cube_data
-         A (L, M, N) array of data on a uniform grid (defined by ugrid).
-
     atcoords
          A (N, 3) float array with Cartesian coordinates of the atoms.
-
-    atnums
-         A (N,) int vector with the atomic numbers.
-
-    polar
-         A (3, 3) matrix containing the dipole polarizability tensor.
 
     atcorenums
          A (N,) float array with pseudo-potential core charges.
 
+    atforces
+        A (N, 3) float array with Cartesian forces on each atom.
+
+    atfrozen
+        A (N,) bool array with frozen atoms. (All atoms are free if this
+        attribute is not set.)
+
+    atmasses
+        A (N,) float array with atomic masses
+
+    atnums
+         A (N,) int vector with the atomic numbers.
+
+    cube_data
+         A (L, M, N) array of data on a uniform grid (defined by ugrid).
+
+    polar
+         A (3, 3) matrix containing the dipole polarizability tensor.
+
     **Unspecified type (duck typing):**
+
+    athessian
+        A (3*N, 3*N) array containing the energy Hessian w.r.t Cartesian atomic
+        displacements.
 
     cellvecs
          A (NP, 3) array containing the (real-space) cell vectors describing
@@ -195,10 +209,6 @@ class IOData:
 
     kin
          The kinetic energy operator.
-
-    links
-         A mapping between the atoms in the primitive unit and the
-         crystallographic unit.
 
     ms2
          The spin multiplicity.
@@ -262,23 +272,38 @@ class IOData:
                        'dm_spin_mp3', 'dm_spin_cc', 'dm_spin_ci', 'dm_spin_scf', 'kin',
                        'na', 'olp']
 
-    # only perform type checking on minimal attributes
-    atnums = ArrayTypeCheckDescriptor('atnums', 1, (-1,), int, ['atcoords', 'atcorenums'],
-                                      doc="A (N,) int vector with the atomic numbers.")
-    atcoords = ArrayTypeCheckDescriptor('atcoords', 2, (-1, 3), float,
-                                        ['atnums', 'atcorenums'],
-                                        doc="A (N, 3) float array with Cartesian atcoords "
-                                            "of the atoms.")
-    cube_data = ArrayTypeCheckDescriptor('cube_data', 3,
-                                         doc="A (L, M, N) array of data on a uniform grid "
-                                             "(defined by ugrid).")
-    polar = ArrayTypeCheckDescriptor('polar', 2, (3, 3), float,
-                                     doc="A (3, 3) matrix containing the dipole polarizability "
-                                         "tensor.")
-    atcorenums = ArrayTypeCheckDescriptor('atcorenums', 1, (-1,), float,
-                                          ['atcoords', 'atnums'], 'atnums',
-                                          doc="A (N,) float array with pseudo-potential core "
-                                              "charges.")
+    # only perform type checking on some attributes
+    atcoords = ArrayTypeCheckDescriptor(
+        'atcoords', 2, (-1, 3), float,
+        ['atcorenums', 'atforces', 'atfrozen', 'atmasses', 'atnums'],
+        doc="A (N, 3) float array with Cartesian coordinates of the atoms.")
+    atcorenums = ArrayTypeCheckDescriptor(
+        'atcorenums', 1, (-1,), float,
+        ['atcoords', 'atforces', 'atfrozen', 'atmasses', 'atnums'],
+        'atnums',
+        doc="A (N,) float array with pseudo-potential core charges.")
+    atforces = ArrayTypeCheckDescriptor(
+        'atforces', 2, (-1, 3), float,
+        ['atcoords', 'atcorenums', 'atfrozen', 'atmasses', 'atnums'],
+        doc="A (N, 3) float array with Cartesian atomic forces.")
+    atfrozen = ArrayTypeCheckDescriptor(
+        'atfrozen', 1, (-1,), bool,
+        ['atcoords', 'atcorenums', 'atforces', 'atmasses', 'atnums'],
+        doc="A (N,) boolean array flagging fixed atoms.")
+    atmasses = ArrayTypeCheckDescriptor(
+        'atmasses', 1, (-1,), float,
+        ['atcoords', 'atcorenums', 'atforces', 'atfrozen', 'atnums'],
+        doc="A (N,) float array with atomic masses.")
+    atnums = ArrayTypeCheckDescriptor(
+        'atnums', 1, (-1,), int,
+        ['atcoords', 'atcorenums', 'atforces', 'atfrozen', 'atmasses'],
+        doc="A (N,) int vector with the atomic numbers.")
+    cube_data = ArrayTypeCheckDescriptor(
+        'cube_data', 3,
+        doc="A (L, M, N) array of data on a uniform grid (defined by ugrid).")
+    polar = ArrayTypeCheckDescriptor(
+        'polar', 2, (3, 3), float,
+        doc="A (3, 3) matrix containing the dipole polarizability tensor.")
 
     @property
     def natom(self) -> int:

--- a/iodata/test/data/peroxide_tsopt.fchk
+++ b/iodata/test/data/peroxide_tsopt.fchk
@@ -52,7 +52,7 @@ Nuclear QMom                               R   N=           4
 Nuclear GFac                               R   N=           4
   0.00000000E+00  0.00000000E+00  2.79284600E+00  2.79284600E+00
 MicOpt                                     I   N=           4
-          -1          -1          -1          -1
+          -1          -1          -1          -2
 Number of residues                         I                0
 Number of secondary structures             I                0
 Redundant internal dimensions              I   N=           4

--- a/iodata/test/test_utils.py
+++ b/iodata/test/test_utils.py
@@ -1,0 +1,26 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Unit tests for iodata.utils."""
+
+
+from ..utils import amu
+
+
+def test_amu():
+    assert abs(amu * 1.008 - 1837.47) < 1e-1

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -29,8 +29,13 @@ from scipy.linalg import eigh
 __all__ = ['LineIterator', 'set_four_index_element', 'MolecularOrbitals']
 
 
+# The unit conversion factors below can be used as follows:
+# - Conversion to atomic units: distance = 5*angstrom
+# - Conversion from atomic units: print(distance/angstrom)
 angstrom: float = spc.angstrom / spc.value(u'atomic unit of length')
-electronvolt: float = 1. / spc.value(u'hartree-electron volt relationship')
+electronvolt: float = 1 / spc.value(u'hartree-electron volt relationship')
+# atomic mass unit (not atomic unit of mass!)
+amu: float = 1e-3 / (spc.value(u'electron mass') * spc.value(u'Avogadro constant'))
 
 
 class LineIterator:


### PR DESCRIPTION
We should consider using atgradient instead of atforces. The former is more common. The links attribute was removed from the documentation because it is no longer used.