### PR TITLE
More API changes in IOData

### DIFF
--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -237,12 +237,15 @@ def load(lit: LineIterator) -> dict:
 
     # F) Load optional properties
     # Mask out ghost atoms from charges
+    atcharges = {}
     if 'Mulliken Charges' in fchk:
-        result['mulliken_charges'] = fchk['Mulliken Charges'][mask]
+        atcharges['mulliken'] = fchk['Mulliken Charges'][mask]
     if 'ESP Charges' in fchk:
-        result['esp_charges'] = fchk['ESP Charges'][mask]
+        atcharges['esp'] = fchk['ESP Charges'][mask]
     if 'NPA Charges' in fchk:
-        result['npa_charges'] = fchk['NPA Charges'][mask]
+        atcharges['npa'] = fchk['NPA Charges'][mask]
+    if atcharges:
+        result['atcharges'] = atcharges
 
     return result
 

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -68,12 +68,11 @@ def load(lit: LineIterator) -> dict:
     Returns
     -------
     out
-        Output dictionary containing ``title``, ``atcoords``, ``atnums``, ``atcorenums``,
-        ``obasis``, ``mo``, ``energy`` & ``mulliken_charges`` keys and
-        corresponding values. It may also contain ``npa_charges``, ``esp_charges``,
-        ``dm_full_mp2``, ``dm_spin_mp2``, ``dm_full_mp3``, ``dm_spin_mp3``, ``dm_full_cc``,
-        ``dm_spin_cc``, ``dm_full_ci``, ``dm_spin_ci``, ``dm_full_scf``, ``dm_spin_scf``,
-        ``polar``, ``dipole_moment`` & ``quadrupole_moment`` keys and their values as well.
+        Output dictionary containing ``title``, ``atcoords``, ``atnums``,
+        ``atcorenums``, ``obasis``, ``mo``, ``energy`` & ``mulliken_charges``
+        keys and corresponding values. It may also contain ``npa_charges``,
+        ``esp_charges``, ``one_rdms``, ``polar``, ``dipole_moment`` &
+        ``quadrupole_moment`` keys and their values as well.
 
     """
     fchk = _load_fchk_low(lit, [
@@ -181,9 +180,15 @@ def load(lit: LineIterator) -> dict:
     nbasis = fchk["Number of basis functions"]
 
     # C) Load density matrices
-    for lot in 'MP2', 'MP3', 'CC', 'CI', 'SCF':
-        _load_dm('Total %s Density' % lot, fchk, result, 'dm_full_%s' % lot.lower())
-        _load_dm('Spin %s Density' % lot, fchk, result, 'dm_spin_%s' % lot.lower())
+    one_rdms = {}
+    _load_dm('Total SCF Density', fchk, one_rdms, 'scf')
+    _load_dm('Spin SCF Density', fchk, one_rdms, 'scf_spin')
+    # only one of the lots should be present, hence using the same key
+    for lot in 'MP2', 'MP3', 'CC', 'CI':
+        _load_dm('Total {} Density'.format(lot), fchk, one_rdms, 'post_scf')
+        _load_dm('Spin {} Density'.format(lot), fchk, one_rdms, 'post_scf_spin')
+    if one_rdms:
+        result['one_rdms'] = one_rdms
 
     # D) Load the wavefunction
     # Handle small difference in fchk files from g03 and g09
@@ -220,7 +225,7 @@ def load(lit: LineIterator) -> dict:
         mo_occs[:nbeta] = 2.0
         if nalpha != nbeta:
             # delete dm_full_scf because it is known to be buggy
-            result.pop('dm_full_scf')
+            result['one_rdms'].pop('scf')
 
     # create a MO namedtuple
     result['mo'] = MolecularOrbitals(mo_type, norba, norbb, mo_occs, mo_coeffs, None, mo_energy)

--- a/iodata/formats/gaussianlog.py
+++ b/iodata/formats/gaussianlog.py
@@ -63,19 +63,26 @@ def load(lit: LineIterator) -> dict:
     # Then load the two- and four-index operators. This part is written such
     # that it does not make any assumptions about the order in which these
     # operators are printed.
-    result = {}
+    one_ints = {}
+    two_ints = {}
     while True:
         line = next(lit)
         if line.startswith(" Normal termination of Gaussian"):
             break
         elif line.startswith(' *** Overlap ***'):
-            result['olp'] = _load_twoindex_g09(lit, nbasis)
+            one_ints['olp'] = _load_twoindex_g09(lit, nbasis)
         elif line.startswith(' *** Kinetic Energy ***'):
-            result['kin'] = _load_twoindex_g09(lit, nbasis)
+            one_ints['kin_ao'] = _load_twoindex_g09(lit, nbasis)
         elif line.startswith(' ***** Potential Energy *****'):
-            result['na'] = _load_twoindex_g09(lit, nbasis)
+            one_ints['na_ao'] = _load_twoindex_g09(lit, nbasis)
         elif line.startswith(' *** Dumping Two-Electron integrals ***'):
-            result['er'] = _load_fourindex_g09(lit, nbasis)
+            two_ints['er_ao'] = _load_fourindex_g09(lit, nbasis)
+
+    result = {}
+    if one_ints:
+        result['one_ints'] = one_ints
+    if two_ints:
+        result['two_ints'] = two_ints
     return result
 
 

--- a/iodata/formats/molpro.py
+++ b/iodata/formats/molpro.py
@@ -107,8 +107,8 @@ def load(lit: LineIterator) -> dict:
     return {
         'nelec': nelec,
         'spinpol': spinpol,
-        'one_mo': one_mo,
-        'two_mo': two_mo,
+        'one_ints': {'core_mo': one_mo},
+        'two_ints': {'two_mo': two_mo},
         'core_energy': core_energy,
     }
 
@@ -133,8 +133,8 @@ def dump(f: TextIO, data: 'IOData'):
        older versions are not supported.
 
     """
-    one_mo = data.one_mo
-    two_mo = data.two_mo
+    one_mo = data.one_ints['core_mo']
+    two_mo = data.two_ints['two_mo']
     nactive = one_mo.shape[0]
     core_energy = getattr(data, 'core_energy', 0.0)
     nelec = getattr(data, 'nelec', 0)

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -196,6 +196,12 @@ class IOData:
     mo
         An instance of MolecularOrbitals.
 
+    nelec
+         The number of electrons.
+
+    obasis
+         An OrderedDict containing parameters to instantiate a GOBasis class.
+
     one_ints
         Dictionary where keys are names and values are numpy arrays with
         one-body operators, typically integrals of a one-body operator
@@ -215,20 +221,11 @@ class IOData:
         ``post_scf_spin``, followed by a suffix ``_ao`` or ``_mo``, similar to
         the names in ``one_ints``.
 
-    grid
-         An integration grid (usually a UniformGrid instance).
-
     spinpol
          The spin polarization. By default, its value is derived from the
          molecular orbitals (mo attribute), as abs(nalpha - nbeta). In this
          case, spinpol cannot be set. When no molecular orbitals are present,
          this attribute can be set.
-
-    nelec
-         The number of electrons.
-
-    obasis
-         An OrderedDict containing parameters to instantiate a GOBasis class.
 
     title
          A suitable name for the data.

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -173,6 +173,10 @@ class IOData:
 
     **Unspecified type (duck typing):**
 
+    atcharges
+        A dictionary where keys are names of charge definitions and values are
+        arrays with atomic charges (size N).
+
     athessian
         A (3*N, 3*N) array containing the energy Hessian w.r.t Cartesian atomic
         displacements.
@@ -213,17 +217,11 @@ class IOData:
          case, spinpol cannot be set. When no molecular orbitals are present,
          this attribute can be set.
 
-    mulliken_charges
-         Mulliken AIM charges.
-
     na
          The nuclear attraction operator.
 
     nelec
          The number of electrons.
-
-    npa_charges
-         Natural charges.
 
     obasis
          An OrderedDict containing parameters to instantiate a GOBasis class.

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -209,11 +209,11 @@ class IOData:
         omitted because it is only useful to compute them in the atomic-orbital
         basis.
 
-    dm_full (optionally with a suffix like _mp2, _mp3, _cc, _ci, _scf).
-         The spin-summed first-order density matrix.
-
-    dm_spin (optionally with a suffix like _mp2, _mp3, _cc, _ci, _scf).
-         The spin-difference first-order density matrix.
+    one_rdms
+        Dictionary where keys are names and values are one-particle density
+        matrices. Names could begin with ``scf``, ``post_scf``, ``scf_spin``,
+        ``post_scf_spin``, followed by a suffix ``_ao`` or ``_mo``, similar to
+        the names in ``one_ints``.
 
     grid
          An integration grid (usually a UniformGrid instance).
@@ -240,6 +240,12 @@ class IOData:
         (electron repulsion) or ``two`` (general pairswise interaction). When
         relevant, these names must have a suffix ``_ao`` or ``_mo`` to clarify
         in which basis the integrals are computed, see one_ints for more details.
+
+    two_rdms
+        Dictionary where keys are names and values are two-particle density
+        matrices. Names could begin with ``post_scf``, ``post_scf_spin``,
+        followed by a suffix ``_ao`` or ``_mo``, similar to the names in
+        ``one_ints``.
 
     ugrid
          A dictionary describing the uniform grid (typically from a cube file).

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -147,10 +147,10 @@ class IOData:
     ------------------------------------------
 
     atcoords
-         A (N, 3) float array with Cartesian coordinates of the atoms.
+        A (N, 3) float array with Cartesian coordinates of the atoms.
 
     atcorenums
-         A (N,) float array with pseudo-potential core charges.
+        A (N,) float array with pseudo-potential core charges.
 
     atforces
         A (N, 3) float array with Cartesian forces on each atom.
@@ -163,13 +163,13 @@ class IOData:
         A (N,) float array with atomic masses
 
     atnums
-         A (N,) int vector with the atomic numbers.
+        A (N,) int vector with the atomic numbers.
 
     cube_data
-         A (L, M, N) array of data on a uniform grid (defined by ugrid).
+        A (L, M, N) array of data on a uniform grid (defined by ugrid).
 
     polar
-         A (3, 3) matrix containing the dipole polarizability tensor.
+        A (3, 3) matrix containing the dipole polarizability tensor.
 
     **Unspecified type (duck typing):**
 
@@ -182,25 +182,25 @@ class IOData:
         displacements.
 
     cellvecs
-         A (NP, 3) array containing the (real-space) cell vectors describing
-         periodic boundary conditions. A single vector corresponds to a 1D cell,
-         e.g. for a wire. Two vectors describe a 2D cell, e.g. for a membrane.
-         Three vectors describe a 3D cell, e.g. a crystalline solid.
+        A (NP, 3) array containing the (real-space) cell vectors describing
+        periodic boundary conditions. A single vector corresponds to a 1D cell,
+        e.g. for a wire. Two vectors describe a 2D cell, e.g. for a membrane.
+        Three vectors describe a 3D cell, e.g. a crystalline solid.
 
     core_energy
-         The Hartree-Fock energy due to the core orbitals
+        The Hartree-Fock energy due to the core orbitals
 
     energy
-         The total energy (electronic+nn)
+        The total energy (electronic+nn)
 
     mo
         An instance of MolecularOrbitals.
 
     nelec
-         The number of electrons.
+        The number of electrons.
 
     obasis
-         An OrderedDict containing parameters to instantiate a GOBasis class.
+        An OrderedDict containing parameters to instantiate a GOBasis class.
 
     one_ints
         Dictionary where keys are names and values are numpy arrays with
@@ -221,10 +221,10 @@ class IOData:
         ``post_scf_spin``. These matrices are always expressed in the AO basis.
 
     spinpol
-         The spin polarization. By default, its value is derived from the
-         molecular orbitals (mo attribute), as abs(nalpha - nbeta). In this
-         case, spinpol cannot be set. When no molecular orbitals are present,
-         this attribute can be set.
+        The spin polarization. By default, its value is derived from the
+        molecular orbitals (mo attribute), as abs(nalpha - nbeta). In this case,
+        spinpol cannot be set. When no molecular orbitals are present, this
+        attribute can be set.
 
     title
          A suitable name for the data.
@@ -243,12 +243,12 @@ class IOData:
         are always expressed in the AO basis.
 
     ugrid
-         A dictionary describing the uniform grid (typically from a cube file).
-         It contains the following fields: ``origin``, a 3D vector with the
-         origin of the axes frame. ``axes`` a 3x3 array where each row
-         represents the spacing between two neighboring grid points along the
-         first, second and third axis, respectively. ``shape`` A three-tuple
-         with the number of points along each axis, respectively.
+        A dictionary describing the uniform grid (typically from a cube file).
+        It contains the following fields: ``origin``, a 3D vector with the
+        origin of the axes frame. ``axes`` a 3x3 array where each row represents
+        the spacing between two neighboring grid points along the first, second
+        and third axis, respectively. ``shape`` A three-tuple with the number of
+        points along each axis, respectively.
 
     """
 

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -217,9 +217,8 @@ class IOData:
 
     one_rdms
         Dictionary where keys are names and values are one-particle density
-        matrices. Names could begin with ``scf``, ``post_scf``, ``scf_spin``,
-        ``post_scf_spin``, followed by a suffix ``_ao`` or ``_mo``, similar to
-        the names in ``one_ints``.
+        matrices. Names can be ``scf``, ``post_scf``, ``scf_spin``,
+        ``post_scf_spin``. These matrices are always expressed in the AO basis.
 
     spinpol
          The spin polarization. By default, its value is derived from the
@@ -240,9 +239,8 @@ class IOData:
 
     two_rdms
         Dictionary where keys are names and values are two-particle density
-        matrices. Names could begin with ``post_scf``, ``post_scf_spin``,
-        followed by a suffix ``_ao`` or ``_mo``, similar to the names in
-        ``one_ints``.
+        matrices. Names can be ``post_scf`` or ``post_scf_spin``. These matrices
+        are always expressed in the AO basis.
 
     ugrid
          A dictionary describing the uniform grid (typically from a cube file).

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -193,11 +193,21 @@ class IOData:
     energy
          The total energy (electronic+nn)
 
-    er
-         The electron repulsion four-index operator
-
     mo
         An instance of MolecularOrbitals.
+
+    one_ints
+        Dictionary where keys are names and values are numpy arrays with
+        one-body operators, typically integrals of a one-body operator
+        with a pair of (Gaussian) basis functions. Names can start with ``olp``
+        (overlap), ``kin`` (kinetic energy), ``na`` (nuclear attraction),
+        ``core`` (core hamiltonian), etc. When relevant, these names must have a
+        suffix ``_ao`` or ``_mo`` to clarify in which basis the integrals are
+        computed. ``_ao`` is used to denote integrals in a non-orthogonal
+        (atomic orbital) basis. ``_mo`` is used to denote an orthogonal
+        (molecular orbital) basis. For the overlap integrals, this suffix can be
+        omitted because it is only useful to compute them in the atomic-orbital
+        basis.
 
     dm_full (optionally with a suffix like _mp2, _mp3, _cc, _ci, _scf).
          The spin-summed first-order density matrix.
@@ -208,17 +218,11 @@ class IOData:
     grid
          An integration grid (usually a UniformGrid instance).
 
-    kin
-         The kinetic energy operator.
-
     spinpol
          The spin polarization. By default, its value is derived from the
          molecular orbitals (mo attribute), as abs(nalpha - nbeta). In this
          case, spinpol cannot be set. When no molecular orbitals are present,
          this attribute can be set.
-
-    na
-         The nuclear attraction operator.
 
     nelec
          The number of electrons.
@@ -226,17 +230,16 @@ class IOData:
     obasis
          An OrderedDict containing parameters to instantiate a GOBasis class.
 
-    olp
-         The overlap operator.
-
-    one_mo
-         One-electron integrals in the (Hartree-Fock) molecular-orbital basis
-
     title
          A suitable name for the data.
 
-    two_mo
-         Two-electron integrals in the (Hartree-Fock) molecular-orbital basis
+    two_ints
+        Dictionary where keys are names and values are numpy arrays with
+        two-body operators, typically integrals of two-body operator
+        with four of (Gaussian) basis functions. Names can start with ``er``
+        (electron repulsion) or ``two`` (general pairswise interaction). When
+        relevant, these names must have a suffix ``_ao`` or ``_mo`` to clarify
+        in which basis the integrals are computed, see one_ints for more details.
 
     ugrid
          A dictionary describing the uniform grid (typically from a cube file).
@@ -255,20 +258,6 @@ class IOData:
         """
         for key, value in kwargs.items():
             setattr(self, key, value)
-
-    # Numpy array attributes that may require orbital basis reordering or sign correction.
-    # Note: this list is a very fragile thing and should be implemented differently in
-    # future. Ideally, each IO format should be implemented as a class, with a load and
-    # a dump method. Besides these two basic methods, it should also provide additional
-    # information on the fields it can read/write and which should be considered for
-    # reordering basis functions or changing their signs. The current approach to maintain
-    # this list at the iodata level requires us to keep it up-to-date whenever we change
-    # something in the file formats. (The same can be said of the class doc string and the
-    # documentation of the file formats.)
-    two_index_names = ['dm_full', 'dm_full_mp2', 'dm_full_mp3', 'dm_full_cc',
-                       'dm_full_ci', 'dm_full_scf', 'dm_spin', 'dm_spin_mp2',
-                       'dm_spin_mp3', 'dm_spin_cc', 'dm_spin_ci', 'dm_spin_scf', 'kin',
-                       'na', 'olp']
 
     # only perform type checking on some attributes
     atcoords = ArrayTypeCheckDescriptor(

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -166,7 +166,7 @@ class IOData:
         A (N,) int vector with the atomic numbers.
 
     cube_data
-        A (L, M, N) array of data on a uniform grid (defined by ugrid).
+        A (K, L, M) array of data on a uniform grid (defined by ugrid).
 
     polar
         A (3, 3) matrix containing the dipole polarizability tensor.
@@ -177,9 +177,29 @@ class IOData:
         A dictionary where keys are names of charge definitions and values are
         arrays with atomic charges (size N).
 
+    atffparams
+        A dictionary with arrays of atomic force field parameters (typically
+        non-bonded). Keys include 'charges', 'vdw_radii', 'sigmas', 'epsilons',
+        'alphas' (atomic polarizabilities), 'c6s', 'c8s', 'c10s', 'buck_as',
+        'buck_bs', 'lj_as', 'core_charges', 'valence_charges', 'valence_widths',
+        etc. Not all of them have to be present, depending on the use case.
+
     athessian
         A (3*N, 3*N) array containing the energy Hessian w.r.t Cartesian atomic
         displacements.
+
+    basisdef
+        A basis set definition, i.e. a dictionary whose keys are symbols (of
+        chemical elements), atomic numbers (similar to previous, str to make
+        distinction with following) or an atom index (integer referring to a
+        specific atom in a molecule). The format of the values is to be decided
+        when implementing a load function for basis set definitions.
+
+    bonds
+        An (nbond, 3) array with the list of covalent bonds. Each row represents
+        one bond and consists of three integers: first atom index (starting
+        from zero), second atom index & an optional bond type (0: not known, 1:
+        single, 2: double, 3: triple, 4: conjugated).
 
     cellvecs
         A (NP, 3) array containing the (real-space) cell vectors describing
@@ -191,7 +211,15 @@ class IOData:
         The Hartree-Fock energy due to the core orbitals
 
     energy
-        The total energy (electronic+nn)
+        The total energy (electronic + nn)
+
+    extcharges
+        Array with values of external charges, with shape (nextcharge, 4). First
+        three columns for Cartesian X, Y and Z coordinates, last column for the
+        actual charge.
+
+    g_rot
+        The rotational symmetry number of the molecule.
 
     mo
         An instance of MolecularOrbitals.
@@ -201,6 +229,11 @@ class IOData:
 
     obasis
         An OrderedDict containing parameters to instantiate a GOBasis class.
+
+    obasis_name
+        A name or DOI describing the basis set used for the orbitals in the
+        mo attribute (if applicable). Should be consistent with
+        www.basissetexchange.org.
 
     one_ints
         Dictionary where keys are names and values are numpy arrays with
@@ -219,6 +252,10 @@ class IOData:
         Dictionary where keys are names and values are one-particle density
         matrices. Names can be ``scf``, ``post_scf``, ``scf_spin``,
         ``post_scf_spin``. These matrices are always expressed in the AO basis.
+
+    run_type
+        The type of calculation that lead to the results stored in IOData, e.g.
+        'energy', 'energy_force', 'opt', 'freq', ...
 
     spinpol
         The spin polarization. By default, its value is derived from the

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -207,21 +207,21 @@ def test_load_fchk_ghost_atoms():
 
 
 def test_load_fchk_ch3_rohf_g03():
-    fields = load_fchk_helper_internal('ch3_rohf_sto3g_g03.fchk')
-    assert_equal(fields['mo'].occs.shape[0], fields['mo'].coeffs.shape[0])
-    assert_equal(fields['mo'].occs.sum(), 9.0)
-    assert_equal(fields['mo'].occs.min(), 0.0)
-    assert_equal(fields['mo'].occs.max(), 2.0)
-    assert 'dm_full_scf' not in fields
+    mol = load_fchk_helper('ch3_rohf_sto3g_g03.fchk')
+    assert_equal(mol.mo.occs.shape[0], mol.mo.coeffs.shape[0])
+    assert_equal(mol.mo.occs.sum(), 9.0)
+    assert_equal(mol.mo.occs.min(), 0.0)
+    assert_equal(mol.mo.occs.max(), 2.0)
+    assert 'scf' not in mol.one_rdms
 
 
 def check_load_azirine(key, numbers):
     """Perform some basic checks on a azirine fchk file."""
-    fields = load_fchk_helper_internal('2h-azirine-{}.fchk'.format(key))
-    assert fields['obasis'].nbasis == 33
-    dm_full = fields['dm_full_%s' % key]
-    assert_equal(dm_full[0, 0], numbers[0])
-    assert_equal(dm_full[32, 32], numbers[1])
+    mol = load_fchk_helper('2h-azirine-{}.fchk'.format(key))
+    assert mol.obasis.nbasis == 33
+    dm = mol.one_rdms['post_scf']
+    assert_equal(dm[0, 0], numbers[0])
+    assert_equal(dm[32, 32], numbers[1])
 
 
 def test_load_azirine_cc():
@@ -240,14 +240,14 @@ def test_load_azirine_mp3():
     check_load_azirine('mp3', [2.08243417E+00, 1.02590815E-01])
 
 
-def check_load_nitrogen(key, numbers_full, numbers_spin):
+def check_load_nitrogen(key, numbers, numbers_spin):
     """Perform some basic checks on a nitrogen fchk file."""
-    fields = load_fchk_helper_internal('nitrogen-{}.fchk'.format(key))
-    assert fields['obasis'].nbasis == 9
-    dm_full = fields['dm_full_%s' % key]
-    assert_equal(dm_full[0, 0], numbers_full[0])
-    assert_equal(dm_full[8, 8], numbers_full[1])
-    dm_spin = fields['dm_spin_%s' % key]
+    mol = load_fchk_helper('nitrogen-{}.fchk'.format(key))
+    assert mol.obasis.nbasis == 9
+    dm = mol.one_rdms['post_scf']
+    assert_equal(dm[0, 0], numbers[0])
+    assert_equal(dm[8, 8], numbers[1])
+    dm_spin = mol.one_rdms['post_scf_spin']
     assert_equal(dm_spin[0, 0], numbers_spin[0])
     assert_equal(dm_spin[8, 8], numbers_spin[1])
 
@@ -268,29 +268,29 @@ def test_load_nitrogen_mp3():
     check_load_nitrogen('mp3', [2.08674302E+00, 4.91149023E-01], [7.06941101E-04, -1.96276763E-02])
 
 
-def check_normalization_dm_full_azirine(key):
+def check_normalization_dm_azirine(key):
     """Perform some basic checks on a 2h-azirine fchk file."""
     mol = load_fchk_helper('2h-azirine-{}.fchk'.format(key))
     olp = compute_overlap(mol.obasis)
-    dm = getattr(mol, 'dm_full_%s' % key)
+    dm = mol.one_rdms['post_scf']
     check_dm(dm, olp, eps=1e-2, occ_max=2)
     assert_allclose(np.einsum('ab,ba', olp, dm), 22.0, atol=1.e-3)
 
 
-def test_normalization_dm_full_azirine_cc():
-    check_normalization_dm_full_azirine('cc')
+def test_normalization_dm_azirine_cc():
+    check_normalization_dm_azirine('cc')
 
 
-def test_normalization_dm_full_azirine_ci():
-    check_normalization_dm_full_azirine('ci')
+def test_normalization_dm_azirine_ci():
+    check_normalization_dm_azirine('ci')
 
 
-def test_normalization_dm_full_azirine_mp2():
-    check_normalization_dm_full_azirine('mp2')
+def test_normalization_dm_azirine_mp2():
+    check_normalization_dm_azirine('mp2')
 
 
-def test_normalization_dm_full_azirine_mp3():
-    check_normalization_dm_full_azirine('mp3')
+def test_normalization_dm_azirine_mp3():
+    check_normalization_dm_azirine('mp3')
 
 
 def test_load_water_hfs_321g():

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -93,9 +93,9 @@ def test_load_fchk_hf_sto3g_num():
     assert mol.atcoords.shape[1] == 3
     assert len(mol.atnums) == 2
     assert_allclose(mol.energy, -9.856961609951867E+01)
-    assert_allclose(mol.mulliken_charges, [0.45000000E+00, 4.22300000E+00])
-    assert_allclose(mol.npa_charges, [3.50000000E+00, 1.32000000E+00])
-    assert_allclose(mol.esp_charges, [0.77700000E+00, 0.66600000E+00])
+    assert_allclose(mol.atcharges['mulliken'], [0.45000000E+00, 4.22300000E+00])
+    assert_allclose(mol.atcharges['npa'], [3.50000000E+00, 1.32000000E+00])
+    assert_allclose(mol.atcharges['esp'], [0.77700000E+00, 0.66600000E+00])
 
 
 def test_load_fchk_h_sto3g_num():
@@ -202,7 +202,7 @@ def test_load_fchk_ghost_atoms():
     natom, nghost = 3, 3
     assert_equal(fields['atnums'].shape[0], natom)
     assert_equal(fields['atcoords'].shape[0], natom)
-    assert_equal(fields['mulliken_charges'].shape[0], natom)
+    assert_equal(fields['atcharges']['mulliken'].shape[0], natom)
     assert_equal(fields['obasis'].centers.shape[0], natom + nghost)
 
 

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -40,73 +40,68 @@ def test_load_operators_water_sto3g_hf_g03():
     eps = 1e-5
     result = load_log_helper('water_sto3g_hf_g03.log')
 
-    overlap = result['olp']
-    kinetic = result['kin']
-    nuclear_attraction = result['na']
-    electronic_repulsion = result['er']
+    olp = result['one_ints']['olp']
+    kin_ao = result['one_ints']['kin_ao']
+    na_ao = result['one_ints']['na_ao']
+    er_ao = result['two_ints']['er_ao']
 
-    assert_equal(overlap.shape, (7, 7))
-    assert_equal(kinetic.shape, (7, 7))
-    assert_equal(nuclear_attraction.shape, (7, 7))
-    assert_equal(electronic_repulsion.shape, (7, 7, 7, 7))
+    assert_equal(olp.shape, (7, 7))
+    assert_equal(kin_ao.shape, (7, 7))
+    assert_equal(na_ao.shape, (7, 7))
+    assert_equal(er_ao.shape, (7, 7, 7, 7))
 
-    assert_allclose(overlap[0, 0], 1.0, atol=eps)
-    assert_allclose(overlap[0, 1], 0.236704, atol=eps)
-    assert_allclose(overlap[0, 2], 0.0, atol=eps)
-    assert_allclose(overlap[-1, -3], (-0.13198), atol=eps)
+    assert_allclose(olp[0, 0], 1.0, atol=eps)
+    assert_allclose(olp[0, 1], 0.236704, atol=eps)
+    assert_allclose(olp[0, 2], 0.0, atol=eps)
+    assert_allclose(olp[-1, -3], (-0.13198), atol=eps)
 
-    assert_allclose(kinetic[2, 0], 0.0, atol=eps)
-    assert_allclose(kinetic[4, 4], 2.52873, atol=eps)
-    assert_allclose(kinetic[-1, 5], 0.00563279, atol=eps)
-    assert_allclose(kinetic[-1, -3], (-0.0966161), atol=eps)
+    assert_allclose(kin_ao[2, 0], 0.0, atol=eps)
+    assert_allclose(kin_ao[4, 4], 2.52873, atol=eps)
+    assert_allclose(kin_ao[-1, 5], 0.00563279, atol=eps)
+    assert_allclose(kin_ao[-1, -3], (-0.0966161), atol=eps)
 
-    assert_allclose(nuclear_attraction[3, 3], 9.99259, atol=eps)
-    assert_allclose(nuclear_attraction[-2, -1], 1.55014, atol=eps)
-    assert_allclose(nuclear_attraction[2, 6], 2.76941, atol=eps)
-    assert_allclose(nuclear_attraction[0, 3], 0.0, atol=eps)
+    assert_allclose(na_ao[3, 3], 9.99259, atol=eps)
+    assert_allclose(na_ao[-2, -1], 1.55014, atol=eps)
+    assert_allclose(na_ao[2, 6], 2.76941, atol=eps)
+    assert_allclose(na_ao[0, 3], 0.0, atol=eps)
 
-    assert_allclose(electronic_repulsion[0, 0, 0, 0], 4.78506575204, atol=eps)
-    assert_allclose(electronic_repulsion[6, 6, 6, 6], 0.774605944194, atol=eps)
-    assert_allclose(
-        electronic_repulsion[6, 5, 0, 5], 0.0289424337101, atol=eps)
-    assert_allclose(
-        electronic_repulsion[5, 4, 0, 1], 0.0027414529147, atol=eps)
+    assert_allclose(er_ao[0, 0, 0, 0], 4.78506575204, atol=eps)
+    assert_allclose(er_ao[6, 6, 6, 6], 0.774605944194, atol=eps)
+    assert_allclose(er_ao[6, 5, 0, 5], 0.0289424337101, atol=eps)
+    assert_allclose(er_ao[5, 4, 0, 1], 0.0027414529147, atol=eps)
 
 
 def test_load_operators_water_ccpvdz_pure_hf_g03():
     eps = 1e-5
     result = load_log_helper('water_ccpvdz_pure_hf_g03.log')
 
-    overlap = result['olp']
-    kinetic = result['kin']
-    nuclear_attraction = result['na']
-    electronic_repulsion = result['er']
+    olp = result['one_ints']['olp']
+    kin_ao = result['one_ints']['kin_ao']
+    na_ao = result['one_ints']['na_ao']
+    er_ao = result['two_ints']['er_ao']
 
-    assert_equal(overlap.shape, (24, 24))
-    assert_equal(kinetic.shape, (24, 24))
-    assert_equal(nuclear_attraction.shape, (24, 24))
-    assert_equal(electronic_repulsion.shape, (24, 24, 24, 24))
+    assert_equal(olp.shape, (24, 24))
+    assert_equal(kin_ao.shape, (24, 24))
+    assert_equal(na_ao.shape, (24, 24))
+    assert_equal(er_ao.shape, (24, 24, 24, 24))
 
-    assert_allclose(overlap[0, 0], 1.0, atol=eps)
-    assert_allclose(overlap[0, 1], 0.214476, atol=eps)
-    assert_allclose(overlap[0, 2], 0.183817, atol=eps)
-    assert_allclose(overlap[10, 16], 0.380024, atol=eps)
-    assert_allclose(overlap[-1, -3], 0.000000, atol=eps)
+    assert_allclose(olp[0, 0], 1.0, atol=eps)
+    assert_allclose(olp[0, 1], 0.214476, atol=eps)
+    assert_allclose(olp[0, 2], 0.183817, atol=eps)
+    assert_allclose(olp[10, 16], 0.380024, atol=eps)
+    assert_allclose(olp[-1, -3], 0.000000, atol=eps)
 
-    assert_allclose(kinetic[2, 0], 0.160648, atol=eps)
-    assert_allclose(kinetic[11, 11], 4.14750, atol=eps)
-    assert_allclose(kinetic[-1, 5], -0.0244025, atol=eps)
-    assert_allclose(kinetic[-1, -6], -0.0614899, atol=eps)
+    assert_allclose(kin_ao[2, 0], 0.160648, atol=eps)
+    assert_allclose(kin_ao[11, 11], 4.14750, atol=eps)
+    assert_allclose(kin_ao[-1, 5], -0.0244025, atol=eps)
+    assert_allclose(kin_ao[-1, -6], -0.0614899, atol=eps)
 
-    assert_allclose(nuclear_attraction[3, 3], 12.8806, atol=eps)
-    assert_allclose(nuclear_attraction[-2, -1], 0.0533113, atol=eps)
-    assert_allclose(nuclear_attraction[2, 6], 0.173282, atol=eps)
-    assert_allclose(nuclear_attraction[-1, 0], 1.24131, atol=eps)
+    assert_allclose(na_ao[3, 3], 12.8806, atol=eps)
+    assert_allclose(na_ao[-2, -1], 0.0533113, atol=eps)
+    assert_allclose(na_ao[2, 6], 0.173282, atol=eps)
+    assert_allclose(na_ao[-1, 0], 1.24131, atol=eps)
 
-    assert_allclose(electronic_repulsion[0, 0, 0, 0], 4.77005841522, atol=eps)
-    assert_allclose(electronic_repulsion[23, 23, 23, 23],
-                    0.785718708997, atol=eps)
-    assert_allclose(electronic_repulsion[23, 8, 23, 2],
-                    -0.0400337571969, atol=eps)
-    assert_allclose(electronic_repulsion[15, 2, 12, 0],
-                    -0.0000308196281033, atol=eps)
+    assert_allclose(er_ao[0, 0, 0, 0], 4.77005841522, atol=eps)
+    assert_allclose(er_ao[23, 23, 23, 23], 0.785718708997, atol=eps)
+    assert_allclose(er_ao[23, 8, 23, 2], -0.0400337571969, atol=eps)
+    assert_allclose(er_ao[15, 2, 12, 0], -0.0000308196281033, atol=eps)

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -105,6 +105,8 @@ def test_charge_nelec1():
     mol = IOData()
     mol.nelec = 4
     mol.charge = -1
+    assert mol.nelec == 4
+    assert mol.charge == -1
 
 
 def test_charge_nelec2():

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -69,7 +69,7 @@ def test_unknown_format():
 def test_dm_water_sto3g_hf():
     with path('iodata.test.data', 'water_sto3g_hf_g03.fchk') as fn_fchk:
         mol = load_one(str(fn_fchk))
-    dm = mol.dm_full_scf
+    dm = mol.one_rdms['scf']
     assert_allclose(dm[0, 0], 2.10503807, atol=1.e-7)
     assert_allclose(dm[0, 1], -0.439115917, atol=1.e-7)
     assert_allclose(dm[1, 1], 1.93312061, atol=1.e-7)
@@ -79,13 +79,13 @@ def test_dm_lih_sto3g_hf():
     with path('iodata.test.data', 'li_h_3-21G_hf_g09.fchk') as fn_fchk:
         mol = load_one(str(fn_fchk))
 
-    dm_full = mol.dm_full_scf
-    assert_allclose(dm_full[0, 0], 1.96589709, atol=1.e-7)
-    assert_allclose(dm_full[0, 1], 0.122114249, atol=1.e-7)
-    assert_allclose(dm_full[1, 1], 0.0133112081, atol=1.e-7)
-    assert_allclose(dm_full[10, 10], 4.23924688E-01, atol=1.e-7)
+    dm = mol.one_rdms['scf']
+    assert_allclose(dm[0, 0], 1.96589709, atol=1.e-7)
+    assert_allclose(dm[0, 1], 0.122114249, atol=1.e-7)
+    assert_allclose(dm[1, 1], 0.0133112081, atol=1.e-7)
+    assert_allclose(dm[10, 10], 4.23924688E-01, atol=1.e-7)
 
-    dm_spin = mol.dm_spin_scf
+    dm_spin = mol.one_rdms['scf_spin']
     assert_allclose(dm_spin[0, 0], 1.40210760E-03, atol=1.e-9)
     assert_allclose(dm_spin[0, 1], -2.65370873E-03, atol=1.e-9)
     assert_allclose(dm_spin[1, 1], 5.38701212E-03, atol=1.e-9)

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -38,23 +38,25 @@ def test_load_fcidump_psi4_h2():
     assert_allclose(mol.core_energy, 0.7151043364864863E+00)
     assert_equal(mol.nelec, 2)
     assert_equal(mol.spinpol, 0)
-    assert_equal(mol.one_mo.shape, (10, 10))
-    assert_allclose(mol.one_mo[0, 0], -0.1251399119550580E+01)
-    assert_allclose(mol.one_mo[2, 1], 0.9292454365115077E-01)
-    assert_allclose(mol.one_mo[1, 2], 0.9292454365115077E-01)
-    assert_allclose(mol.one_mo[9, 9], 0.9035054979531029E+00)
-    assert_allclose(mol.two_mo.shape, (10, 10, 10, 10))
-    assert_allclose(mol.two_mo[0, 0, 0, 0], 0.6589928924251115E+00)
+    core_mo = mol.one_ints['core_mo']
+    assert_equal(core_mo.shape, (10, 10))
+    assert_allclose(core_mo[0, 0], -0.1251399119550580E+01)
+    assert_allclose(core_mo[2, 1], 0.9292454365115077E-01)
+    assert_allclose(core_mo[1, 2], 0.9292454365115077E-01)
+    assert_allclose(core_mo[9, 9], 0.9035054979531029E+00)
+    two_mo = mol.two_ints['two_mo']
+    assert_allclose(two_mo.shape, (10, 10, 10, 10))
+    assert_allclose(two_mo[0, 0, 0, 0], 0.6589928924251115E+00)
     # Check physicist's notation and symmetry
-    assert_allclose(mol.two_mo[6, 1, 5, 0], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[5, 1, 6, 0], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[6, 0, 5, 1], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[5, 0, 6, 1], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[1, 6, 0, 5], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[1, 5, 0, 6], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[0, 6, 1, 5], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[0, 5, 1, 6], 0.5335846565304321E-01)
-    assert_allclose(mol.two_mo[9, 9, 9, 9], 0.6273759381091796E+00)
+    assert_allclose(two_mo[6, 1, 5, 0], 0.5335846565304321E-01)
+    assert_allclose(two_mo[5, 1, 6, 0], 0.5335846565304321E-01)
+    assert_allclose(two_mo[6, 0, 5, 1], 0.5335846565304321E-01)
+    assert_allclose(two_mo[5, 0, 6, 1], 0.5335846565304321E-01)
+    assert_allclose(two_mo[1, 6, 0, 5], 0.5335846565304321E-01)
+    assert_allclose(two_mo[1, 5, 0, 6], 0.5335846565304321E-01)
+    assert_allclose(two_mo[0, 6, 1, 5], 0.5335846565304321E-01)
+    assert_allclose(two_mo[0, 5, 1, 6], 0.5335846565304321E-01)
+    assert_allclose(two_mo[9, 9, 9, 9], 0.6273759381091796E+00)
 
 
 def test_load_fcidump_molpro_h2():
@@ -63,23 +65,25 @@ def test_load_fcidump_molpro_h2():
     assert_allclose(mol.core_energy, 0.7151043364864863E+00)
     assert_equal(mol.nelec, 2)
     assert_equal(mol.spinpol, 0)
-    assert_equal(mol.one_mo.shape, (4, 4))
-    assert_allclose(mol.one_mo[0, 0], -0.1245406261597530E+01)
-    assert_allclose(mol.one_mo[0, 1], -0.1666402467335385E+00)
-    assert_allclose(mol.one_mo[1, 0], -0.1666402467335385E+00)
-    assert_allclose(mol.one_mo[3, 3], 0.3216193420753873E+00)
-    assert_allclose(mol.two_mo.shape, (4, 4, 4, 4))
-    assert_allclose(mol.two_mo[0, 0, 0, 0], 0.6527679278914691E+00)
+    core_mo = mol.one_ints['core_mo']
+    assert_equal(core_mo.shape, (4, 4))
+    assert_allclose(core_mo[0, 0], -0.1245406261597530E+01)
+    assert_allclose(core_mo[0, 1], -0.1666402467335385E+00)
+    assert_allclose(core_mo[1, 0], -0.1666402467335385E+00)
+    assert_allclose(core_mo[3, 3], 0.3216193420753873E+00)
+    two_mo = mol.two_ints['two_mo']
+    assert_allclose(two_mo.shape, (4, 4, 4, 4))
+    assert_allclose(two_mo[0, 0, 0, 0], 0.6527679278914691E+00)
     # Check physicist's notation and symmetry
-    assert_allclose(mol.two_mo[3, 0, 2, 1], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[2, 0, 3, 1], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[3, 1, 2, 0], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[2, 1, 3, 0], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[0, 3, 1, 2], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[0, 2, 1, 3], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[1, 3, 0, 2], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[1, 2, 0, 3], 0.7756042287284058E-01)
-    assert_allclose(mol.two_mo[3, 3, 3, 3], 0.7484308847738417E+00)
+    assert_allclose(two_mo[3, 0, 2, 1], 0.7756042287284058E-01)
+    assert_allclose(two_mo[2, 0, 3, 1], 0.7756042287284058E-01)
+    assert_allclose(two_mo[3, 1, 2, 0], 0.7756042287284058E-01)
+    assert_allclose(two_mo[2, 1, 3, 0], 0.7756042287284058E-01)
+    assert_allclose(two_mo[0, 3, 1, 2], 0.7756042287284058E-01)
+    assert_allclose(two_mo[0, 2, 1, 3], 0.7756042287284058E-01)
+    assert_allclose(two_mo[1, 3, 0, 2], 0.7756042287284058E-01)
+    assert_allclose(two_mo[1, 2, 0, 3], 0.7756042287284058E-01)
+    assert_allclose(two_mo[3, 3, 3, 3], 0.7484308847738417E+00)
 
 
 def test_dump_load_fcidimp_consistency_ao(tmpdir):
@@ -89,9 +93,9 @@ def test_dump_load_fcidimp_consistency_ao(tmpdir):
     mol0.nelec = 10
     mol0.spinpol = 0
     with path('iodata.test.data', 'psi4_h2_one.npy') as fn:
-        mol0.one_mo = np.load(str(fn))
+        mol0.one_ints = {'core_mo': np.load(str(fn))}
     with path('iodata.test.data', 'psi4_h2_two.npy') as fn:
-        mol0.two_mo = np.load(str(fn))
+        mol0.two_ints = {'two_mo': np.load(str(fn))}
 
     # Dump to a file and load it again
     fn_tmp = os.path.join(tmpdir, 'FCIDUMP')
@@ -101,5 +105,5 @@ def test_dump_load_fcidimp_consistency_ao(tmpdir):
     # Compare results
     assert_equal(mol0.nelec, mol1.nelec)
     assert_equal(mol0.spinpol, mol1.spinpol)
-    assert_allclose(mol0.one_mo, mol1.one_mo)
-    assert_allclose(mol0.two_mo, mol1.two_mo)
+    assert_allclose(mol0.one_ints['core_mo'], mol1.one_ints['core_mo'])
+    assert_allclose(mol0.two_ints['two_mo'], mol1.two_ints['two_mo'])


### PR DESCRIPTION
The following changes for #41 are included:
- group integral and density matrices into dictionaries.
- group various types of atomic charges into a dict.
- many new attributes documented, which will be used later.
- style fixes: indentation in docstring and alphabetical order.