### PR TITLE
Try using attrs module

### DIFF
--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -25,7 +25,8 @@ import numpy as np
 from scipy.special import factorialk
 
 from ..basis import angmom_sti, MolecularBasis, Shell, HORTON2_CONVENTIONS
-from ..utils import LineIterator, MolecularOrbitals
+from ..orbitals import MolecularOrbitals
+from ..utils import LineIterator
 
 
 __all__ = []

--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -25,7 +25,7 @@ import numpy as np
 from scipy.special import factorialk
 
 from ..basis import angmom_sti, MolecularBasis, Shell, HORTON2_CONVENTIONS
-from ..orbitals import MolecularOrbitals
+from ..orbitals import RestrictedOrbitals, UnrestrictedOrbitals
 from ..utils import LineIterator
 
 
@@ -448,20 +448,16 @@ def load_one(lit: LineIterator) -> dict:
 
     # Turn orbital data into a MolecularOrbitals object.
     if restricted:
-        mo_type = 'restricted'
         norb, nel = _get_norb_nel(oe_alpha)
-        norb_alpha = norb_beta = norb
         assert nel % 2 == 0
         orb_alpha_coeffs = np.zeros([obasis.nbasis, norb])
         orb_alpha_energies = np.zeros(norb)
         orb_alpha_occs = np.zeros(norb)
         _fill_orbitals(orb_alpha_coeffs, orb_alpha_energies, orb_alpha_occs,
                        oe_alpha, coeffs_alpha, obasis, restricted)
-        mo_occs = orb_alpha_occs
-        mo_coeffs = orb_alpha_coeffs
-        mo_energy = orb_alpha_energies
+        mo = RestrictedOrbitals(
+            2 * orb_alpha_occs, orb_alpha_coeffs, orb_alpha_energies, None)
     else:
-        mo_type = 'unrestricted'
         norb_alpha = _get_norb_nel(oe_alpha)[0]
         norb_beta = _get_norb_nel(oe_beta)[0]
         assert norb_alpha == norb_beta
@@ -476,12 +472,13 @@ def load_one(lit: LineIterator) -> dict:
         _fill_orbitals(orb_beta_coeffs, orb_beta_energies, orb_beta_occs,
                        oe_beta, coeffs_beta, obasis, restricted)
 
-        mo_occs = np.concatenate((orb_alpha_occs, orb_beta_occs), axis=0)
-        mo_energy = np.concatenate((orb_alpha_energies, orb_beta_energies), axis=0)
-        mo_coeffs = np.concatenate((orb_alpha_coeffs, orb_beta_coeffs), axis=1)
-
-    # create a MO namedtuple
-    mo = MolecularOrbitals(mo_type, norb_alpha, norb_beta, mo_occs, mo_coeffs, None, mo_energy)
+        mo = UnrestrictedOrbitals(
+            norb_alpha,
+            np.concatenate((orb_alpha_occs, orb_beta_occs), axis=0),
+            np.concatenate((orb_alpha_coeffs, orb_beta_coeffs), axis=1),
+            np.concatenate((orb_alpha_energies, orb_beta_energies), axis=0),
+            None,
+        )
 
     result = {
         'obasis': obasis,

--- a/iodata/formats/cube.py
+++ b/iodata/formats/cube.py
@@ -187,6 +187,6 @@ def dump_one(f: TextIO, data: IOData):
         attributes.
 
     """
-    title = getattr(data, 'title', 'Created with IOData')
+    title = data.title or 'Created with IOData'
     _write_cube_header(f, title, data.atcoords, data.atnums, data.cube, data.atcorenums)
     _write_cube_data(f, data.cube.data)

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -249,8 +249,8 @@ def load_many(lit: LineIterator) -> Iterator[dict]:
     ------
     out
         Output dictionary containing ``title``, ``atcoords``, ``atnums``,
-        ``atcorenums``, ``ipoint``, ``npoint``, ``istep``, ``nstep``,
-        ``gradient``, ``reaction_coordinate``, and ``energy``.
+        ``atcorenums``, ``extra`` (with ``ipoint``, ``npoint``, ``istep``,
+        ``nstep``), ``gradient``, ``reaction_coordinate``, and ``energy``.
 
     Trajectories from a Gaussian optimization, relaxed scan or IRC calculation
     are written in groups of frames, called "points" in the Gaussian world, e.g.
@@ -293,16 +293,18 @@ def load_many(lit: LineIterator) -> Iterator[dict]:
                 'title': fchk['title'],
                 'atnums': fchk["Atomic numbers"],
                 'atcorenums': fchk["Nuclear charges"],
-                'ipoint': ipoint,
-                'npoint': len(nsteps),
-                'istep': istep,
-                'nstep': nstep,
                 'energy': energy,
                 'atcoords': atcoords,
                 'atgradient': gradients,
+                'extra': {
+                    'ipoint': ipoint,
+                    'npoint': len(nsteps),
+                    'istep': istep,
+                    'nstep': nstep,
+                },
             }
             if prefix == "IRC point":
-                data['reaction_coordinate'] = recor
+                data['extra']['reaction_coordinate'] = recor
             yield data
 
 

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -195,7 +195,6 @@ def load_one(lit: LineIterator) -> dict:
 
     if 'Beta Orbital Energies' in fchk:
         # unrestricted
-        norbb = fchk['Beta Orbital Energies'].shape[0]
         mo_coeffs_b = np.copy(fchk['Beta MO coefficients'].reshape(nbasis_indep, nbasis).T)
         mo_coeffs = np.concatenate((mo_coeffs, mo_coeffs_b), axis=1)
         mo_energies = np.concatenate((mo_energies, np.copy(fchk['Beta Orbital Energies'])), axis=0)
@@ -205,7 +204,6 @@ def load_one(lit: LineIterator) -> dict:
         mo = UnrestrictedOrbitals(norba, mo_occs, mo_coeffs, mo_energies, None)
     else:
         # restricted closed-shell and open-shell
-        norbb = norba
         mo_occs = np.zeros(nbasis_indep)
         mo_occs[:nalpha] = 1.0
         mo_occs[:nbeta] = 2.0

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -25,7 +25,8 @@ from typing import List, Tuple, Iterator
 import numpy as np
 
 from ..basis import MolecularBasis, Shell, HORTON2_CONVENTIONS
-from ..utils import LineIterator, MolecularOrbitals, amu
+from ..orbitals import MolecularOrbitals
+from ..utils import LineIterator, amu
 
 
 __all__ = []

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -28,7 +28,7 @@ from ..basis import (angmom_its, angmom_sti, MolecularBasis, Shell,
                      convert_conventions, HORTON2_CONVENTIONS)
 from ..iodata import IOData
 from ..periodic import sym2num, num2sym
-from ..orbitals import MolecularOrbitals
+from ..orbitals import RestrictedOrbitals, UnrestrictedOrbitals
 from ..overlap import compute_overlap, gob_cart_normalization
 from ..utils import angstrom, LineIterator
 
@@ -104,12 +104,12 @@ def _load_low(lit: LineIterator) -> dict:
     atnums = None
     atcoords = None
     obasis = None
-    coeff_alpha = None
-    ener_alpha = None
-    occ_alpha = None
-    coeff_beta = None
-    ener_beta = None
-    occ_beta = None
+    coeffsa = None
+    energiesa = None
+    occsa = None
+    coeffsb = None
+    energiesb = None
+    occsb = None
     title = None
 
     line = next(lit)
@@ -154,8 +154,8 @@ def _load_low(lit: LineIterator) -> dict:
         # molecular-orbital coefficients.
         elif line == '[mo]':
             data_alpha, data_beta = _load_helper_coeffs(lit)
-            coeff_alpha, ener_alpha, occ_alpha = data_alpha
-            coeff_beta, ener_beta, occ_beta = data_beta
+            coeffsa, energiesa, occsa = data_alpha
+            coeffsb, energiesb, occsb = data_beta
 
     # Assign pure and Cartesian correctly. This needs to be done after reading
     # because the tags for pure functions may come after the basis set.
@@ -164,25 +164,20 @@ def _load_low(lit: LineIterator) -> dict:
         if shell.angmoms[0] in pure_angmoms:
             shell.kinds[0] = 'p'
 
-    if coeff_beta is None:
-        mo_type = 'restricted'
-        if coeff_alpha.shape[0] != obasis.nbasis:
+    if coeffsb is None:
+        if coeffsa.shape[0] != obasis.nbasis:
             lit.error("Number of alpha orbital coefficients does not match the size of the basis.")
-        norba = norbb = coeff_alpha.shape[1]
-        mo_occs = occ_alpha
-        mo_coeffs = coeff_alpha
-        mo_energy = ener_alpha
+        mo = RestrictedOrbitals(occsa, coeffsa, energiesa, None)
     else:
-        mo_type = 'unrestricted'
-        if coeff_beta.shape[0] != obasis.nbasis:
+        if coeffsb.shape[0] != obasis.nbasis:
             lit.error("Number of beta orbital coefficients does not match the size of the basis.")
-        norba = coeff_alpha.shape[1]
-        norbb = coeff_beta.shape[1]
-        mo_occs = np.concatenate((occ_alpha, occ_beta), axis=0)
-        mo_energy = np.concatenate((ener_alpha, ener_beta), axis=0)
-        mo_coeffs = np.concatenate((coeff_alpha, coeff_beta), axis=1)
-    # create a MO namedtuple
-    mo = MolecularOrbitals(mo_type, norba, norbb, mo_occs, mo_coeffs, None, mo_energy)
+        mo = UnrestrictedOrbitals(
+            coeffsa.shape[1],
+            np.concatenate((occsa, occsb), axis=0),
+            np.concatenate((coeffsa, coeffsb), axis=1),
+            np.concatenate((energiesa, energiesb), axis=0),
+            None
+        )
 
     result = {
         'atcoords': atcoords,
@@ -253,12 +248,12 @@ def _load_helper_obasis(lit: LineIterator) -> MolecularBasis:
 
 def _load_helper_coeffs(lit: LineIterator) -> Tuple:
     """Load the orbital coefficients."""
-    coeff_alpha = []
-    ener_alpha = []
-    occ_alpha = []
-    coeff_beta = []
-    ener_beta = []
-    occ_beta = []
+    coeffsa = []
+    energiesa = []
+    occsa = []
+    coeffsb = []
+    energiesb = []
+    occsb = []
 
     while True:
         try:
@@ -290,13 +285,13 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
         col = []
         # store column of coefficients, i.e. one orbital, energy and occ
         if info['spin'].strip().lower() == 'alpha':
-            coeff_alpha.append(col)
-            ener_alpha.append(energy)
-            occ_alpha.append(occ)
+            coeffsa.append(col)
+            energiesa.append(energy)
+            occsa.append(occ)
         else:
-            coeff_beta.append(col)
-            ener_beta.append(energy)
-            occ_beta.append(occ)
+            coeffsb.append(col)
+            energiesb.append(energy)
+            occsb.append(occ)
         for line in lit:
             words = line.split()
             if len(words) != 2 or not words[0].isdigit():
@@ -306,18 +301,18 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
                 break
             col.append(float(words[1]))
 
-    coeff_alpha = np.array(coeff_alpha).T
-    ener_alpha = np.array(ener_alpha)
-    occ_alpha = np.array(occ_alpha)
-    if not coeff_beta:
-        coeff_beta = None
-        ener_beta = None
-        occ_beta = None
+    coeffsa = np.array(coeffsa).T
+    energiesa = np.array(energiesa)
+    occsa = np.array(occsa)
+    if not coeffsb:
+        coeffsb = None
+        energiesb = None
+        occsb = None
     else:
-        coeff_beta = np.array(coeff_beta).T
-        ener_beta = np.array(ener_beta)
-        occ_beta = np.array(occ_beta)
-    return (coeff_alpha, ener_alpha, occ_alpha), (coeff_beta, ener_beta, occ_beta)
+        coeffsb = np.array(coeffsb).T
+        energiesb = np.array(energiesb)
+        occsb = np.array(occsb)
+    return (coeffsa, energiesa, occsa), (coeffsb, energiesb, occsb)
 
 
 def _is_normalized_properly(obasis: MolecularBasis, atcoords: np.ndarray,
@@ -523,15 +518,12 @@ def _fix_molden_from_buggy_codes(result: dict, filename: str):
     """
     obasis = result['obasis']
     atcoords = result['atcoords']
-    if result['mo'].type == 'restricted':
-        coeffs_a = result['mo'].coeffs
-        coeffs_b = None
-    elif result['mo'].type == 'unrestricted':
-        coeffs_a = result['mo'].coeffs[:, :result['mo'].norba]
-        coeffs_b = result['mo'].coeffs[:, result['mo'].norba:]
-    else:
-        raise ValueError('Molecular orbital type={0} not recognized'.format(result['mo'].type))
-    if _is_normalized_properly(obasis, atcoords, coeffs_a, coeffs_b):
+    coeffsa = result['mo'].coeffsa
+    coeffsb = result['mo'].coeffsb
+    # Skip testing coeffsb if it is the same array as coeffsa.
+    if coeffsa is coeffsb:
+        coeffsb = None
+    if _is_normalized_properly(obasis, atcoords, coeffsa, coeffsb):
         # The file is good. No need to change obasis.
         return
     print('5:Detected incorrect normalization of orbitals loaded from a Molden or MKL file.')
@@ -539,7 +531,7 @@ def _fix_molden_from_buggy_codes(result: dict, filename: str):
     # --- ORCA
     print('5:Trying to fix it as if it was a file generated by ORCA.')
     orca_obasis = _fix_obasis_orca(obasis)
-    if _is_normalized_properly(orca_obasis, atcoords, coeffs_a, coeffs_b):
+    if _is_normalized_properly(orca_obasis, atcoords, coeffsa, coeffsb):
         print('5:Detected typical ORCA errors in file. Fixing them...')
         result['obasis'] = orca_obasis
         return
@@ -548,7 +540,7 @@ def _fix_molden_from_buggy_codes(result: dict, filename: str):
     print('5:Trying to fix it as if it was a file generated by PSI4 (pre 1.0).')
     psi4_obasis = _fix_obasis_psi4(obasis)
     if psi4_obasis is not None and \
-       _is_normalized_properly(psi4_obasis, atcoords, coeffs_a, coeffs_b):
+       _is_normalized_properly(psi4_obasis, atcoords, coeffsa, coeffsb):
         print('5:Detected typical PSI4 errors in file. Fixing them...')
         result['obasis'] = psi4_obasis
         return
@@ -557,7 +549,7 @@ def _fix_molden_from_buggy_codes(result: dict, filename: str):
     print('5:Trying to fix it as if it was a file generated by Turbomole.')
     turbom_obasis = _fix_obasis_turbomole(obasis)
     if turbom_obasis is not None and \
-       _is_normalized_properly(turbom_obasis, atcoords, coeffs_a, coeffs_b):
+       _is_normalized_properly(turbom_obasis, atcoords, coeffsa, coeffsb):
         print('5:Detected typical Turbomole errors in file. Fixing them...')
         result['obasis'] = turbom_obasis
         return
@@ -565,7 +557,7 @@ def _fix_molden_from_buggy_codes(result: dict, filename: str):
     # --- Renormalized contractions
     print('5:Last resort: trying by renormalizing all contractions')
     normed_obasis = _fix_obasis_normalize_contractions(obasis)
-    if _is_normalized_properly(normed_obasis, atcoords, coeffs_a, coeffs_b):
+    if _is_normalized_properly(normed_obasis, atcoords, coeffsa, coeffsb):
         print('5:Detected unnormalized contractions in file. Fixing them...')
         result['obasis'] = normed_obasis
         return
@@ -664,13 +656,12 @@ def dump_one(f: TextIO, data: IOData):
     permutation, signs = convert_conventions(obasis, CONVENTIONS)
 
     # Print the mean-field orbitals
-    if data.mo.type == 'unrestricted':
+    if isinstance(data.mo, UnrestrictedOrbitals):
         f.write('[MO]\n')
-        norba = data.mo.norba
-        _dump_helper_orb(f, 'Alpha', data.mo.energies[:norba], data.mo.occs[:norba],
-                         data.mo.coeffs[:, :norba][permutation] * signs.reshape(-1, 1))
-        _dump_helper_orb(f, 'Beta', data.mo.energies[norba:], data.mo.occs[norba:],
-                         data.mo.coeffs[:, norba:][permutation] * signs.reshape(-1, 1))
+        _dump_helper_orb(f, 'Alpha', data.mo.energiesa, data.mo.occsa,
+                         data.mo.coeffsa[permutation] * signs.reshape(-1, 1))
+        _dump_helper_orb(f, 'Beta', data.mo.energiesb, data.mo.occsb,
+                         data.mo.coeffsb[permutation] * signs.reshape(-1, 1))
     else:
         f.write('[MO]\n')
         _dump_helper_orb(f, 'Alpha', data.mo.energies, data.mo.occs,

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -28,8 +28,9 @@ from ..basis import (angmom_its, angmom_sti, MolecularBasis, Shell,
                      convert_conventions, HORTON2_CONVENTIONS)
 from ..iodata import IOData
 from ..periodic import sym2num, num2sym
+from ..orbitals import MolecularOrbitals
 from ..overlap import compute_overlap, gob_cart_normalization
-from ..utils import angstrom, LineIterator, MolecularOrbitals
+from ..utils import angstrom, LineIterator
 
 
 __all__ = []

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -589,7 +589,7 @@ def dump_one(f: TextIO, data: IOData):
     """
     # Print the header
     f.write('[Molden Format]\n')
-    if hasattr(data, 'title'):
+    if data.title is not None:
         f.write('[Title]\n')
         f.write(' {}\n'.format(data.title))
 
@@ -605,8 +605,8 @@ def dump_one(f: TextIO, data: IOData):
     f.write('\n')
 
     # Print the basis set
-    if not hasattr(data, 'obasis'):
-        raise IOError('A Gaussian orbital basis is required to write a molden input file.')
+    if data.obasis is None:
+        raise IOError('A Gaussian orbital basis is required to write a molden file.')
     obasis = data.obasis
 
     # Figure out the pure/Cartesian situation. Note that the Molden

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -25,7 +25,8 @@ import numpy as np
 
 from .molden import CONVENTIONS, _fix_molden_from_buggy_codes
 from ..basis import angmom_sti, MolecularBasis, Shell
-from ..utils import angstrom, LineIterator, MolecularOrbitals
+from ..orbitals import MolecularOrbitals
+from ..utils import angstrom, LineIterator
 
 
 __all__ = []

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from .molden import CONVENTIONS, _fix_molden_from_buggy_codes
 from ..basis import angmom_sti, MolecularBasis, Shell
-from ..orbitals import MolecularOrbitals
+from ..orbitals import RestrictedOrbitals, UnrestrictedOrbitals
 from ..utils import angstrom, LineIterator
 
 
@@ -162,12 +162,12 @@ def load_one(lit: LineIterator) -> dict:
     atnums = None
     atcoords = None
     obasis = None
-    coeff_alpha = None
-    ener_alpha = None
-    occ_alpha = None
-    coeff_beta = None
-    ener_beta = None
-    occ_beta = None
+    coeffsa = None
+    energiesa = None
+    occsa = None
+    coeffsb = None
+    energiesb = None
+    occsb = None
     # Using a loop because we're not entirely sure if sections in an MKL file
     # have a fixed order.
     while True:
@@ -184,13 +184,13 @@ def load_one(lit: LineIterator) -> dict:
         elif line == '$BASIS':
             obasis = _load_helper_obasis(lit)
         elif line == '$COEFF_ALPHA':
-            coeff_alpha, ener_alpha = _load_helper_coeffs(lit, obasis.nbasis)
+            coeffsa, energiesa = _load_helper_coeffs(lit, obasis.nbasis)
         elif line == '$OCC_ALPHA':
-            occ_alpha = _load_helper_occ(lit)
+            occsa = _load_helper_occ(lit)
         elif line == '$COEFF_BETA':
-            coeff_beta, ener_beta = _load_helper_coeffs(lit, obasis.nbasis)
+            coeffsb, energiesb = _load_helper_coeffs(lit, obasis.nbasis)
         elif line == '$OCC_BETA':
-            occ_beta = _load_helper_occ(lit)
+            occsb = _load_helper_occ(lit)
 
     if charge is None:
         lit.error('Charge and spin polarization not found.')
@@ -198,40 +198,35 @@ def load_one(lit: LineIterator) -> dict:
         lit.error('Coordinates not found.')
     if obasis is None:
         lit.error('Orbital basis not found.')
-    if coeff_alpha is None:
+    if coeffsa is None:
         lit.error('Alpha orbitals not found.')
-    if occ_alpha is None:
+    if occsa is None:
         lit.error('Alpha occupation numbers not found.')
 
     nelec = atnums.sum() - charge
-    if coeff_beta is None:
+    if coeffsb is None:
         # restricted closed-shell
-        mo_type = 'restricted'
         assert nelec % 2 == 0
-        assert abs(occ_alpha.sum() - nelec) < 1e-7
-        norba = norbb = coeff_alpha.shape[1]
-        mo_occs = occ_alpha
-        mo_coeffs = coeff_alpha
-        mo_energy = ener_alpha
+        assert abs(occsa.sum() - nelec) < 1e-7
+        mo = RestrictedOrbitals(occsa, coeffsa, energiesa, None)
     else:
-        mo_type = 'unrestricted'
-        if occ_beta is None:
+        if occsb is None:
             lit.error('Beta occupation numbers not found in mkl file while '
                       'beta orbitals were present.')
-        nalpha = int(np.round(occ_alpha.sum()))
-        nbeta = int(np.round(occ_beta.sum()))
+        nalpha = int(np.round(occsa.sum()))
+        nbeta = int(np.round(occsb.sum()))
         assert abs(spinpol - abs(nalpha - nbeta)) < 1e-7
         assert nelec == nalpha + nbeta
-        assert coeff_alpha.shape == coeff_beta.shape
-        assert ener_alpha.shape == ener_beta.shape
-        assert occ_alpha.shape == occ_beta.shape
-        norba = coeff_alpha.shape[1]
-        norbb = coeff_beta.shape[1]
-        mo_occs = np.concatenate((occ_alpha, occ_beta), axis=0)
-        mo_energy = np.concatenate((ener_alpha, ener_beta), axis=0)
-        mo_coeffs = np.concatenate((coeff_alpha, coeff_beta), axis=1)
-    # create a MO namedtuple
-    mo = MolecularOrbitals(mo_type, norba, norbb, mo_occs, mo_coeffs, None, mo_energy)
+        assert coeffsa.shape == coeffsb.shape
+        assert energiesa.shape == energiesb.shape
+        assert occsa.shape == occsb.shape
+        mo = UnrestrictedOrbitals(
+            coeffsa.shape[1],
+            np.concatenate((occsa, occsb), axis=0),
+            np.concatenate((coeffsa, coeffsb), axis=1),
+            np.concatenate((energiesa, energiesb), axis=0),
+            None
+        )
 
     result = {
         'atcoords': atcoords,

--- a/iodata/formats/molpro.py
+++ b/iodata/formats/molpro.py
@@ -135,19 +135,18 @@ def dump_one(f: TextIO, data: IOData):
 
     """
     one_mo = data.one_ints['core_mo']
-    two_mo = data.two_ints['two_mo']
-    nactive = one_mo.shape[0]
-    core_energy = getattr(data, 'core_energy', 0.0)
-    nelec = getattr(data, 'nelec', 0)
-    spinpol = getattr(data, 'spinpol', 0)
 
     # Write header
+    nactive = one_mo.shape[0]
+    nelec = data.nelec or 0
+    spinpol = data.spinpol or 0
     print(f' &FCI NORB={nactive:d},NELEC={nelec:d},MS2={spinpol:d},', file=f)
     print(f"  ORBSYM= {','.join('1' for v in range(nactive))},", file=f)
     print('  ISYM=1', file=f)
     print(' &END', file=f)
 
     # Write integrals and core energy
+    two_mo = data.two_ints['two_mo']
     for i in range(nactive):  # pylint: disable=too-many-nested-blocks
         for j in range(i + 1):
             for k in range(nactive):
@@ -161,5 +160,5 @@ def dump_one(f: TextIO, data: IOData):
             value = one_mo[i, j]
             if value != 0.0:
                 print(f'{value:23.16e} {i+1:4d} {j+1:4d} {0:4d} {0:4d}', file=f)
-    if core_energy != 0.0:
-        print(f'{core_energy:23.16e} {0:4d} {0:4d} {0:4d} {0:4d}', file=f)
+    if data.core_energy is not None:
+        print(f'{data.core_energy:23.16e} {0:4d} {0:4d} {0:4d} {0:4d}', file=f)

--- a/iodata/formats/poscar.py
+++ b/iodata/formats/poscar.py
@@ -90,8 +90,9 @@ def dump_one(f: TextIO, data: IOData):
     print('Direct', file=f)
 
     # Write the coordinates
+    gvecs = np.linalg.inv(data.cellvecs).T
     for uatnum in uatnums:
         indexes = (data.atnums == uatnum).nonzero()[0]
         for index in indexes:
-            row = np.dot(data.gvecs, data.atcoords[index])
+            row = np.dot(gvecs, data.atcoords[index])
             print(f'  {row[0]: 21.16f} {row[1]: 21.16f} {row[2]: 21.16f}   F   F   F', file=f)

--- a/iodata/formats/poscar.py
+++ b/iodata/formats/poscar.py
@@ -72,7 +72,7 @@ def dump_one(f: TextIO, data: IOData):
         ``cellvecs`` attributes. It may contain ``title`` attribute.
 
     """
-    print(getattr(data, 'title', 'Created with HORTON'), file=f)
+    print(data.title or 'Created with IOData', file=f)
     print('   1.00000000000000', file=f)
 
     # Write cell vectors, each row is one vector in angstrom:

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -26,7 +26,8 @@ import numpy as np
 from ..basis import MolecularBasis, Shell
 from ..overlap import gob_cart_normalization
 from ..periodic import sym2num
-from ..utils import MolecularOrbitals, LineIterator
+from ..orbitals import MolecularOrbitals
+from ..utils import LineIterator
 
 
 __all__ = []

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -26,7 +26,7 @@ import numpy as np
 from ..basis import MolecularBasis, Shell
 from ..overlap import gob_cart_normalization
 from ..periodic import sym2num
-from ..orbitals import MolecularOrbitals
+from ..orbitals import RestrictedOrbitals, UnrestrictedOrbitals
 from ..utils import LineIterator
 
 
@@ -328,23 +328,17 @@ def load_one(lit: LineIterator) -> dict:
     mo_coefficients /= scales.reshape(-1, 1)
     # make the wavefunction
     if mo_occ.max() > 1.0:
-        # close shell system
-        mo_type = 'restricted'
-        na_orb = len(mo_occ)
-        nb_orb = len(mo_occ)
+        # closed-shell system
+        mo = RestrictedOrbitals(mo_occ, mo_coefficients, mo_energy, None)
     else:
-        # open shell system
-        mo_type = 'unrestricted'
-        # counting the number of alpha and beta orbitals
-        n = 1
-        while (n < mo_coefficients.shape[1]
-               and mo_energy[n] >= mo_energy[n - 1]
-               and mo_count[n] == mo_count[n - 1] + 1):
-            n += 1
-        na_orb = n
-        nb_orb = len(mo_occ) - n
-    # create a MO namedtuple
-    mo = MolecularOrbitals(mo_type, na_orb, nb_orb, mo_occ, mo_coefficients, None, mo_energy)
+        # open-shell system
+        # counting the number of alpha orbitals
+        norba = 1
+        while (norba < mo_coefficients.shape[1]
+               and mo_energy[norba] >= mo_energy[norba - 1]
+               and mo_count[norba] == mo_count[norba - 1] + 1):
+            norba += 1
+        mo = UnrestrictedOrbitals(norba, mo_occ, mo_coefficients, mo_energy, None)
 
     result = {
         'title': title,

--- a/iodata/formats/xyz.py
+++ b/iodata/formats/xyz.py
@@ -109,7 +109,7 @@ def dump_one(f: TextIO, data: IOData):
 
     """
     print(data.natom, file=f)
-    print(getattr(data, 'title', 'Created with IODATA module'), file=f)
+    print(data.title or 'Created with IOData', file=f)
     for i in range(data.natom):
         n = num2sym[data.atnums[i]]
         x, y, z = data.atcoords[i] / angstrom

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -313,7 +313,12 @@ class IOData:
 
     @property
     def spinpol(self) -> float:
-        """Return the spin multiplicity."""
+        """Return the spin polarization.
+
+        Warning: for restricted wavefunctions, it is assumed that an occupation
+        number in ]0, 2[ implies spin polarizaiton, which may not always be a
+        valid assumption.
+        """
         if self.mo is None:
             return self._spinpol
         return self.mo.spinpol

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -19,101 +19,46 @@
 """Module for handling input/output from different file formats."""
 
 
-from typing import List, Tuple, Type
-
+import attr
 import numpy as np
+
+from .basis import MolecularBasis
+from .orbitals import Orbitals
+from .utils import Cube
 
 
 __all__ = ['IOData']
 
 
-class ArrayTypeCheckDescriptor:
-    """A type checker for IOData attributes."""
-
-    def __init__(self, name: str, ndim: int = None, shape: Tuple = None, dtype: Type = None,
-                 matching: List[str] = None, default: str = None, doc=None):
-        """Initialize decorator to perform type and shape checking of np.ndarray attributes.
-
-        Parameters
-        ----------
-        name
-            Name of the attribute (without leading underscores).
-        ndim
-            The number of dimensions of the array.
-        shape
-            The shape of the array. Use -1 for dimensions where the shape is
-            not fixed a priori.
-        dtype
-            The datatype of the array.
-        matching
-            A list of names of other attributes that must have consistent
-            shapes. This argument requires that the shape is specified.
-            All dimensions for which the shape tuple equals -1 are must be
-            the same in this attribute and the matching attributes.
-        default
-            The name of another (type-checked) attribute to return as default
-            when this attribute is not set
-
-        """
-        if matching is not None and shape is None:
-            raise TypeError('The matching argument requires the shape to be specified.')
-
-        self._name = name
-        self._ndim = ndim
-        self._shape = shape
-        if dtype is None:
-            self._dtype = None
-        else:
-            self._dtype = np.dtype(dtype)
-        self._matching = matching
-        self._default = default
-        self.__doc__ = doc or 'A type-checked attribute'
-
-    def __get__(self, instance, owner):
-        if instance is None:
-            return self
-        if self._default is not None and not hasattr(instance, '_' + self._name):
-            # When the attribute is not present, we assign it first with the
-            # default value. The return statement can then remain completely
-            # general.
-            default = (getattr(instance, '_' + self._default).astype(self._dtype))
-            setattr(instance, '_' + self._name, default)
-        return getattr(instance, '_' + self._name)
-
-    def __set__(self, obj, value):
-        # try casting to proper dtype:
-        value = np.array(value, dtype=self._dtype, copy=False)
-        # if not isinstance(value, np.ndarray):
-        #    raise TypeError('Attribute \'%s\' of \'%s\' must be a numpy '
-        #                    'array.' % (self._name, type(obj)))
-        if self._ndim is not None and value.ndim != self._ndim:
-            raise TypeError(f"Attribute '{self._name}' of '{type(obj)}' must be a numpy array "
-                            f"with {self._ndim} dimension(s).")
-        if self._shape is not None:
-            for i in range(len(self._shape)):
-                if self._shape[i] >= 0 and self._shape[i] != value.shape[i]:
-                    raise TypeError(f"Attribute '{self._name}' of '{type(obj)}' must be a numpy"
-                                    f" array {self._shape[i]} elements in dimension {i}.")
-        if self._dtype is not None:
-            if not issubclass(value.dtype.type, self._dtype.type):
-                raise TypeError(f"Attribute '{self._name}' of '{type(obj)}' must be a numpy "
-                                f"array with dtype '{self._dtype.type}'.")
-        if self._matching is not None:
-            for othername in self._matching:
-                other = getattr(obj, '_' + othername, None)
-                if other is not None:
-                    for i in range(len(self._shape)):
-                        if self._shape[i] == -1 and \
-                                other.shape[i] != value.shape[i]:
-                            raise TypeError(f"shape[{i}] of attribute '{self._name}' of "
-                                            f"'{type(obj)}' in is incompatible with "
-                                            f"that of '{othername}'.")
-        setattr(obj, '_' + self._name, value)
-
-    def __delete__(self, obj):
-        delattr(obj, '_' + self._name)
+def convert_array_to(dtype):
+    """Return a function to convert arrays to the given type."""
+    def converter(array):
+        if array is None:
+            return None
+        return np.array(array, copy=False, dtype=dtype)
+    return converter
 
 
+def validate_shape(*shape):
+    """Return a function to validate the shape of an array."""
+    def validator(obj, attrname, value):
+        if value is None:
+            return
+        myshape = tuple([obj.natom if size == 'natom' else size for size in shape])
+        if len(myshape) != len(value.shape):
+            raise TypeError('Expect ndim {} for attribute {}, got {}'.format(
+                len(myshape), attrname, len(value.shape)))
+        for axis, size in enumerate(myshape):
+            if size is None:
+                continue
+            if size != value.shape[axis]:
+                raise TypeError(
+                    'Expect size {} for axis {} of attribute {}, got {}'.format(
+                        size, axis, attrname, value.shape[axis]))
+    return validator
+
+
+@attr.s(auto_attribs=True, slots=True)
 class IOData:
     """A container class for data loaded from (or to be written to) a file.
 
@@ -122,41 +67,35 @@ class IOData:
     set are removed after the IOData instance is constructed. The following
     attributes are supported by at least one of the io formats:
 
-    Type checked array attributes (if present)
-    ------------------------------------------
-
+    Attributes
+    ----------
+    atcharges
+        A dictionary where keys are names of charge definitions and values are
+        arrays with atomic charges (size N).
     atcoords
         A (N, 3) float array with Cartesian coordinates of the atoms.
     atcorenums
         A (N,) float array with pseudo-potential core charges. The matrix
         elements corresponding to ghost atoms are zero.
-    atfrozen
-        A (N,) bool array with frozen atoms. (All atoms are free if this
-        attribute is not set.)
-    atgradient
-        A (N, 3) float array with the first derivatives of the energy w.r.t.
-        Cartesian atomic displacements.
-    atmasses
-        A (N,) float array with atomic masses
-
-    atnums
-        A (N,) int vector with the atomic numbers.
-
-    Attributes without type checking
-    --------------------------------
-
-    atcharges
-        A dictionary where keys are names of charge definitions and values are
-        arrays with atomic charges (size N).
     atffparams
         A dictionary with arrays of atomic force field parameters (typically
         non-bonded). Keys include 'charges', 'vdw_radii', 'sigmas', 'epsilons',
         'alphas' (atomic polarizabilities), 'c6s', 'c8s', 'c10s', 'buck_as',
         'buck_bs', 'lj_as', 'core_charges', 'valence_charges', 'valence_widths',
         etc. Not all of them have to be present, depending on the use case.
+    atfrozen
+        A (N,) bool array with frozen atoms. (All atoms are free if this
+        attribute is not set.)
+    atgradient
+        A (N, 3) float array with the first derivatives of the energy w.r.t.
+        Cartesian atomic displacements.
     athessian
         A (3*N, 3*N) array containing the energy Hessian w.r.t Cartesian atomic
         displacements.
+    atmasses
+        A (N,) float array with atomic masses
+    atnums
+        A (N,) int vector with the atomic numbers.
     basisdef
         A basis set definition, i.e. a dictionary whose keys are symbols (of
         chemical elements), atomic numbers (similar to previous, str to make
@@ -173,6 +112,8 @@ class IOData:
         periodic boundary conditions. A single vector corresponds to a 1D cell,
         e.g. for a wire. Two vectors describe a 2D cell, e.g. for a membrane.
         Three vectors describe a 3D cell, e.g. a crystalline solid.
+    charge
+        The net charge of the system.
     core_energy
         The Hartree-Fock energy due to the core orbitals
     cube
@@ -252,111 +193,134 @@ class IOData:
 
     """
 
-    def __init__(self, **kwargs):
-        """Initialize an IOData instance.
+    atcharges: dict = {}
+    atcoords: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape('natom', 3))
+    _atcorenums: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape('natom'))
+    atffparams: dict = {}
+    atfrozen: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(bool),
+        validator=validate_shape('natom'))
+    atgradient: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape('natom', 3))
+    athessian: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape(None, None))
+    atmasses: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape('natom'))
+    atnums: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(int),
+        validator=validate_shape('natom'))
+    basisdef: str = None
+    bonds: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(int),
+        validator=validate_shape(None, 3))
+    cellvecs: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape(None, 3))
+    _charge: float = None
+    core_energy: float = None
+    cube: Cube = None
+    energy: float = None
+    extcharges: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=validate_shape(None, 4))
+    extra: dict = {}
+    g_rot: float = None
+    lot: str = None
+    mo: Orbitals = None
+    moments: dict = {}
+    _nelec: float = None
+    obasis: MolecularBasis = None
+    obasis_name: str = None
+    one_ints: dict = {}
+    one_rdms: dict = {}
+    run_type: str = None
+    _spinpol: float = None
+    title: str = None
+    two_ints: dict = {}
+    two_rdms: dict = {}
 
-        All keyword arguments will be turned into corresponding attributes.
-        """
-        for key, value in kwargs.items():
-            setattr(self, key, value)
+    # Public interfaces to private attributes
 
-    # only perform type checking on some attributes
-    atcoords = ArrayTypeCheckDescriptor(
-        'atcoords', 2, (-1, 3), float,
-        ['atcorenums', 'atgradient', 'atfrozen', 'atmasses', 'atnums'],
-        doc="A (N, 3) float array with Cartesian coordinates of the atoms.")
-    atcorenums = ArrayTypeCheckDescriptor(
-        'atcorenums', 1, (-1,), float,
-        ['atcoords', 'atgradient', 'atfrozen', 'atmasses', 'atnums'],
-        'atnums',
-        doc="A (N,) float array with pseudo-potential core charges.")
-    atgradient = ArrayTypeCheckDescriptor(
-        'atgradient', 2, (-1, 3), float,
-        ['atcoords', 'atcorenums', 'atfrozen', 'atmasses', 'atnums'],
-        doc="A (N, 3) float array with Cartesian atomic forces.")
-    atfrozen = ArrayTypeCheckDescriptor(
-        'atfrozen', 1, (-1,), bool,
-        ['atcoords', 'atcorenums', 'atgradient', 'atmasses', 'atnums'],
-        doc="A (N,) boolean array flagging fixed atoms.")
-    atmasses = ArrayTypeCheckDescriptor(
-        'atmasses', 1, (-1,), float,
-        ['atcoords', 'atcorenums', 'atgradient', 'atfrozen', 'atnums'],
-        doc="A (N,) float array with atomic masses.")
-    atnums = ArrayTypeCheckDescriptor(
-        'atnums', 1, (-1,), int,
-        ['atcoords', 'atcorenums', 'atgradient', 'atfrozen', 'atmasses'],
-        doc="A (N,) int vector with the atomic numbers.")
+    @property
+    def atcorenums(self) -> np.ndarray:
+        """Return effective core charges."""
+        result = self._atcorenums
+        if result is None and self.atnums is not None:
+            # Known bug in pylint. See
+            # https://stackoverflow.com/questions/47972143/using-attr-with-pylint
+            # https://github.com/PyCQA/pylint/issues/1694
+            # pylint: disable=no-member
+            result = self.atnums.astype(float)
+            self._atcorenums = result
+        return result
+
+    @atcorenums.setter
+    def atcorenums(self, atcorenums):
+        self._atcorenums = atcorenums
+
+    @property
+    def charge(self) -> float:
+        """Return the net charge of the system."""
+        if self.atcorenums is None:
+            return self._charge
+        return self.atcorenums.sum() - self.nelec
+
+    @charge.setter
+    def charge(self, charge: float):
+        if self.atcorenums is None:
+            self._charge = charge
+        else:
+            self.nelec = self.atcorenums.sum() - charge
 
     @property
     def natom(self) -> int:
         """Return the number of atoms."""
-        if hasattr(self, 'atcoords'):
-            return len(self.atcoords)
-        if hasattr(self, 'atcorenums'):
-            return len(self.atcorenums)
-        if hasattr(self, 'atgradient'):
-            return len(self.atgradient)
-        if hasattr(self, 'atfrozen'):
-            return len(self.atfrozen)
-        if hasattr(self, 'atmasses'):
-            return len(self.atmasses)
-        if hasattr(self, 'atnums'):
-            return len(self.atnums)
-        raise AttributeError("Cannot determine the number of atoms.")
+        natom = None
+        if self.atcoords is not None:
+            natom = len(self.atcoords)
+        elif self.atcorenums is not None:
+            natom = len(self.atcorenums)
+        elif self.atgradient is not None:
+            natom = len(self.atgradient)
+        elif self.atfrozen is not None:
+            natom = len(self.atfrozen)
+        elif self.atmasses is not None:
+            natom = len(self.atmasses)
+        elif self.atnums is not None:
+            natom = len(self.atnums)
+        return natom
 
     @property
     def nelec(self) -> float:
         """Return the number of electrons."""
-        mo = getattr(self, 'mo', None)
-        if mo is None:
+        if self.mo is None:
             return self._nelec
-        return mo.nelec
+        return self.mo.nelec
 
     @nelec.setter
     def nelec(self, nelec: float):
-        mo = getattr(self, 'mo', None)
-        if mo is None:
-            # We need to fix the following together with all the no-member
-            # warnings, see https://github.com/theochem/iodata/issues/73
-            # pylint: disable=attribute-defined-outside-init
+        if self.mo is None:
             self._nelec = nelec
         else:
             raise TypeError("nelec cannot be set when orbitals are present.")
 
     @property
-    def charge(self) -> float:
-        """Return the net charge of the system."""
-        atcorenums = getattr(self, 'atcorenums', None)
-        if atcorenums is None:
-            return self._charge
-        return atcorenums.sum() - self.nelec
-
-    @charge.setter
-    def charge(self, charge: float):
-        atcorenums = getattr(self, 'atcorenums', None)
-        if atcorenums is None:
-            # We need to fix the following together with all the no-member
-            # warnings, see https://github.com/theochem/iodata/issues/73
-            # pylint: disable=attribute-defined-outside-init
-            self._charge = charge
-        else:
-            self.nelec = atcorenums.sum() - charge
-
-    @property
     def spinpol(self) -> float:
         """Return the spin multiplicity."""
-        mo = getattr(self, 'mo', None)
-        if mo is None:
+        if self.mo is None:
             return self._spinpol
-        return mo.spinpol
+        return self.mo.spinpol
 
     @spinpol.setter
     def spinpol(self, spinpol: float):
-        mo = getattr(self, 'mo', None)
-        if mo is None:
-            # We need to fix the following together with all the no-member
-            # warnings, see https://github.com/theochem/iodata/issues/73
-            # pylint: disable=attribute-defined-outside-init
+        if self.mo is None:
             self._spinpol = spinpol
         else:
             raise TypeError("spinpol cannot be set when orbitals are present.")

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -75,7 +75,15 @@ class Orbitals:
 
 @attr.s(auto_attribs=True)
 class RestrictedOrbitals(Orbitals):
-    """Restricted Orbitals class."""
+    """Restricted Orbitals class.
+
+    Warning: the interpretation of the occupation numbers may only be suitable
+    for single-reference orbitals (not fractionally occupied natural orbitals.)
+    When an occupation number is in ]0, 1], it is assumed that an alpha orbital
+    is (fractionally) occupied. When an occupation number is in ]1, 2], it is
+    assumed that the alpha orbital is fully occupied and the beta orbital is
+    (fractionally) occupied.
+    """
 
     @property
     def spinpol(self) -> float:

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -1,0 +1,83 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Data structure for molecular orbitals."""
+
+
+from typing import NamedTuple
+
+import numpy as np
+
+
+__all__ = ['MolecularOrbitals']
+
+
+class MolecularOrbitals(NamedTuple):
+    """Molecular Orbitals Class.
+
+    Attributes
+    ----------
+    type : str
+        Molecular orbital type; choose from 'restricted', 'unrestricted', or 'generalized'.
+    norba : int
+        Number of alpha molecular orbitals. None in case of type=='generalized'.
+    norbb : int
+        Number of beta molecular orbitals. None in case of type=='generalized'.
+    occs : np.ndarray
+        Molecular orbital occupation numbers. The number of elements equals the
+        number of columns of coeffs.
+    coeffs : np.ndarray
+        Molecular orbital basis coefficients.
+        In case of restricted: shape = (nbasis, norb_a) = (nbasis, norb_b).
+        In case of unrestricted: shape = (nbasis, norb_a + norb_b).
+        In case of generalized: shape = (2*nbasis, norb), where norb is the
+        total number of orbitals (not defined by other attributes).
+    irreps : np.ndarray
+        Irreducible representation. The number of elements equals the
+        number of columns of coeffs.
+    energies : np.ndarray
+        Molecular orbital energies. The number of elements equals the
+        number of columns of coeffs.
+
+    """
+
+    type: str
+    norba: int
+    norbb: int
+    occs: np.ndarray
+    coeffs: np.ndarray
+    irreps: np.ndarray
+    energies: np.ndarray
+
+    @property
+    def nelec(self) -> float:
+        """Return the total number of electrons."""
+        return self.occs.sum()
+
+    @property
+    def spinpol(self) -> float:
+        """Return the spin multiplicity of the Slater determinant."""
+        if self.type == 'restricted':
+            nbeta = np.clip(self.occs, 0, 1).sum()
+            sq = self.nelec - 2 * nbeta
+        elif self.type == 'unrestricted':
+            sq = self.occs[:self.norba].sum() - self.occs[self.norba:].sum()
+        else:
+            # Not sure how to do this in a simply way.
+            raise NotImplementedError
+        return abs(sq)

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -109,7 +109,6 @@ def compare_mols(mol1, mol2):
         assert mol2.obasis is None
     # wfn
     permutation, signs = convert_conventions(mol1.obasis, mol2.obasis.conventions)
-    assert mol1.mo.type == mol2.mo.type
     assert_allclose(mol1.mo.occs, mol2.mo.occs)
     assert_allclose(mol1.mo.energies, mol2.mo.energies)
     assert_allclose(mol1.mo.coeffs[permutation] * signs.reshape(-1, 1), mol2.mo.coeffs, atol=1e-8)

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -85,7 +85,7 @@ def truncated_file(fn_orig, nline, nadd, tmpdir):
 
 def compare_mols(mol1, mol2):
     """Compare two IOData objects."""
-    assert getattr(mol1, 'title', None) == getattr(mol2, 'title', None)
+    assert mol1.title == mol2.title
     assert_equal(mol1.atnums, mol2.atnums)
     assert_equal(mol1.atcorenums, mol2.atcorenums)
     assert_allclose(mol1.atcoords, mol2.atcoords)
@@ -120,8 +120,8 @@ def compare_mols(mol1, mol2):
         ('one_rdms', ['scf', 'scf_spin', 'post_scf', 'post_scf_spin']),
     ]
     for attrname, keys in cases:
-        d1 = getattr(mol1, attrname, {})
-        d2 = getattr(mol2, attrname, {})
+        d1 = getattr(mol1, attrname)
+        d2 = getattr(mol2, attrname)
         for key in keys:
             if key in d1:
                 assert key in d2

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -110,8 +110,9 @@ def compare_mols(mol1, mol2):
     # wfn
     permutation, signs = convert_conventions(mol1.obasis, mol2.obasis.conventions)
     assert_allclose(mol1.mo.occs, mol2.mo.occs)
-    assert_allclose(mol1.mo.energies, mol2.mo.energies)
     assert_allclose(mol1.mo.coeffs[permutation] * signs.reshape(-1, 1), mol2.mo.coeffs, atol=1e-8)
+    assert_allclose(mol1.mo.energies, mol2.mo.energies)
+    assert_equal(mol1.mo.irreps, mol2.mo.irreps)
     # operators and density matrices
     cases = [
         ('one_ints', ['olp', 'kin_ao', 'na_ao']),

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.chgcar module."""
 
 import numpy as np

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -26,6 +26,7 @@ from numpy.testing import assert_equal, assert_allclose
 from .common import truncated_file, check_orthonormal
 
 from ..api import load_one
+from ..orbitals import UnrestrictedOrbitals, RestrictedOrbitals
 from ..overlap import compute_overlap
 
 try:
@@ -34,20 +35,17 @@ except ImportError:
     from importlib.resources import path
 
 
-# TODO: add more obasis tests?
-
-
 def test_atom_si_uks():
     with path('iodata.test.data', 'atom_si.cp2k.out') as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [14])
     assert_equal(mol.atcorenums, [4])
-    assert mol.mo.type == 'unrestricted'
-    assert_equal(mol.mo.occs[:mol.mo.norba], [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
-    assert_equal(mol.mo.occs[mol.mo.norba:], [1, 0, 0, 0])
-    assert_allclose(mol.mo.energies[:mol.mo.norba],
+    assert isinstance(mol.mo, UnrestrictedOrbitals)
+    assert_equal(mol.mo.occsa, [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
+    assert_equal(mol.mo.occsb, [1, 0, 0, 0])
+    assert_allclose(mol.mo.energiesa,
                     [-0.398761, -0.154896, -0.154896, -0.154896], atol=1.e-4)
-    assert_allclose(mol.mo.energies[mol.mo.norba:],
+    assert_allclose(mol.mo.energiesb,
                     [-0.334567, -0.092237, -0.092237, -0.092237], atol=1.e-4)
     assert_allclose(mol.energy, -3.761587698067, atol=1.e-10)
     assert len(mol.obasis.shells) == 3
@@ -58,8 +56,8 @@ def test_atom_si_uks():
     assert mol.obasis.shells[2].kinds == ['p']
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_atom_o_rks():
@@ -67,8 +65,8 @@ def test_atom_o_rks():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [8])
     assert_equal(mol.atcorenums, [6])
-    assert mol.mo.type == 'restricted'
-    assert_equal(mol.mo.occs, [1, 1, 1, 1])
+    assert isinstance(mol.mo, RestrictedOrbitals)
+    assert_equal(mol.mo.occs, [2, 2, 2, 2])
     assert_allclose(mol.mo.energies, [0.102709, 0.606458, 0.606458, 0.606458], atol=1.e-4)
     assert_allclose(mol.energy, -15.464982778766, atol=1.e-10)
     assert_equal(mol.obasis.shells[0].angmoms, [0, 0])
@@ -88,19 +86,16 @@ def test_carbon_gs_ae_contracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
-    assert mol.mo.type == 'unrestricted'
-    assert_allclose(mol.mo.occs[:mol.mo.norba],
-                    [1, 1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
-    assert_allclose(mol.mo.energies[:mol.mo.norba],
-                    [-10.058194, -0.526244, -0.214978, -0.214978, -0.214978])
-    assert_allclose(mol.mo.occs[mol.mo.norba:], [1, 1, 0, 0, 0])
-    assert_allclose(mol.mo.energies[mol.mo.norba:],
-                    [-10.029898, -0.434300, -0.133323, -0.133323, -0.133323])
+    assert isinstance(mol.mo, UnrestrictedOrbitals)
+    assert_allclose(mol.mo.occsa, [1, 1, 2 / 3, 2 / 3, 2 / 3])
+    assert_allclose(mol.mo.energiesa, [-10.058194, -0.526244, -0.214978, -0.214978, -0.214978])
+    assert_allclose(mol.mo.occsb, [1, 1, 0, 0, 0])
+    assert_allclose(mol.mo.energiesb, [-10.029898, -0.434300, -0.133323, -0.133323, -0.133323])
     assert_allclose(mol.energy, -37.836423363057)
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_carbon_gs_ae_uncontracted():
@@ -108,19 +103,16 @@ def test_carbon_gs_ae_uncontracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
-    assert mol.mo.type == 'unrestricted'
-    assert_allclose(mol.mo.occs[:mol.mo.norba],
-                    [1, 1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
-    assert_allclose(mol.mo.energies[:mol.mo.norba],
-                    [-10.050076, -0.528162, -0.217626, -0.217626, -0.217626])
-    assert_allclose(mol.mo.occs[mol.mo.norba:], [1, 1, 0, 0, 0])
-    assert_allclose(mol.mo.energies[mol.mo.norba:],
-                    [-10.022715, -0.436340, -0.137135, -0.137135, -0.137135])
+    assert isinstance(mol.mo, UnrestrictedOrbitals)
+    assert_allclose(mol.mo.occsa, [1, 1, 2 / 3, 2 / 3, 2 / 3])
+    assert_allclose(mol.mo.energiesa, [-10.050076, -0.528162, -0.217626, -0.217626, -0.217626])
+    assert_allclose(mol.mo.occsb, [1, 1, 0, 0, 0])
+    assert_allclose(mol.mo.energiesb, [-10.022715, -0.436340, -0.137135, -0.137135, -0.137135])
     assert_allclose(mol.energy, -37.842552743398)
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_carbon_gs_pp_contracted():
@@ -128,18 +120,16 @@ def test_carbon_gs_pp_contracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
-    assert mol.mo.type == 'unrestricted'
-    assert_allclose(mol.mo.occs[:mol.mo.norba], [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
-    assert_allclose(mol.mo.energies[:mol.mo.norba],
-                    [-0.528007, -0.219974, -0.219974, -0.219974])
-    assert_allclose(mol.mo.occs[mol.mo.norba:], [1, 0, 0, 0])
-    assert_allclose(mol.mo.energies[mol.mo.norba:],
-                    [-0.429657, -0.127060, -0.127060, -0.127060])
+    assert isinstance(mol.mo, UnrestrictedOrbitals)
+    assert_allclose(mol.mo.occsa, [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
+    assert_allclose(mol.mo.energiesa, [-0.528007, -0.219974, -0.219974, -0.219974])
+    assert_allclose(mol.mo.occsb, [1, 0, 0, 0])
+    assert_allclose(mol.mo.energiesb, [-0.429657, -0.127060, -0.127060, -0.127060])
     assert_allclose(mol.energy, -5.399938535844)
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_carbon_gs_pp_uncontracted():
@@ -147,18 +137,16 @@ def test_carbon_gs_pp_uncontracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
-    assert mol.mo.type == 'unrestricted'
-    assert_allclose(mol.mo.occs[:mol.mo.norba], [1, 2.0 / 3.0, 2.0 / 3.0, 2.0 / 3.0])
-    assert_allclose(mol.mo.energies[:mol.mo.norba],
-                    [-0.528146, -0.219803, -0.219803, -0.219803])
-    assert_allclose(mol.mo.occs[mol.mo.norba:], [1, 0, 0, 0])
-    assert_allclose(mol.mo.energies[mol.mo.norba:],
-                    [-0.429358, -0.126411, -0.126411, -0.126411])
+    assert isinstance(mol.mo, UnrestrictedOrbitals)
+    assert_allclose(mol.mo.occsa, [1, 2 / 3, 2 / 3, 2 / 3])
+    assert_allclose(mol.mo.energiesa, [-0.528146, -0.219803, -0.219803, -0.219803])
+    assert_allclose(mol.mo.occsb, [1, 0, 0, 0])
+    assert_allclose(mol.mo.energiesb, [-0.429358, -0.126411, -0.126411, -0.126411])
     assert_allclose(mol.energy, -5.402288849332)
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_carbon_sc_ae_contracted():
@@ -166,8 +154,8 @@ def test_carbon_sc_ae_contracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
-    assert mol.mo.type == 'restricted'
-    assert_allclose(mol.mo.occs, [1, 1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert isinstance(mol.mo, RestrictedOrbitals)
+    assert_allclose(mol.mo.occs, [2, 2, 2 / 3, 2 / 3, 2 / 3])
     assert_allclose(mol.mo.energies, [-10.067251, -0.495823, -0.187878, -0.187878, -0.187878])
     assert_allclose(mol.energy, -37.793939631890)
     # check mo normalization
@@ -180,8 +168,8 @@ def test_carbon_sc_ae_uncontracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
-    assert mol.mo.type == 'restricted'
-    assert_allclose(mol.mo.occs, [1, 1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert isinstance(mol.mo, RestrictedOrbitals)
+    assert_allclose(mol.mo.occs, [2, 2, 2 / 3, 2 / 3, 2 / 3])
     assert_allclose(mol.mo.energies, [-10.062206, -0.499716, -0.192580, -0.192580, -0.192580])
     assert_allclose(mol.energy, -37.800453482378)
     # check mo normalization
@@ -194,8 +182,8 @@ def test_carbon_sc_pp_contracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
-    assert mol.mo.type == 'restricted'
-    assert_allclose(mol.mo.occs, [1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert isinstance(mol.mo, RestrictedOrbitals)
+    assert_allclose(mol.mo.occs, [2, 2 / 3, 2 / 3, 2 / 3])
     assert_allclose(mol.mo.energies, [-0.500732, -0.193138, -0.193138, -0.193138])
     assert_allclose(mol.energy, -5.350765755382)
     # check mo normalization
@@ -208,8 +196,8 @@ def test_carbon_sc_pp_uncontracted():
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
-    assert mol.mo.type == 'restricted'
-    assert_allclose(mol.mo.occs, [1, 1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0])
+    assert isinstance(mol.mo, RestrictedOrbitals)
+    assert_allclose(mol.mo.occs, [2, 2 / 3, 2 / 3, 2 / 3])
     assert_allclose(mol.mo.energies, [-0.500238, -0.192365, -0.192365, -0.192365])
     assert_allclose(mol.energy, -5.352864672201)
     # check mo normalization

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.cp2k module."""
 
 import pytest

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.cube module."""
 
 

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -345,7 +345,7 @@ def check_trj_basics(trj, nsteps, title, irc):
             assert mol.atcoords.shape == (natom, 3)
             assert mol.atgradient.shape == (natom, 3)
             assert mol.title == title
-            assert hasattr(mol, 'energy')
+            assert mol.energy is not None
             assert ('reaction_coordinate' in mol.extra) ^ (not irc)
 
 

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -27,6 +27,7 @@ import pytest
 
 from ..api import load_one, load_many
 from ..formats.fchk import load_one as load_fchk
+from ..orbitals import UnrestrictedOrbitals, RestrictedOrbitals
 from ..overlap import compute_overlap
 from ..utils import check_dm, LineIterator
 
@@ -61,7 +62,7 @@ def test_load_fchk_hf_sto3g_num():
     assert mol.run_type == 'energy'
     assert mol.lot == 'rhf'
     assert mol.obasis_name == 'sto-3g'
-    assert mol.mo.type == 'restricted'
+    assert isinstance(mol.mo, RestrictedOrbitals)
     assert mol.spinpol == 0
     assert mol.obasis.nbasis == 6
     assert len(mol.obasis.shells) == 3
@@ -157,46 +158,37 @@ def test_load_fchk_water_sto3g_hf():
 
 
 def test_load_fchk_lih_321g_hf():
-    fields = load_fchk_helper_internal('li_h_3-21G_hf_g09.fchk')
-    assert len(fields['obasis'].shells) == 5
-    assert fields['obasis'].nbasis == 11
-    assert len(fields['atcoords']) == len(fields['atnums'])
-    assert fields['atcoords'].shape[1] == 3
-    assert len(fields['atnums']) == 2
+    mol = load_fchk_helper('li_h_3-21G_hf_g09.fchk')
+    assert len(mol.obasis.shells) == 5
+    assert mol.obasis.nbasis == 11
+    assert len(mol.atcoords) == len(mol.atnums)
+    assert mol.atcoords.shape[1] == 3
+    assert len(mol.atnums) == 2
+    assert_allclose(mol.energy, -7.687331212191968E+00)
 
-    orb_alpha_coeffs = fields['mo'].coeffs[:, :fields['mo'].norba]
-    orb_alpha_energies = fields['mo'].energies[:fields['mo'].norba]
-    orb_alpha_occs = fields['mo'].occs[:fields['mo'].norba]
+    assert_allclose(mol.mo.energiesa[0], (-2.76117), atol=1.e-4)
+    assert_allclose(mol.mo.energiesa[-1], 0.97089, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsa[0, 0], 0.99105, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsa[1, 0], 0.06311, atol=1.e-4)
+    assert mol.mo.coeffsa[3, 2] < 1.e-4
+    assert_allclose(mol.mo.coeffsa[-1, 9], 0.13666, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsa[4, -1], 0.17828, atol=1.e-4)
+    assert_equal(mol.mo.occsa.sum(), 2)
+    assert_equal(mol.mo.occsa.min(), 0.0)
+    assert_equal(mol.mo.occsa.max(), 1.0)
 
-    assert_allclose(orb_alpha_energies[0], (-2.76117), atol=1.e-4)
-    assert_allclose(orb_alpha_energies[-1], 0.97089, atol=1.e-4)
-    assert_allclose(orb_alpha_coeffs[0, 0], 0.99105, atol=1.e-4)
-    assert_allclose(orb_alpha_coeffs[1, 0], 0.06311, atol=1.e-4)
-    assert orb_alpha_coeffs[3, 2] < 1.e-4
-    assert_allclose(orb_alpha_coeffs[-1, 9], 0.13666, atol=1.e-4)
-    assert_allclose(orb_alpha_coeffs[4, -1], 0.17828, atol=1.e-4)
-    assert_equal(orb_alpha_occs.sum(), 2)
-    assert_equal(orb_alpha_occs.min(), 0.0)
-    assert_equal(orb_alpha_occs.max(), 1.0)
-
-    orb_beta_coeffs = fields['mo'].coeffs[:, fields['mo'].norba:]
-    orb_beta_energies = fields['mo'].energies[fields['mo'].norba:]
-    orb_beta_occs = fields['mo'].occs[fields['mo'].norba:]
-
-    assert_allclose(orb_beta_energies[0], -2.76031, atol=1.e-4)
-    assert_allclose(orb_beta_energies[-1], 1.13197, atol=1.e-4)
-    assert_allclose(orb_beta_coeffs[0, 0], 0.99108, atol=1.e-4)
-    assert_allclose(orb_beta_coeffs[1, 0], 0.06295, atol=1.e-4)
-    assert abs(orb_beta_coeffs[3, 2]) < 1e-4
-    assert_allclose(orb_beta_coeffs[-1, 9], 0.80875, atol=1.e-4)
-    assert_allclose(orb_beta_coeffs[4, -1], -0.15503, atol=1.e-4)
-    assert_equal(orb_beta_occs.sum(), 1)
-    assert_equal(orb_beta_occs.min(), 0.0)
-    assert_equal(orb_beta_occs.max(), 1.0)
-    assert_equal(orb_alpha_occs.shape[0], orb_alpha_coeffs.shape[0])
-    assert_equal(orb_beta_occs.shape[0], orb_beta_coeffs.shape[0])
-    energy = fields['energy']
-    assert_allclose(energy, -7.687331212191968E+00)
+    assert_allclose(mol.mo.energiesb[0], -2.76031, atol=1.e-4)
+    assert_allclose(mol.mo.energiesb[-1], 1.13197, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsb[0, 0], 0.99108, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsb[1, 0], 0.06295, atol=1.e-4)
+    assert abs(mol.mo.coeffsb[3, 2]) < 1e-4
+    assert_allclose(mol.mo.coeffsb[-1, 9], 0.80875, atol=1.e-4)
+    assert_allclose(mol.mo.coeffsb[4, -1], -0.15503, atol=1.e-4)
+    assert_equal(mol.mo.occsb.sum(), 1)
+    assert_equal(mol.mo.occsb.min(), 0.0)
+    assert_equal(mol.mo.occsb.max(), 1.0)
+    assert_equal(mol.mo.occsa.shape[0], mol.mo.coeffsa.shape[0])
+    assert_equal(mol.mo.occsb.shape[0], mol.mo.coeffsb.shape[0])
 
 
 def test_load_fchk_ghost_atoms():
@@ -456,10 +448,10 @@ def test_atmasses():
 
 def test_spinpol():
     mol1 = load_fchk_helper('ch3_rohf_sto3g_g03.fchk')
-    assert mol1.mo.type == 'restricted'
+    assert isinstance(mol1.mo, RestrictedOrbitals)
     assert mol1.spinpol == 1
     mol2 = load_fchk_helper('li_h_3-21G_hf_g09.fchk')
-    assert mol2.mo.type == 'unrestricted'
+    assert isinstance(mol2.mo, UnrestrictedOrbitals)
     assert mol2.spinpol == 1
     with pytest.raises(TypeError):
         mol2.spinpol = 2

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.formats.fchk module."""
 
 
@@ -335,10 +335,10 @@ def check_trj_basics(trj, nsteps, title, irc):
     for ipoint, nstep in enumerate(nsteps):
         for istep in range(nstep):
             mol = trj.pop(0)
-            assert mol.ipoint == ipoint
-            assert mol.npoint == len(nsteps)
-            assert mol.istep == istep
-            assert mol.nstep == nstep
+            assert mol.extra['ipoint'] == ipoint
+            assert mol.extra['npoint'] == len(nsteps)
+            assert mol.extra['istep'] == istep
+            assert mol.extra['nstep'] == nstep
             assert mol.natom == natom
             assert mol.atnums.shape == (natom, )
             assert mol.atcorenums.shape == (natom, )
@@ -346,7 +346,7 @@ def check_trj_basics(trj, nsteps, title, irc):
             assert mol.atgradient.shape == (natom, 3)
             assert mol.title == title
             assert hasattr(mol, 'energy')
-            assert hasattr(mol, 'reaction_coordinate') ^ (not irc)
+            assert ('reaction_coordinate' in mol.extra) ^ (not irc)
 
 
 def test_peroxide_opt():
@@ -403,10 +403,10 @@ def test_peroxide_irc():
     assert_allclose(trj[0].energy, -1.48750432E+02)
     assert_allclose(trj[5].energy, -1.48752713E+02)
     assert_allclose(trj[-1].energy, -1.48757803E+02)
-    assert trj[0].reaction_coordinate == 0.0
-    assert_allclose(trj[1].reaction_coordinate, 1.05689581E-01)
-    assert_allclose(trj[10].reaction_coordinate, 1.05686037E+00)
-    assert_allclose(trj[-1].reaction_coordinate, -1.05685760E+00)
+    assert trj[0].extra['reaction_coordinate'] == 0.0
+    assert_allclose(trj[1].extra['reaction_coordinate'], 1.05689581E-01)
+    assert_allclose(trj[10].extra['reaction_coordinate'], 1.05686037E+00)
+    assert_allclose(trj[-1].extra['reaction_coordinate'], -1.05685760E+00)
     assert_allclose(trj[0].atcoords[2],
                     [-1.94749866E+00, -5.22905491E-01, -1.47814774E+00])
     assert_allclose(trj[10].atcoords[1],

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.log module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.iodata module."""
 
 
 import numpy as np
-from numpy.testing import assert_raises, assert_allclose
+from numpy.testing import assert_allclose
 import pytest
 
 from .common import compute_1rdm
@@ -36,30 +36,30 @@ except ImportError:
 def test_typecheck():
     m = IOData(atcoords=np.array([[1, 2, 3], [2, 3, 1]]))
     assert np.issubdtype(m.atcoords.dtype, np.floating)
-    assert not hasattr(m, 'atnums')
+    assert m.atnums is None
     m = IOData(atnums=np.array([2.0, 3.0]), atcorenums=np.array([1, 1]),
                atcoords=np.array([[1, 2, 3], [2, 3, 1]]))
     assert np.issubdtype(m.atnums.dtype, np.integer)
     assert np.issubdtype(m.atcorenums.dtype, np.floating)
-    assert hasattr(m, 'atnums')
-    del m.atnums
-    assert not hasattr(m, 'atnums')
+    assert m.atnums is not None
+    m.atnums = None
+    assert m.atnums is None
 
 
 def test_typecheck_raises():
     # check attribute type
-    assert_raises(TypeError, IOData, atcoords=np.array([[1, 2], [2, 3]]))
-    assert_raises(TypeError, IOData, atnums=np.array([[1, 2], [2, 3]]))
+    pytest.raises(TypeError, IOData, atcoords=np.array([[1, 2], [2, 3]]))
+    pytest.raises(TypeError, IOData, atnums=np.array([[1, 2], [2, 3]]))
     # check inconsistency between various attributes
     atnums, atcorenums, atcoords = np.array(
         [2, 3]), np.array([1]), np.array([[1, 2, 3]])
-    assert_raises(TypeError, IOData, atnums=atnums,
+    pytest.raises(TypeError, IOData, atnums=atnums,
                   atcorenums=atcorenums)
-    assert_raises(TypeError, IOData, atnums=atnums, atcoords=atcoords)
+    pytest.raises(TypeError, IOData, atnums=atnums, atcoords=atcoords)
 
 
 def test_unknown_format():
-    assert_raises(ValueError, load_one, 'foo.unknown_file_extension')
+    pytest.raises(ValueError, load_one, 'foo.unknown_file_extension')
 
 
 def test_dm_water_sto3g_hf():
@@ -129,21 +129,15 @@ def test_undefined():
     # One a blank IOData object, accessing undefined charge and nelec should raise
     # an AttributeError.
     mol = IOData()
-    with pytest.raises(AttributeError):
-        _ = mol.charge
-    with pytest.raises(AttributeError):
-        _ = mol.nelec
-    with pytest.raises(AttributeError):
-        _ = mol.spinpol
-    with pytest.raises(AttributeError):
-        _ = mol.natom
+    assert mol.charge is None
+    assert mol.nelec is None
+    assert mol.spinpol is None
+    assert mol.natom is None
     mol.nelec = 5
-    with pytest.raises(AttributeError):
-        _ = mol.charge
+    assert mol.charge is None
     mol = IOData()
     mol.charge = 1
-    with pytest.raises(AttributeError):
-        _ = mol.nelec
+    assert mol.nelec is None
 
 
 def test_natom():

--- a/iodata/test/test_locpot.py
+++ b/iodata/test/test_locpot.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.locpot module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -46,12 +46,14 @@ def test_load_molden_li2_orca():
 
     # Check geometry
     assert_equal(mol.atnums, [3, 3])
+    assert_allclose(mol.mo.occsa[:4], [1, 1, 1, 0])
+    assert_allclose(mol.mo.occsb[:4], [1, 1, 0, 0])
     assert_allclose(mol.atcoords[1], [5.2912331750, 0.0, 0.0])
 
     # Check normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp, 1e-5)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp, 1e-5)
+    check_orthonormal(mol.mo.coeffsa, olp, 1e-5)
+    check_orthonormal(mol.mo.coeffsb, olp, 1e-5)
 
     # Check Mulliken charges
     charges = compute_mulliken_charges(mol)
@@ -68,6 +70,7 @@ def test_load_molden_h2o_orca():
 
     # Check geometry
     assert_equal(mol.atnums, [8, 1, 1])
+    assert_allclose(mol.mo.occs[:6], [2, 2, 2, 2, 2, 0])
     assert_allclose(mol.atcoords[2], [0.0, -0.1808833432, 1.9123825806])
 
     # Check normalization

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.molden module."""
 
 import os

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -48,6 +48,9 @@ def test_load_molden_li2_orca():
     assert_equal(mol.atnums, [3, 3])
     assert_allclose(mol.mo.occsa[:4], [1, 1, 1, 0])
     assert_allclose(mol.mo.occsb[:4], [1, 1, 0, 0])
+    assert_equal(mol.mo.irreps, ['1a'] * mol.mo.norb)
+    assert_equal(mol.mo.irrepsa, ['1a'] * mol.mo.norba)
+    assert_equal(mol.mo.irrepsb, ['1a'] * mol.mo.norbb)
     assert_allclose(mol.atcoords[1], [5.2912331750, 0.0, 0.0])
 
     # Check normalization
@@ -71,6 +74,7 @@ def test_load_molden_h2o_orca():
     # Check geometry
     assert_equal(mol.atnums, [8, 1, 1])
     assert_allclose(mol.mo.occs[:6], [2, 2, 2, 2, 2, 0])
+    assert_equal(mol.mo.irreps, ['1a'] * mol.mo.norb)
     assert_allclose(mol.atcoords[2], [0.0, -0.1808833432, 1.9123825806])
 
     # Check normalization
@@ -253,6 +257,15 @@ def test_load_molden_nh3_turbomole():
     charges = compute_mulliken_charges(mol)
     molden_charges = np.array([0.03801, -0.27428, 0.01206, 0.22421])
     assert_allclose(charges, molden_charges, atol=1.e-3)
+
+
+def test_load_molden_f():
+    with path('iodata.test.data', 'F.molden') as fn_molden:
+        mol = load_one(str(fn_molden))
+    assert_allclose(mol.mo.occsa[:6], [1, 1, 1, 1, 1, 0])
+    assert_allclose(mol.mo.occsb[:6], [1, 1, 1, 1, 0, 0])
+    assert_equal(mol.mo.irrepsa[:6], ['Ag', 'Ag', 'B3u', 'B2u', 'B1u', 'B3u'])
+    assert_equal(mol.mo.irrepsb[:6], ['Ag', 'Ag', 'B3u', 'B2u', 'B1u', 'B3u'])
 
 
 def check_load_dump_consistency(fn, tmpdir):

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.formats.molekel module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -72,8 +72,8 @@ def test_load_mkl_li2():
         mol = load_one(str(fn_mkl))
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp, 1e-5)
-    check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp, 1e-5)
+    check_orthonormal(mol.mo.coeffsa, olp, 1e-5)
+    check_orthonormal(mol.mo.coeffsb, olp, 1e-5)
 
 
 def test_load_mkl_h2():

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.molpro module."""
 
 import os

--- a/iodata/test/test_orca.py
+++ b/iodata/test/test_orca.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.orca module."""
 
 import numpy as np

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import numpy as np

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.poscar module."""
 
 import os
@@ -70,7 +70,6 @@ def test_load_dump_consistency(tmpdir):
     mol0.cellvecs = np.array([[2.05278155, 0.23284023, 1.59024118],
                               [4.96430141, 4.73044423, 4.67590975],
                               [3.48374425, 0.67931228, 0.66281160]])
-    mol0.gvecs = np.linalg.inv(mol0.cellvecs).T
 
     fn_tmp = os.path.join(tmpdir, 'POSCAR')
     dump_one(mol0, fn_tmp)

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.wfn module."""
 
 
@@ -238,4 +237,4 @@ def test_load_wfn_lih_cation_fci():
     assert_equal(mol.atnums, [3, 1])
     assert_equal(mol.mo.occs.shape, (11,))
     assert_allclose(mol.mo.occs.sum(), 3., rtol=0., atol=1.e-6)
-    #assert abs(mol.mo.occsa.sum() - 1.5) < 1.e-6
+    # assert abs(mol.mo.occsa.sum() - 1.5) < 1.e-6

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -27,6 +27,7 @@ from numpy.testing import assert_equal, assert_allclose
 from .common import compute_mulliken_charges, check_orthonormal
 from ..api import load_one
 from ..formats.wfn import load_wfn_low
+from ..orbitals import UnrestrictedOrbitals
 from ..overlap import compute_overlap
 from ..utils import LineIterator
 
@@ -134,11 +135,9 @@ def check_wfn(fn_wfn, nbasis, energy, charges_mulliken):
     assert mol.obasis.nbasis == nbasis
     # check orthonormal mo
     olp = compute_overlap(mol.obasis, mol.atcoords)
-    if mol.mo.type == 'restricted':
-        check_orthonormal(mol.mo.coeffs, olp, 1.e-5)
-    elif mol.mo.type == 'unrestricted':
-        check_orthonormal(mol.mo.coeffs[:, :mol.mo.norba], olp, 1.e-5)
-        check_orthonormal(mol.mo.coeffs[:, mol.mo.norba:], olp, 1.e-5)
+    check_orthonormal(mol.mo.coeffsa, olp, 1.e-5)
+    if isinstance(mol.mo, UnrestrictedOrbitals):
+        check_orthonormal(mol.mo.coeffsb, olp, 1.e-5)
     # check energy & atomic charges
     if energy is not None:
         assert_allclose(mol.energy, energy, rtol=0., atol=1.e-5)
@@ -202,15 +201,15 @@ def test_load_wfn_o2_virtual():
                     -149.664140769678, np.array([0.0, 0.0]))
     # check MO occupation
     assert_equal(mol.mo.occs.shape, (88,))
-    assert_allclose(mol.mo.occs[:mol.mo.norba], [1.] * 9 + [0.] * 35)
-    assert_allclose(mol.mo.occs[mol.mo.norba:], [1.] * 7 + [0.] * 37)
+    assert_allclose(mol.mo.occsa, [1.] * 9 + [0.] * 35)
+    assert_allclose(mol.mo.occsb, [1.] * 7 + [0.] * 37)
     # check MO energies
     assert_equal(mol.mo.energies.shape, (88,))
-    mo_energies_a = mol.mo.energies[:mol.mo.norba]
+    mo_energies_a = mol.mo.energiesa
     assert_allclose(mo_energies_a[0], -20.752000, rtol=0, atol=1.e-6)
     assert_allclose(mo_energies_a[10], 0.179578, rtol=0, atol=1.e-6)
     assert_allclose(mo_energies_a[-1], 51.503193, rtol=0, atol=1.e-6)
-    mo_energies_b = mol.mo.energies[mol.mo.norba:]
+    mo_energies_b = mol.mo.energiesb
     assert_allclose(mo_energies_b[0], -20.697027, rtol=0, atol=1.e-6)
     assert_allclose(mo_energies_b[15], 0.322590, rtol=0, atol=1.e-6)
     assert_allclose(mo_energies_b[-1], 51.535258, rtol=0, atol=1.e-6)
@@ -239,4 +238,4 @@ def test_load_wfn_lih_cation_fci():
     assert_equal(mol.atnums, [3, 1])
     assert_equal(mol.mo.occs.shape, (11,))
     assert_allclose(mol.mo.occs.sum(), 3., rtol=0., atol=1.e-6)
-    # assert abs(mol.mo.occs[:mol.mo.norba].sum() - 1.5) < 1.e-6
+    #assert abs(mol.mo.occsa.sum() - 1.5) < 1.e-6

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.wfn module."""
 
 import pytest

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.xyz module."""
 
 import os

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -26,7 +26,8 @@ import scipy.constants as spc
 from scipy.linalg import eigh
 
 
-__all__ = ['LineIterator', 'set_four_index_element', 'MolecularOrbitals']
+__all__ = ['LineIterator', 'Cube', 'set_four_index_element', 'volume',
+           'derive_naturals', 'check_dm']
 
 
 # The unit conversion factors below can be used as follows:
@@ -85,62 +86,6 @@ class LineIterator:
         """Go one line back and decrease the lineno attribute by one."""
         self.stack.append(line)
         self.lineno -= 1
-
-
-class MolecularOrbitals(NamedTuple):
-    """Molecular Orbitals Class.
-
-    Attributes
-    ----------
-    type : str
-        Molecular orbital type; choose from 'restricted', 'unrestricted', or 'generalized'.
-    norba : int
-        Number of alpha molecular orbitals. None in case of type=='generalized'.
-    norbb : int
-        Number of beta molecular orbitals. None in case of type=='generalized'.
-    occs : np.ndarray
-        Molecular orbital occupation numbers. The number of elements equals the
-        number of columns of coeffs.
-    coeffs : np.ndarray
-        Molecular orbital basis coefficients.
-        In case of restricted: shape = (nbasis, norb_a) = (nbasis, norb_b).
-        In case of unrestricted: shape = (nbasis, norb_a + norb_b).
-        In case of generalized: shape = (2*nbasis, norb), where norb is the
-        total number of orbitals (not defined by other attributes).
-    irreps : np.ndarray
-        Irreducible representation. The number of elements equals the
-        number of columns of coeffs.
-    energies : np.ndarray
-        Molecular orbital energies. The number of elements equals the
-        number of columns of coeffs.
-
-    """
-
-    type: str
-    norba: int
-    norbb: int
-    occs: np.ndarray
-    coeffs: np.ndarray
-    irreps: np.ndarray
-    energies: np.ndarray
-
-    @property
-    def nelec(self):
-        """Return the total number of electrons."""
-        return self.occs.sum()
-
-    @property
-    def spinpol(self):
-        """Return the spin multiplicity of the Slater determinant."""
-        if self.type == 'restricted':
-            nbeta = np.clip(self.occs, 0, 1).sum()
-            sq = self.nelec - 2 * nbeta
-        elif self.type == 'unrestricted':
-            sq = self.occs[:self.norba].sum() - self.occs[self.norba:].sum()
-        else:
-            # Not sure how to do this in a simply way.
-            raise NotImplementedError
-        return abs(sq)
 
 
 class Cube(NamedTuple):

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
         'Intended Audience :: Science/Research',
     ],
     setup_requires=['numpy>=1.0', 'cython>=0.24.1'],
-    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy',
+    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'attr>=19.1.0',
                       'importlib_resources; python_version < "3.7"'],
 )

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   run:
     - python
     - scipy
+    - attrs >=19.1.0
     - importlib_resources  # [py<37]
 
 test:


### PR DESCRIPTION
Fixes #77 
Fixes #73 

The two issues were solved at the same time because #77, implied making different classes for orbitals (to avoid lots of ifs), but subclassing of NamedTuple subclasses do not work, such that I had to switch to attrs to fix this, which was mainly the point of #73.

The fix of #73 is only partially successful. Not all pylint exclusions could be removed. Several bugs were found by using the attrs module, see https://www.attrs.org/en/stable/. Atts is an extra dependency but not a major concern because attrs is also a dependency of pytest, which we use anyway.

Other notable changes:
- This PR is API breaking because the constructor for the orbitals got simplified.
- Load irreps from Molden file (for testing new features mainly).
