### PR TITLE
Some more name changes and explicit ghost atoms

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -87,7 +87,7 @@ class Shell(NamedTuple):
     Attributes
     ----------
     icenter
-        An integer referring to a row in the centers array
+        An integer referring to a row in the array atcoords in an IOData object.
     angmoms
         An integer array of angular momentum quantum numbers, non-negative, with
         shape (ncon,).
@@ -140,12 +140,6 @@ class MolecularBasis(NamedTuple):
 
     Attributes
     ----------
-    centers
-        an array with of shape (ncenter, 3). Must be the same as the array
-        of atomic positions (real atoms, ghost atoms and extra point charges)
-        elsewhere in IOData.
-        # TODO: this could be dropped as soon as the atomic positions in IOData
-        # are allowed to contain ghost atoms.
     shells
         a list of objects of the type Shell
     conventions
@@ -171,7 +165,6 @@ class MolecularBasis(NamedTuple):
 
     """
 
-    centers: np.ndarray
     shells: tuple
     conventions: Dict[str, str]
     primitive_normalization: str

--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -114,7 +114,7 @@ def _read_cp2k_contracted_obasis(lit: LineIterator) -> MolecularBasis:
                             [kind] * coeffs.shape[1],
                             exponents, coeffs))
 
-    return MolecularBasis(np.zeros((1, 3)), shells, CONVENTIONS, 'L2')
+    return MolecularBasis(shells, CONVENTIONS, 'L2')
 
 
 def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> MolecularBasis:
@@ -158,7 +158,7 @@ def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> MolecularBasis:
                 0, np.array([angmom]), [kind],
                 np.array([exponent]), np.array([[coeff]])))
 
-    return MolecularBasis(np.zeros((1, 3)), shells, CONVENTIONS, 'L2')
+    return MolecularBasis(shells, CONVENTIONS, 'L2')
 
 
 # pylint: disable=inconsistent-return-statements
@@ -485,7 +485,7 @@ def load(lit: LineIterator) -> dict:
     result = {
         'obasis': obasis,
         'mo': mo,
-        'atcoords': obasis.centers,
+        'atcoords': np.zeros((1, 3), float),
         'atnums': np.array([atnum]),
         'energy': energy,
         'atcorenums': np.array([atcorenum]),

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -115,12 +115,6 @@ def load(lit: LineIterator) -> dict:
     if atfrozen is not None:
         atfrozen = (atfrozen == -2)
         print(atfrozen)
-    # Mask out ghost atoms
-    mask = atcorenums != 0.0
-    atnums = atnums[mask]
-    # Do not overwrite coordinates array, because it is needed to specify basis
-    system_atcoords = atcoords[mask]
-    atcorenums = atcorenums[mask]
 
     # B) Load the orbital basis set
     shell_types = fchk["Shell types"]
@@ -158,14 +152,14 @@ def load(lit: LineIterator) -> dict:
     del nprims
     del exponents
 
-    obasis = MolecularBasis(atcoords, shells, CONVENTIONS, 'L2')
+    obasis = MolecularBasis(shells, CONVENTIONS, 'L2')
 
     result = {
         'title': fchk['title'],
         'energy': fchk['Total Energy'],
         'lot': fchk['lot'].lower(),
         'obasis_name': fchk['obasis_name'].lower(),
-        'atcoords': system_atcoords,
+        'atcoords': atcoords,
         'atnums': atnums,
         'obasis': obasis,
         'atcorenums': atcorenums,
@@ -250,14 +244,13 @@ def load(lit: LineIterator) -> dict:
         result['moments'] = moments
 
     # F) Load optional properties
-    # Mask out ghost atoms from charges
     atcharges = {}
     if 'Mulliken Charges' in fchk:
-        atcharges['mulliken'] = fchk['Mulliken Charges'][mask]
+        atcharges['mulliken'] = fchk['Mulliken Charges']
     if 'ESP Charges' in fchk:
-        atcharges['esp'] = fchk['ESP Charges'][mask]
+        atcharges['esp'] = fchk['ESP Charges']
     if 'NPA Charges' in fchk:
-        atcharges['npa'] = fchk['NPA Charges'][mask]
+        atcharges['npa'] = fchk['NPA Charges']
     if atcharges:
         result['atcharges'] = atcharges
 

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -590,8 +590,9 @@ def dump(f: TextIO, data: 'IOData'):
     """
     # Print the header
     f.write('[Molden Format]\n')
-    f.write('[Title]\n')
-    f.write(' {}\n'.format(getattr(data, 'title', 'Created with HORTON')))
+    if hasattr(data, 'title'):
+        f.write('[Title]\n')
+        f.write(' {}\n'.format(data.title))
 
     # Print the elements numbers and the coordinates
     f.write('[Atoms] AU\n')

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -87,7 +87,7 @@ def _load_helper_obasis(lit: LineIterator) -> MolecularBasis:
             exponents.append(float(words[0]))
             coeffs.append([float(words[1])])
         shells.append(Shell(icenter, [angmom], [kind], np.array(exponents), np.array(coeffs)))
-    return MolecularBasis(np.zeros((icenter + 1, 3)), shells, CONVENTIONS, 'L2')
+    return MolecularBasis(shells, CONVENTIONS, 'L2')
 
 
 def _load_helper_coeffs(lit: LineIterator, nbasis: int) -> Tuple[np.ndarray, np.ndarray]:
@@ -182,7 +182,6 @@ def load(lit: LineIterator) -> dict:
             atnums, atcoords = _load_helper_atoms(lit)
         elif line == '$BASIS':
             obasis = _load_helper_obasis(lit)
-            obasis.centers[:] = atcoords
         elif line == '$COEFF_ALPHA':
             coeff_alpha, ener_alpha = _load_helper_coeffs(lit, obasis.nbasis)
         elif line == '$OCC_ALPHA':

--- a/iodata/formats/orca.py
+++ b/iodata/formats/orca.py
@@ -65,13 +65,11 @@ def load(lit: LineIterator) -> dict:
         if line.startswith('FINAL SINGLE POINT ENERGY'):
             words = line.split()
             result['energy'] = float(words[4])
-        # read also the dipole moment (commented out until key is in iodata)
-        # if line.startswith('Total Dipole Moment'):
-        #    dipole = np.zeros(3)
-        #    dipole[0] = float(words[5])
-        #    dipole[1] = float(words[6])
-        #    dipole[2] = float(words[7])
-        #    result['dipole'] = dipole
+        # Read also the dipole moment
+        if line.startswith('Total Dipole Moment'):
+            words = line.split()
+            dipole = np.array([float(words[4]), float(words[5]), float(words[6])])
+            result['moments'] = {(1, 'c'): dipole}
     return result
 
 

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -200,8 +200,7 @@ def load_wfn_low(lit: LineIterator) -> Tuple:
 
 # pylint: disable=too-many-branches
 def build_obasis(icenters: np.ndarray, type_assignments: np.ndarray,
-                 exponents: np.ndarray, atcoords: np.ndarray,
-                 lit: LineIterator) -> Tuple[MolecularBasis, np.ndarray]:
+                 exponents: np.ndarray, lit: LineIterator) -> Tuple[MolecularBasis, np.ndarray]:
     """Construct a basis set using the arrays read from a WFN file.
 
     Parameters
@@ -214,8 +213,6 @@ def build_obasis(icenters: np.ndarray, type_assignments: np.ndarray,
         is zero.
     exponents
         The Gaussian exponents of all basis functions. shape=(nbasis,)
-    atcoords
-        The positions of all atoms. shape=(natom, 3).
 
     """
     # Build the basis set, keeping track of permutations in case there are
@@ -287,7 +284,7 @@ def build_obasis(icenters: np.ndarray, type_assignments: np.ndarray,
                                 np.array([[1.0]])))
         # Move on to the next contraction
         ibasis += ncart * ncon
-    obasis = MolecularBasis(atcoords, shells, CONVENTIONS, 'L2')
+    obasis = MolecularBasis(shells, CONVENTIONS, 'L2')
     assert obasis.nbasis == nbasis
     return obasis, permutation
 
@@ -310,7 +307,7 @@ def load(lit: LineIterator) -> dict:
     (title, atnums, atcoords, icenters, type_assignments, exponents,
      mo_count, mo_occ, mo_energy, mo_coefficients, energy) = load_wfn_low(lit)
     # Build the basis set and the permutation needed to regroup shells.
-    obasis, permutation = build_obasis(icenters, type_assignments, exponents, atcoords, lit)
+    obasis, permutation = build_obasis(icenters, type_assignments, exponents, lit)
     # Re-order the mo coefficients.
     mo_coefficients = mo_coefficients[permutation]
     # Get the normalization of the un-normalized Cartesian basis functions.

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -150,7 +150,8 @@ class IOData:
         A (N, 3) float array with Cartesian coordinates of the atoms.
 
     atcorenums
-        A (N,) float array with pseudo-potential core charges.
+        A (N,) float array with pseudo-potential core charges. The matrix
+        elements corresponding to ghost atoms are zero.
 
     atforces
         A (N, 3) float array with Cartesian forces on each atom.

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -168,10 +168,8 @@ class IOData:
     cube_data
         A (K, L, M) array of data on a uniform grid (defined by ugrid).
 
-    polar
-        A (3, 3) matrix containing the dipole polarizability tensor.
-
-    **Unspecified type (duck typing):**
+    Attributes without type checking
+    --------------------------------
 
     atcharges
         A dictionary where keys are names of charge definitions and values are
@@ -218,11 +216,28 @@ class IOData:
         three columns for Cartesian X, Y and Z coordinates, last column for the
         actual charge.
 
+    extra
+        A dictionary with additional data loaded from a file. Any data which
+        cannot be assigned to the other attributes belongs here. It may be
+        decided in future to move some of the results from this dictionary to
+        IOData attributes, with a more final name.
+
     g_rot
         The rotational symmetry number of the molecule.
 
+    lot
+        The level of theory used to compute the orbitals (and other properties).
+
     mo
         An instance of MolecularOrbitals.
+
+    moments
+        A dictionary with electrostatic multipole moments. Keys are (angmom,
+        kind) tuples where angmom is an integer for the angular momentum and
+        kind is 'c' for Cartesian or 'p' for pure functions (only for angmom >=
+        2). The corresponding values are 1D numpy arrays. The order of the
+        components of the multipole moments follows the HORTON2_CONVENTIONS from
+        iodata/basis.py
 
     nelec
         The number of electrons.
@@ -326,9 +341,6 @@ class IOData:
     cube_data = ArrayTypeCheckDescriptor(
         'cube_data', 3,
         doc="A (L, M, N) array of data on a uniform grid (defined by ugrid).")
-    polar = ArrayTypeCheckDescriptor(
-        'polar', 2, (3, 3), float,
-        doc="A (3, 3) matrix containing the dipole polarizability tensor.")
 
     @property
     def natom(self) -> int:

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -24,14 +24,14 @@ from scipy.special import factorialk
 
 from .overlap_accel import add_overlap
 from .overlap_helper import tfs
-from .basis import convert_conventions, iter_cart_alphabet
+from .basis import convert_conventions, iter_cart_alphabet, MolecularBasis
 from .basis import HORTON2_CONVENTIONS as OVERLAP_CONVENTIONS
 
 
 __all__ = ['OVERLAP_CONVENTIONS', 'compute_overlap', 'gob_cart_normalization']
 
 
-def compute_overlap(obasis: 'MolecularBasis') -> np.ndarray:
+def compute_overlap(obasis: MolecularBasis, atcoords: np.ndarray) -> np.ndarray:
     r"""Compute overlap matrix for the given molecular basis set.
 
     .. math::
@@ -40,6 +40,13 @@ def compute_overlap(obasis: 'MolecularBasis') -> np.ndarray:
     This function takes into account the requested order of the basis functions
     in ``obasis.conventions``. Note that only L2 normalized primitives are
     supported at the moment.
+
+    Parameters
+    ----------
+    obasis
+        The orbital basis set.
+    atcoords
+        The atomic Cartesian coordinates (including those of ghost atoms).
 
     Returns
     -------
@@ -63,13 +70,13 @@ def compute_overlap(obasis: 'MolecularBasis') -> np.ndarray:
     # Loop over shell0
     begin0 = 0
     for i0, shell0 in enumerate(obasis.shells):
-        r0 = obasis.centers[shell0.icenter]
+        r0 = atcoords[shell0.icenter]
         end0 = begin0 + shell0.nbasis
 
         # Loop over shell1 (lower triangular only, including diagonal)
         begin1 = 0
         for i1, shell1 in enumerate(obasis.shells[:i0 + 1]):
-            r1 = obasis.centers[shell1.icenter]
+            r1 = atcoords[shell1.icenter]
             end1 = begin1 + shell1.nbasis
 
             # START of Cartesian coordinates. Shell types are positive

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -85,8 +85,9 @@ def truncated_file(fn_orig, nline, nadd, tmpdir):
 
 def compare_mols(mol1, mol2):
     """Compare two IOData objects."""
-    assert getattr(mol1, 'title') == getattr(mol2, 'title')
+    assert getattr(mol1, 'title', None) == getattr(mol2, 'title', None)
     assert_equal(mol1.atnums, mol2.atnums)
+    assert_equal(mol1.atcorenums, mol2.atcorenums)
     assert_allclose(mol1.atcoords, mol2.atcoords)
     # orbital basis
     if mol1.obasis is not None:

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -97,7 +97,6 @@ def test_shell_info_propertes():
     assert shells[3].ncon == 1
     assert shells[4].ncon == 3
     obasis = MolecularBasis(
-        None,
         shells,
         {(0, 'c'): ['s'],
          (1, 'c'): ['x', 'z', '-y'],
@@ -116,23 +115,21 @@ def test_shell_exceptions():
 
 
 def test_nbasis1():
-    obasis = MolecularBasis(
-        np.zeros((1, 3)), [
-            Shell(0, [0], ['c'], np.zeros(16), None),
-            Shell(0, [1], ['c'], np.zeros(16), None),
-            Shell(0, [2], ['p'], np.zeros(16), None),
-        ], CP2K_CONVENTIONS, 'L2')
+    obasis = MolecularBasis([
+        Shell(0, [0], ['c'], np.zeros(16), None),
+        Shell(0, [1], ['c'], np.zeros(16), None),
+        Shell(0, [2], ['p'], np.zeros(16), None),
+    ], CP2K_CONVENTIONS, 'L2')
     assert obasis.nbasis == 9
 
 
 def test_get_segmented():
-    obasis0 = MolecularBasis(
-        np.zeros((1, 3)), [
-            Shell(0, [0, 1], ['c', 'c'], np.random.uniform(0, 1, 5),
-                  np.random.uniform(-1, 1, (5, 2))),
-            Shell(1, [2, 3], ['p', 'p'], np.random.uniform(0, 1, 7),
-                  np.random.uniform(-1, 1, (7, 2))),
-        ], CP2K_CONVENTIONS, 'L2')
+    obasis0 = MolecularBasis([
+        Shell(0, [0, 1], ['c', 'c'], np.random.uniform(0, 1, 5),
+              np.random.uniform(-1, 1, (5, 2))),
+        Shell(1, [2, 3], ['p', 'p'], np.random.uniform(0, 1, 7),
+              np.random.uniform(-1, 1, (7, 2))),
+    ], CP2K_CONVENTIONS, 'L2')
     assert obasis0.nbasis == 16
     obasis1 = obasis0.get_segmented()
     assert len(obasis1.shells) == 4
@@ -208,7 +205,6 @@ def test_convert_convention_shell():
 
 def test_convert_convention_obasis():
     obasis = MolecularBasis(
-        None,
         [Shell(0, [0], ['c'], None, None),
          Shell(0, [0, 1], ['c', 'c'], None, None),
          Shell(0, [0, 1], ['c', 'c'], None, None),

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -57,7 +57,7 @@ def test_atom_si_uks():
     assert_equal(mol.obasis.shells[2].angmoms, [2])
     assert mol.obasis.shells[2].kinds == ['p']
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
 
@@ -79,7 +79,7 @@ def test_atom_o_rks():
     assert_equal(mol.obasis.shells[2].angmoms, [2])
     assert mol.obasis.shells[2].kinds == ['p']
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
 
 
@@ -98,7 +98,7 @@ def test_carbon_gs_ae_contracted():
                     [-10.029898, -0.434300, -0.133323, -0.133323, -0.133323])
     assert_allclose(mol.energy, -37.836423363057)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
 
@@ -118,7 +118,7 @@ def test_carbon_gs_ae_uncontracted():
                     [-10.022715, -0.436340, -0.137135, -0.137135, -0.137135])
     assert_allclose(mol.energy, -37.842552743398)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
 
@@ -137,7 +137,7 @@ def test_carbon_gs_pp_contracted():
                     [-0.429657, -0.127060, -0.127060, -0.127060])
     assert_allclose(mol.energy, -5.399938535844)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
 
@@ -156,7 +156,7 @@ def test_carbon_gs_pp_uncontracted():
                     [-0.429358, -0.126411, -0.126411, -0.126411])
     assert_allclose(mol.energy, -5.402288849332)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
 
@@ -171,7 +171,7 @@ def test_carbon_sc_ae_contracted():
     assert_allclose(mol.mo.energies, [-10.067251, -0.495823, -0.187878, -0.187878, -0.187878])
     assert_allclose(mol.energy, -37.793939631890)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
 
 
@@ -185,7 +185,7 @@ def test_carbon_sc_ae_uncontracted():
     assert_allclose(mol.mo.energies, [-10.062206, -0.499716, -0.192580, -0.192580, -0.192580])
     assert_allclose(mol.energy, -37.800453482378)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
 
 
@@ -199,7 +199,7 @@ def test_carbon_sc_pp_contracted():
     assert_allclose(mol.mo.energies, [-0.500732, -0.193138, -0.193138, -0.193138])
     assert_allclose(mol.energy, -5.350765755382)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
 
 
@@ -213,7 +213,7 @@ def test_carbon_sc_pp_uncontracted():
     assert_allclose(mol.mo.energies, [-0.500238, -0.192365, -0.192365, -0.192365])
     assert_allclose(mol.energy, -5.352864672201)
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
 
 

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -201,13 +201,13 @@ def test_load_fchk_lih_321g_hf():
 
 def test_load_fchk_ghost_atoms():
     # Load fchk file with ghost atoms
-    fields = load_fchk_helper_internal('water_dimer_ghost.fchk')
+    mol = load_fchk_helper('water_dimer_ghost.fchk')
     # There should be 3 real atoms and 3 ghost atoms
-    natom, nghost = 3, 3
-    assert_equal(fields['atnums'].shape[0], natom)
-    assert_equal(fields['atcoords'].shape[0], natom)
-    assert_equal(fields['atcharges']['mulliken'].shape[0], natom)
-    assert_equal(fields['obasis'].centers.shape[0], natom + nghost)
+    assert mol.natom == 6
+    assert_equal(mol.atnums, [1, 8, 1, 1, 8, 1])
+    assert_equal(mol.atcorenums, [1.0, 8.0, 1.0, 0.0, 0.0, 0.0])
+    assert_equal(mol.atcoords.shape[0], 6)
+    assert_equal(mol.atcharges['mulliken'].shape[0], 6)
 
 
 def test_load_fchk_ch3_rohf_g03():
@@ -275,7 +275,7 @@ def test_load_nitrogen_mp3():
 def check_normalization_dm_azirine(key):
     """Perform some basic checks on a 2h-azirine fchk file."""
     mol = load_fchk_helper('2h-azirine-{}.fchk'.format(key))
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     dm = mol.one_rdms['post_scf']
     check_dm(dm, olp, eps=1e-2, occ_max=2)
     assert_allclose(np.einsum('ab,ba', olp, dm), 22.0, atol=1.e-3)

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -58,6 +58,9 @@ def load_fchk_helper(fn_fchk):
 def test_load_fchk_hf_sto3g_num():
     mol = load_fchk_helper('hf_sto3g.fchk')
     assert mol.title == 'hf_sto3g'
+    assert mol.run_type == 'energy'
+    assert mol.lot == 'rhf'
+    assert mol.obasis_name == 'sto-3g'
     assert mol.mo.type == 'restricted'
     assert mol.spinpol == 0
     assert mol.obasis.nbasis == 6
@@ -111,13 +114,14 @@ def test_load_fchk_h_sto3g_num():
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
-    fields = load_fchk_helper_internal('o2_cc_pvtz_pure.fchk')
-    assert len(fields['obasis'].shells) == 20
-    assert fields['obasis'].nbasis == 60
-    assert len(fields['atcoords']) == len(fields['atnums'])
-    assert fields['atcoords'].shape[1] == 3
-    assert len(fields['atnums']) == 2
-    assert_allclose(fields['energy'], -1.495944878699246E+02)
+    mol = load_fchk_helper('o2_cc_pvtz_pure.fchk')
+    assert mol.run_type == 'energy'
+    assert mol.lot == 'rhf'
+    assert mol.obasis_name == 'cc-pvtz'
+    assert len(mol.obasis.shells) == 20
+    assert mol.obasis.nbasis == 60
+    assert mol.natom == 2
+    assert_allclose(mol.energy, -1.495944878699246E+02)
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
@@ -295,11 +299,13 @@ def test_normalization_dm_azirine_mp3():
 
 def test_load_water_hfs_321g():
     mol = load_fchk_helper('water_hfs_321g.fchk')
-    assert_allclose(mol.polar[0, 0], 7.23806684E+00)
-    assert_allclose(mol.polar[1, 1], 8.04213953E+00)
-    assert_allclose(mol.polar[1, 2], 1.20021770E-10)
-    assert_allclose(mol.dipole_moment, [-5.82654324E-17, 0.00000000E+00, -8.60777067E-01])
-    assert_allclose(mol.quadrupole_moment,
+    pol = mol.extra['polarizability_tensor']
+    assert_allclose(pol[0, 0], 7.23806684E+00)
+    assert_allclose(pol[1, 1], 8.04213953E+00)
+    assert_allclose(pol[1, 2], 1.20021770E-10)
+    assert_allclose(mol.moments[(1, 'c')],
+                    [-5.82654324E-17, 0.00000000E+00, -8.60777067E-01])
+    assert_allclose(mol.moments[(2, 'c')],
                     [-8.89536026E-01,  # xx
                      8.28408371E-17,  # xy
                      4.89353090E-17,  # xz
@@ -310,8 +316,9 @@ def test_load_water_hfs_321g():
 
 def test_load_monosilicic_acid_hf_lan():
     mol = load_fchk_helper('monosilicic_acid_hf_lan.fchk')
-    assert_allclose(mol.dipole_moment, [-6.05823053E-01, -9.39656399E-03, 4.18948869E-01])
-    assert_allclose(mol.quadrupole_moment,
+    assert_allclose(mol.moments[(1, 'c')],
+                    [-6.05823053E-01, -9.39656399E-03, 4.18948869E-01])
+    assert_allclose(mol.moments[(2, 'c')],
                     [2.73609152E+00,  # xx
                      -6.65787832E-02,  # xy
                      2.11973730E-01,  # xz
@@ -426,6 +433,9 @@ def test_atforces():
 
 def test_athessian():
     mol = load_fchk_helper('peroxide_tsopt.fchk')
+    assert mol.run_type == 'freq'
+    assert mol.lot == 'rhf'
+    assert mol.obasis_name == 'sto-3g'
     assert_allclose(mol.athessian[0, 0], -1.49799052E-02)
     assert_allclose(mol.athessian[-1, -1], 5.83032386E-01)
     assert_allclose(mol.athessian[0, 1], 5.07295215E-05)

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -95,7 +95,7 @@ def test_dm_lih_sto3g_hf():
 def test_dm_ch3_rohf_g03():
     with path('iodata.test.data', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
         mol = load_one(str(fn_fchk))
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     dm = compute_1rdm(mol)
     assert_allclose(np.einsum('ab,ba', olp, dm), 9, atol=1.e-6)
 

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -289,3 +289,7 @@ def test_load_dump_consistency_nh3_molden_pure(tmpdir):
 
 def test_load_dump_consistency_nh3_molden_cart(tmpdir):
     check_load_dump_consistency('nh3_molden_cart.molden', tmpdir)
+
+
+def test_load_dump_consistency_he2_ghost_psi4_1(tmpdir):
+    check_load_dump_consistency('he2_ghost_psi4_1.0.molden', tmpdir)

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -49,7 +49,7 @@ def test_load_molden_li2_orca():
     assert_allclose(mol.atcoords[1], [5.2912331750, 0.0, 0.0])
 
     # Check normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp, 1e-5)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp, 1e-5)
 
@@ -71,7 +71,7 @@ def test_load_molden_h2o_orca():
     assert_allclose(mol.atcoords[2], [0.0, -0.1808833432, 1.9123825806])
 
     # Check normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp, 1e-5)
 
     # Check Mulliken charges
@@ -208,13 +208,12 @@ def test_load_molden_nh3_psi4_1():
 
 def test_load_molden_he2_ghost_psi4_1():
     # The file tested here is created with PSI4 (version 1.0).
-    # It should be read in properly by ignoring the ghost atoms.
     with path('iodata.test.data', 'he2_ghost_psi4_1.0.molden') as fn_molden:
         mol = load_one(str(fn_molden))
-    np.testing.assert_equal(mol.atcorenums, np.array([2.0]))
+    np.testing.assert_equal(mol.atcorenums, np.array([0.0, 2.0]))
     # Check Mulliken charges.
     # Comparison with numbers from the Molden program output.
-    charges = compute_mulliken_charges(mol, np.array([0.0, 2.0]))
+    charges = compute_mulliken_charges(mol)
     molden_charges = np.array([-0.0041, 0.0041])
     assert_allclose(charges, molden_charges, atol=5e-4)
 

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -71,7 +71,7 @@ def test_load_mkl_li2():
     with path('iodata.test.data', 'li2.mkl') as fn_mkl:
         mol = load_one(str(fn_mkl))
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp, 1e-5)
     check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp, 1e-5)
 
@@ -80,5 +80,5 @@ def test_load_mkl_h2():
     with path('iodata.test.data', 'h2_sto3g.mkl') as fn_mkl:
         mol = load_one(str(fn_mkl))
     # check mo normalization
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp, 1e-5)

--- a/iodata/test/test_orca.py
+++ b/iodata/test/test_orca.py
@@ -32,38 +32,12 @@ except ImportError:
 
 
 def test_load_water_number():
-    # test if IOData has atomic numbers
-    with path('iodata.test.data', 'water_orca.out') as fn_xyz:
-        mol = load_one(fn_xyz)
-    check_water(mol)
-
-
-def test_load_water_element():
-    # test if IOData has atomic symbols
-    with path('iodata.test.data', 'water_orca.out') as fn_xyz:
-        mol = load_one(fn_xyz)
-    check_water(mol)
-
-
-def test_load_scf_energy():
-    # test if IOData has the correct energy
-    with path('iodata.test.data', 'water_orca.out') as fn_xyz:
-        mol = load_one(fn_xyz)
-    check_water(mol)
-
-
-def check_water(mol):
-    """Check if atomic numbers and coordinates obtained from orca out file are correct.
-
-    Parameters
-    ----------
-    mol : IOData
-        IOdata dictionary.
-
-    """
-    np.testing.assert_equal(mol.atnums, [8, 1, 1])
+    with path('iodata.test.data', 'water_orca.out') as fn:
+        mol = load_one(fn)
+    # Test atomic numbers and number of atoms
+    assert mol.natom == 3
+    assert_equal(mol.atnums, [8, 1, 1])
     # check bond length
-
     assert_allclose(np.linalg.norm(
         mol.atcoords[0] - mol.atcoords[1]) / angstrom, 0.9500, atol=1.e-5)
     assert_allclose(np.linalg.norm(
@@ -72,10 +46,5 @@ def check_water(mol):
         mol.atcoords[1] - mol.atcoords[2]) / angstrom, 1.5513, atol=1.e-4)
     # check scf energy
     assert_allclose(mol.energy, -74.959292304818, atol=1e-8)
-
-
-def test_helper_number_atoms():
-    # Test if the number of atoms in the ORCA out file is obtained correctly
-    with path('iodata.test.data', 'water_orca.out') as fn_xyz:
-        mol = load_one(str(fn_xyz))
-    assert_equal(mol.natom, 3)
+    # check dipole moment
+    assert_allclose(mol.moments[(1, 'c')], [0.54642, 0.00000, 0.38638])

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -39,16 +39,18 @@ def test_normalization_basics_segmented():
         shells = [Shell(0, [angmom], ['c'], np.array([0.23]), np.array([[1.0]]))]
         if angmom >= 2:
             shells.append(Shell(0, [angmom], ['p'], np.array([0.23]), np.array([[1.0]])))
-        obasis = MolecularBasis(np.zeros((3, 1)), shells, OVERLAP_CONVENTIONS, 'L2')
-        overlap = compute_overlap(obasis)
+        obasis = MolecularBasis(shells, OVERLAP_CONVENTIONS, 'L2')
+        atcoords = np.zeros((3, 1))
+        overlap = compute_overlap(obasis, atcoords)
         assert_allclose(np.diag(overlap), np.ones(obasis.nbasis))
 
 
 def test_normalization_basics_generalized():
     for angmom in range(2, 7):
         shells = [Shell(0, [angmom] * 2, ['c', 'p'], np.array([0.23]), np.array([[1.0, 1.0]]))]
-        obasis = MolecularBasis(np.zeros((3, 1)), shells, OVERLAP_CONVENTIONS, 'L2')
-        overlap = compute_overlap(obasis)
+        obasis = MolecularBasis(shells, OVERLAP_CONVENTIONS, 'L2')
+        atcoords = np.zeros((3, 1))
+        overlap = compute_overlap(obasis, atcoords)
         assert_allclose(np.diag(overlap), np.ones(obasis.nbasis))
 
 
@@ -79,7 +81,7 @@ def test_load_fchk_hf_sto3g_num():
         ref = np.load(str(fn_npy))
     with path('iodata.test.data', 'hf_sto3g.fchk') as fn_fchk:
         data = load_one(fn_fchk)
-    assert_allclose(ref, compute_overlap(data.obasis), rtol=1.e-5, atol=1.e-8)
+    assert_allclose(ref, compute_overlap(data.obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
@@ -88,7 +90,7 @@ def test_load_fchk_o2_cc_pvtz_pure_num():
         ref = np.load(str(fn_npy))
     with path('iodata.test.data', 'o2_cc_pvtz_pure.fchk') as fn_fchk:
         data = load_one(fn_fchk)
-    assert_allclose(ref, compute_overlap(data.obasis), rtol=1.e-5, atol=1.e-8)
+    assert_allclose(ref, compute_overlap(data.obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
@@ -98,10 +100,11 @@ def test_load_fchk_o2_cc_pvtz_cart_num():
     with path('iodata.test.data', 'o2_cc_pvtz_cart.fchk') as fn_fchk:
         data = load_one(fn_fchk)
     obasis = data.obasis._replace(conventions=OVERLAP_CONVENTIONS)
-    assert_allclose(ref, compute_overlap(obasis), rtol=1.e-5, atol=1.e-8)
+    assert_allclose(ref, compute_overlap(obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 
 def test_overlap_l1():
-    dbasis = MolecularBasis(np.zeros((3, 1)), [], {}, 'L1')
+    dbasis = MolecularBasis([], {}, 'L1')
+    atcoords = np.zeros((3, 1))
     with raises(ValueError):
-        _ = compute_overlap(dbasis)
+        _ = compute_overlap(dbasis, atcoords)

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -133,7 +133,7 @@ def check_wfn(fn_wfn, nbasis, energy, charges_mulliken):
     # check number of basis functions
     assert mol.obasis.nbasis == nbasis
     # check orthonormal mo
-    olp = compute_overlap(mol.obasis)
+    olp = compute_overlap(mol.obasis, mol.atcoords)
     if mol.mo.type == 'restricted':
         check_orthonormal(mol.mo.coeffs, olp, 1.e-5)
     elif mol.mo.type == 'unrestricted':


### PR DESCRIPTION
Fixes #41 

Some notable changes related to the last steps of #41.
- `IOData.obasis.centers` is gone and `IOData.atcoords` can be used instead now. They became identical due the way ghost atoms are not treated.
- I've put `polarizability_tensor` in the `extra` dictionary because I'm not too happy with this long name yet. We don't have to guarantee API stability for the extra fields. The way to represent static response properties may need some reconsideration, which can be postponed.