### PR TITLE
Add charge and improve nelec attribute

### DIFF
--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -316,6 +316,25 @@ class IOData:
         raise ValueError("Cannot determine the number of atoms.")
 
     @property
+    def nelec(self) -> float:
+        """Return the number of electrons."""
+        mo = getattr(self, 'mo', None)
+        if mo is None:
+            return self._nelec
+        return mo.nelec
+
+    @nelec.setter
+    def nelec(self, nelec: float):
+        mo = getattr(self, 'mo', None)
+        if mo is None:
+            # We need to fix the following together with all the no-member
+            # warnings, see https://github.com/theochem/iodata/issues/73
+            # pylint: disable=attribute-defined-outside-init
+            self._nelec = nelec
+        else:
+            raise TypeError("nelec cannot be set when orbitals are present.")
+
+    @property
     def spinmult(self) -> float:
         """Return the spin multiplicity."""
         mo = getattr(self, 'mo', None)

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -313,7 +313,7 @@ class IOData:
             return len(self.atcoords)
         if hasattr(self, 'atcorenums'):
             return len(self.atcorenums)
-        raise ValueError("Cannot determine the number of atoms.")
+        raise AttributeError("Cannot determine the number of atoms.")
 
     @property
     def nelec(self) -> float:
@@ -333,6 +333,25 @@ class IOData:
             self._nelec = nelec
         else:
             raise TypeError("nelec cannot be set when orbitals are present.")
+
+    @property
+    def charge(self) -> float:
+        """Return the net charge of the system."""
+        atcorenums = getattr(self, 'atcorenums', None)
+        if atcorenums is None:
+            return self._charge
+        return atcorenums.sum() - self.nelec
+
+    @charge.setter
+    def charge(self, charge: float):
+        atcorenums = getattr(self, 'atcorenums', None)
+        if atcorenums is None:
+            # We need to fix the following together with all the no-member
+            # warnings, see https://github.com/theochem/iodata/issues/73
+            # pylint: disable=attribute-defined-outside-init
+            self._charge = charge
+        else:
+            self.nelec = atcorenums.sum() - charge
 
     @property
     def spinmult(self) -> float:

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -453,3 +453,12 @@ def test_spinmult():
     assert mol2.spinmult == 2
     with pytest.raises(TypeError):
         mol2.spinmult = 3
+
+
+def test_nelec():
+    mol1 = load_fchk_helper('ch3_rohf_sto3g_g03.fchk')
+    assert mol1.nelec == 9
+    mol2 = load_fchk_helper('li_h_3-21G_hf_g09.fchk')
+    assert mol2.nelec == 3
+    with pytest.raises(TypeError):
+        mol2.nelec = 4

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -455,10 +455,14 @@ def test_spinmult():
         mol2.spinmult = 3
 
 
-def test_nelec():
+def test_nelec_charge():
     mol1 = load_fchk_helper('ch3_rohf_sto3g_g03.fchk')
     assert mol1.nelec == 9
+    assert mol1.charge == 0
     mol2 = load_fchk_helper('li_h_3-21G_hf_g09.fchk')
     assert mol2.nelec == 3
+    assert mol2.charge == 1
     with pytest.raises(TypeError):
         mol2.nelec = 4
+    with pytest.raises(TypeError):
+        mol2.charge = 0

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -21,8 +21,8 @@
 
 
 import numpy as np
-
 from numpy.testing import assert_raises, assert_allclose
+import pytest
 
 from .common import compute_1rdm
 from ..iodata import load_one, IOData
@@ -98,3 +98,51 @@ def test_dm_ch3_rohf_g03():
     olp = compute_overlap(mol.obasis)
     dm = compute_1rdm(mol)
     assert_allclose(np.einsum('ab,ba', olp, dm), 9, atol=1.e-6)
+
+
+def test_charge_nelec1():
+    # One a blank IOData object, charge and nelec can be set independently.
+    mol = IOData()
+    mol.nelec = 4
+    mol.charge = -1
+
+
+def test_charge_nelec2():
+    # When atcorenums is set, nelec and charge are coupled
+    mol = IOData()
+    mol.atcorenums = np.array([6.0, 1.0, 1.0, 1.0, 1.0])
+    mol.nelec = 10
+    assert mol.charge == 0
+    mol.charge = 1
+    assert mol.nelec == 9
+
+
+def test_charge_nelec3():
+    # When atnums is set, nelec and charge are coupled
+    mol = IOData()
+    mol.atnums = np.array([6, 1, 1, 1, 1])
+    mol.nelec = 10
+    assert mol.charge == 0
+    mol.charge = 1
+    assert mol.nelec == 9
+
+
+def test_undefined():
+    # One a blank IOData object, accessing undefined charge and nelec should raise
+    # an AttributeError.
+    mol = IOData()
+    with pytest.raises(AttributeError):
+        _ = mol.charge
+    with pytest.raises(AttributeError):
+        _ = mol.nelec
+    with pytest.raises(AttributeError):
+        _ = mol.spinmult
+    with pytest.raises(AttributeError):
+        _ = mol.natom
+    mol.nelec = 5
+    with pytest.raises(AttributeError):
+        _ = mol.charge
+    mol = IOData()
+    mol.charge = 1
+    with pytest.raises(AttributeError):
+        _ = mol.nelec

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -125,12 +125,16 @@ class MolecularOrbitals(NamedTuple):
     energies: np.ndarray
 
     @property
+    def nelec(self):
+        """Return the total number of electrons."""
+        return self.occs.sum()
+
+    @property
     def spinmult(self):
         """Return the spin multiplicity of the Slater determinant."""
         if self.type == 'restricted':
-            nelec = self.occs.sum()
             nbeta = np.clip(self.occs, 0, 1).sum()
-            sq = nelec - 2 * nbeta
+            sq = self.nelec - 2 * nbeta
         elif self.type == 'unrestricted':
             sq = self.occs[:self.norba].sum() - self.occs[self.norba:].sum()
         else:


### PR DESCRIPTION
This fixes a small part of #41. `nelec` and `charge` are coupled as one would expect. When molecular orbitals are present, nelec is read-only and derived from the occupation numbers. When atomic (core) numbers are set, charge is read-only and derived from nelec.