### PR TITLE
Use attrs for IOData class

### DIFF
--- a/iodata/formats/cube.py
+++ b/iodata/formats/cube.py
@@ -187,6 +187,6 @@ def dump_one(f: TextIO, data: IOData):
         attributes.
 
     """
-    title = getattr(data, 'title', 'Created with IOData')
+    title = data.title or 'Created with IOData'
     _write_cube_header(f, title, data.atcoords, data.atnums, data.cube, data.atcorenums)
     _write_cube_data(f, data.cube.data)

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -250,8 +250,8 @@ def load_many(lit: LineIterator) -> Iterator[dict]:
     ------
     out
         Output dictionary containing ``title``, ``atcoords``, ``atnums``,
-        ``atcorenums``, ``ipoint``, ``npoint``, ``istep``, ``nstep``,
-        ``gradient``, ``reaction_coordinate``, and ``energy``.
+        ``atcorenums``, ``extra`` (with ``ipoint``, ``npoint``, ``istep``,
+        ``nstep``), ``gradient``, ``reaction_coordinate``, and ``energy``.
 
     Trajectories from a Gaussian optimization, relaxed scan or IRC calculation
     are written in groups of frames, called "points" in the Gaussian world, e.g.
@@ -294,16 +294,18 @@ def load_many(lit: LineIterator) -> Iterator[dict]:
                 'title': fchk['title'],
                 'atnums': fchk["Atomic numbers"],
                 'atcorenums': fchk["Nuclear charges"],
-                'ipoint': ipoint,
-                'npoint': len(nsteps),
-                'istep': istep,
-                'nstep': nstep,
                 'energy': energy,
                 'atcoords': atcoords,
                 'atgradient': gradients,
+                'extra': {
+                    'ipoint': ipoint,
+                    'npoint': len(nsteps),
+                    'istep': istep,
+                    'nstep': nstep,
+                },
             }
             if prefix == "IRC point":
-                data['reaction_coordinate'] = recor
+                data['extra']['reaction_coordinate'] = recor
             yield data
 
 

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -595,7 +595,7 @@ def dump_one(f: TextIO, data: IOData):
     """
     # Print the header
     f.write('[Molden Format]\n')
-    if hasattr(data, 'title'):
+    if data.title is not None:
         f.write('[Title]\n')
         f.write(' {}\n'.format(data.title))
 
@@ -611,8 +611,8 @@ def dump_one(f: TextIO, data: IOData):
     f.write('\n')
 
     # Print the basis set
-    if not hasattr(data, 'obasis'):
-        raise IOError('A Gaussian orbital basis is required to write a molden input file.')
+    if data.obasis is None:
+        raise IOError('A Gaussian orbital basis is required to write a molden file.')
     obasis = data.obasis
 
     # Figure out the pure/Cartesian situation. Note that the Molden

--- a/iodata/formats/molpro.py
+++ b/iodata/formats/molpro.py
@@ -135,19 +135,18 @@ def dump_one(f: TextIO, data: IOData):
 
     """
     one_mo = data.one_ints['core_mo']
-    two_mo = data.two_ints['two_mo']
-    nactive = one_mo.shape[0]
-    core_energy = getattr(data, 'core_energy', 0.0)
-    nelec = getattr(data, 'nelec', 0)
-    spinpol = getattr(data, 'spinpol', 0)
 
     # Write header
+    nactive = one_mo.shape[0]
+    nelec = data.nelec or 0
+    spinpol = data.spinpol or 0
     print(f' &FCI NORB={nactive:d},NELEC={nelec:d},MS2={spinpol:d},', file=f)
     print(f"  ORBSYM= {','.join('1' for v in range(nactive))},", file=f)
     print('  ISYM=1', file=f)
     print(' &END', file=f)
 
     # Write integrals and core energy
+    two_mo = data.two_ints['two_mo']
     for i in range(nactive):  # pylint: disable=too-many-nested-blocks
         for j in range(i + 1):
             for k in range(nactive):
@@ -161,5 +160,5 @@ def dump_one(f: TextIO, data: IOData):
             value = one_mo[i, j]
             if value != 0.0:
                 print(f'{value:23.16e} {i+1:4d} {j+1:4d} {0:4d} {0:4d}', file=f)
-    if core_energy != 0.0:
-        print(f'{core_energy:23.16e} {0:4d} {0:4d} {0:4d} {0:4d}', file=f)
+    if data.core_energy is not None:
+        print(f'{data.core_energy:23.16e} {0:4d} {0:4d} {0:4d} {0:4d}', file=f)

--- a/iodata/formats/poscar.py
+++ b/iodata/formats/poscar.py
@@ -72,7 +72,7 @@ def dump_one(f: TextIO, data: IOData):
         ``cellvecs`` attributes. It may contain ``title`` attribute.
 
     """
-    print(getattr(data, 'title', 'Created with HORTON'), file=f)
+    print(data.title or 'Created with IOData', file=f)
     print('   1.00000000000000', file=f)
 
     # Write cell vectors, each row is one vector in angstrom:
@@ -90,8 +90,9 @@ def dump_one(f: TextIO, data: IOData):
     print('Direct', file=f)
 
     # Write the coordinates
+    gvecs = np.linalg.inv(data.cellvecs).T
     for uatnum in uatnums:
         indexes = (data.atnums == uatnum).nonzero()[0]
         for index in indexes:
-            row = np.dot(data.gvecs, data.atcoords[index])
+            row = np.dot(gvecs, data.atcoords[index])
             print(f'  {row[0]: 21.16f} {row[1]: 21.16f} {row[2]: 21.16f}   F   F   F', file=f)

--- a/iodata/formats/xyz.py
+++ b/iodata/formats/xyz.py
@@ -109,7 +109,7 @@ def dump_one(f: TextIO, data: IOData):
 
     """
     print(data.natom, file=f)
-    print(getattr(data, 'title', 'Created with IODATA module'), file=f)
+    print(data.title or 'Created with IOData', file=f)
     for i in range(data.natom):
         n = num2sym[data.atnums[i]]
         x, y, z = data.atcoords[i] / angstrom

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -85,7 +85,7 @@ def truncated_file(fn_orig, nline, nadd, tmpdir):
 
 def compare_mols(mol1, mol2):
     """Compare two IOData objects."""
-    assert getattr(mol1, 'title', None) == getattr(mol2, 'title', None)
+    assert mol1.title == mol2.title
     assert_equal(mol1.atnums, mol2.atnums)
     assert_equal(mol1.atcorenums, mol2.atcorenums)
     assert_allclose(mol1.atcoords, mol2.atcoords)
@@ -121,8 +121,8 @@ def compare_mols(mol1, mol2):
         ('one_rdms', ['scf', 'scf_spin', 'post_scf', 'post_scf_spin']),
     ]
     for attrname, keys in cases:
-        d1 = getattr(mol1, attrname, {})
-        d2 = getattr(mol2, attrname, {})
+        d1 = getattr(mol1, attrname)
+        d2 = getattr(mol2, attrname)
         for key in keys:
             if key in d1:
                 assert key in d2

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.chgcar module."""
 
 import numpy as np

--- a/iodata/test/test_cp2k.py
+++ b/iodata/test/test_cp2k.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.cp2k module."""
 
 import pytest

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.cube module."""
 
 

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.formats.fchk module."""
 
 
@@ -334,18 +334,18 @@ def check_trj_basics(trj, nsteps, title, irc):
     for ipoint, nstep in enumerate(nsteps):
         for istep in range(nstep):
             mol = trj.pop(0)
-            assert mol.ipoint == ipoint
-            assert mol.npoint == len(nsteps)
-            assert mol.istep == istep
-            assert mol.nstep == nstep
+            assert mol.extra['ipoint'] == ipoint
+            assert mol.extra['npoint'] == len(nsteps)
+            assert mol.extra['istep'] == istep
+            assert mol.extra['nstep'] == nstep
             assert mol.natom == natom
             assert mol.atnums.shape == (natom, )
             assert mol.atcorenums.shape == (natom, )
             assert mol.atcoords.shape == (natom, 3)
             assert mol.atgradient.shape == (natom, 3)
             assert mol.title == title
-            assert hasattr(mol, 'energy')
-            assert hasattr(mol, 'reaction_coordinate') ^ (not irc)
+            assert mol.energy is not None
+            assert ('reaction_coordinate' in mol.extra) ^ (not irc)
 
 
 def test_peroxide_opt():
@@ -402,10 +402,10 @@ def test_peroxide_irc():
     assert_allclose(trj[0].energy, -1.48750432E+02)
     assert_allclose(trj[5].energy, -1.48752713E+02)
     assert_allclose(trj[-1].energy, -1.48757803E+02)
-    assert trj[0].reaction_coordinate == 0.0
-    assert_allclose(trj[1].reaction_coordinate, 1.05689581E-01)
-    assert_allclose(trj[10].reaction_coordinate, 1.05686037E+00)
-    assert_allclose(trj[-1].reaction_coordinate, -1.05685760E+00)
+    assert trj[0].extra['reaction_coordinate'] == 0.0
+    assert_allclose(trj[1].extra['reaction_coordinate'], 1.05689581E-01)
+    assert_allclose(trj[10].extra['reaction_coordinate'], 1.05686037E+00)
+    assert_allclose(trj[-1].extra['reaction_coordinate'], -1.05685760E+00)
     assert_allclose(trj[0].atcoords[2],
                     [-1.94749866E+00, -5.22905491E-01, -1.47814774E+00])
     assert_allclose(trj[10].atcoords[1],

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.log module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -16,12 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.iodata module."""
 
 
 import numpy as np
-from numpy.testing import assert_raises, assert_allclose
+from numpy.testing import assert_allclose
 import pytest
 
 from .common import compute_1rdm
@@ -36,30 +36,30 @@ except ImportError:
 def test_typecheck():
     m = IOData(atcoords=np.array([[1, 2, 3], [2, 3, 1]]))
     assert np.issubdtype(m.atcoords.dtype, np.floating)
-    assert not hasattr(m, 'atnums')
+    assert m.atnums is None
     m = IOData(atnums=np.array([2.0, 3.0]), atcorenums=np.array([1, 1]),
                atcoords=np.array([[1, 2, 3], [2, 3, 1]]))
     assert np.issubdtype(m.atnums.dtype, np.integer)
     assert np.issubdtype(m.atcorenums.dtype, np.floating)
-    assert hasattr(m, 'atnums')
-    del m.atnums
-    assert not hasattr(m, 'atnums')
+    assert m.atnums is not None
+    m.atnums = None
+    assert m.atnums is None
 
 
 def test_typecheck_raises():
     # check attribute type
-    assert_raises(TypeError, IOData, atcoords=np.array([[1, 2], [2, 3]]))
-    assert_raises(TypeError, IOData, atnums=np.array([[1, 2], [2, 3]]))
+    pytest.raises(TypeError, IOData, atcoords=np.array([[1, 2], [2, 3]]))
+    pytest.raises(TypeError, IOData, atnums=np.array([[1, 2], [2, 3]]))
     # check inconsistency between various attributes
     atnums, atcorenums, atcoords = np.array(
         [2, 3]), np.array([1]), np.array([[1, 2, 3]])
-    assert_raises(TypeError, IOData, atnums=atnums,
+    pytest.raises(TypeError, IOData, atnums=atnums,
                   atcorenums=atcorenums)
-    assert_raises(TypeError, IOData, atnums=atnums, atcoords=atcoords)
+    pytest.raises(TypeError, IOData, atnums=atnums, atcoords=atcoords)
 
 
 def test_unknown_format():
-    assert_raises(ValueError, load_one, 'foo.unknown_file_extension')
+    pytest.raises(ValueError, load_one, 'foo.unknown_file_extension')
 
 
 def test_dm_water_sto3g_hf():
@@ -129,21 +129,15 @@ def test_undefined():
     # One a blank IOData object, accessing undefined charge and nelec should raise
     # an AttributeError.
     mol = IOData()
-    with pytest.raises(AttributeError):
-        _ = mol.charge
-    with pytest.raises(AttributeError):
-        _ = mol.nelec
-    with pytest.raises(AttributeError):
-        _ = mol.spinpol
-    with pytest.raises(AttributeError):
-        _ = mol.natom
+    assert mol.charge is None
+    assert mol.nelec is None
+    assert mol.spinpol is None
+    assert mol.natom is None
     mol.nelec = 5
-    with pytest.raises(AttributeError):
-        _ = mol.charge
+    assert mol.charge is None
     mol = IOData()
     mol.charge = 1
-    with pytest.raises(AttributeError):
-        _ = mol.nelec
+    assert mol.nelec is None
 
 
 def test_natom():

--- a/iodata/test/test_locpot.py
+++ b/iodata/test/test_locpot.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.locpot module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.molden module."""
 
 import os

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.formats.molekel module."""
 
 from numpy.testing import assert_equal, assert_allclose

--- a/iodata/test/test_molpro.py
+++ b/iodata/test/test_molpro.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.molpro module."""
 
 import os

--- a/iodata/test/test_orca.py
+++ b/iodata/test/test_orca.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.orca module."""
 
 import numpy as np

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import numpy as np

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
+# pylint: disable=unsubscriptable-object
 """Test iodata.formats.poscar module."""
 
 import os
@@ -70,7 +70,6 @@ def test_load_dump_consistency(tmpdir):
     mol0.cellvecs = np.array([[2.05278155, 0.23284023, 1.59024118],
                               [4.96430141, 4.73044423, 4.67590975],
                               [3.48374425, 0.67931228, 0.66281160]])
-    mol0.gvecs = np.linalg.inv(mol0.cellvecs).T
 
     fn_tmp = os.path.join(tmpdir, 'POSCAR')
     dump_one(mol0, fn_tmp)

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.wfn module."""
 
 

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.wfn module."""
 
 import pytest

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=no-member
 """Test iodata.formats.xyz module."""
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -77,6 +77,6 @@ setup(
         'Intended Audience :: Science/Research',
     ],
     setup_requires=['numpy>=1.0', 'cython>=0.24.1'],
-    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy',
+    install_requires=['numpy>=1.0', 'cython>=0.24.1', 'scipy', 'attrs>=19.1.0',
                       'importlib_resources; python_version < "3.7"'],
 )

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -26,6 +26,7 @@ requirements:
   run:
     - python
     - scipy
+    - attrs >=19.1.0
     - importlib_resources  # [py<37]
 
 test:


### PR DESCRIPTION
Fixes #73

Not all pylint exclusions can be removed, essentially due to pylint bugs resulting in many false negatives, see

https://stackoverflow.com/questions/47972143/using-attr-with-pylint
https://github.com/PyCQA/pylint/issues/1694

The good solution is to disable all type-checking warnings of pylint and to use a proper type checker like mypy instead.

Related changes:

- reaction_coordinate, ipoint, npoint, istep and nstep move to extra.
- many getattr and hasattr calls are replaced by nicer code.
- ArrayTypeCheckDescriptor is replaced by two simple functions.
- Document IOData.charge
- Bug got fixed in poscar format (gvecs)