### PR TITLE
Add conventions used in GBasis

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -26,7 +26,8 @@ import numpy as np
 
 __all__ = ['angmom_sti', 'angmom_its', 'Shell', 'MolecularBasis',
            'convert_convention_shell', 'convert_conventions',
-           'iter_cart_alphabet', 'HORTON2_CONVENTIONS', 'PSI4_CONVENTIONS']
+           'iter_cart_alphabet', 'HORTON2_CONVENTIONS', 'PSI4_CONVENTIONS',
+           'GBASIS_CONVENTIONS']
 
 ANGMOM_CHARS = 'spdfghiklmnoqrtuvwxyzabce'
 
@@ -323,21 +324,26 @@ def get_default_conventions():
     QC codes who happen to follow the same conventions.
     """
     horton2 = {(0, 'c'): ['1']}
-    psi4 = {(0, 'c'): ['1']}
+    psi4 = horton2.copy()
+    gbasis = horton2.copy()
     for angmom in range(1, 25):
         conv_cart = list('x' * nx + 'y' * ny + 'z' * nz
                          for nx, ny, nz in iter_cart_alphabet(angmom))
-        horton2[(angmom, 'c')] = conv_cart
-        psi4[(angmom, 'c')] = conv_cart
+        key = (angmom, 'c')
+        horton2[key] = conv_cart
+        psi4[key] = conv_cart
+        gbasis[key] = conv_cart[::-1]
         if angmom > 1:
             char = angmom_its(angmom)
             conv_pure = [char + 'c0']
             for absm in range(1, angmom + 1):
                 conv_pure.append('{}c{}'.format(char, absm))
                 conv_pure.append('{}s{}'.format(char, absm))
-            horton2[(angmom, 'p')] = conv_pure
-            psi4[(angmom, 'p')] = conv_pure[:1:-2] + conv_pure[:1] + conv_pure[1::2]
-    return horton2, psi4
+            key = (angmom, 'p')
+            horton2[key] = conv_pure
+            psi4[key] = conv_pure[:1:-2] + conv_pure[:1] + conv_pure[1::2]
+            gbasis[key] = psi4[key]
+    return horton2, psi4, gbasis
 
 
-HORTON2_CONVENTIONS, PSI4_CONVENTIONS = get_default_conventions()
+HORTON2_CONVENTIONS, PSI4_CONVENTIONS, GBASIS_CONVENTIONS = get_default_conventions()

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -25,7 +25,8 @@ from pytest import raises
 
 from ..basis import (angmom_sti, angmom_its, Shell, MolecularBasis,
                      convert_convention_shell, convert_conventions,
-                     iter_cart_alphabet, HORTON2_CONVENTIONS, PSI4_CONVENTIONS)
+                     iter_cart_alphabet, HORTON2_CONVENTIONS, PSI4_CONVENTIONS,
+                     GBASIS_CONVENTIONS)
 from ..formats.cp2k import CONVENTIONS as CP2K_CONVENTIONS
 
 
@@ -249,15 +250,22 @@ def test_iter_cart_alphabet():
 
 
 def test_conventions():
-    for angmom in range(24):
+    for angmom in range(25):
         assert HORTON2_CONVENTIONS[(angmom, 'c')] == PSI4_CONVENTIONS[(angmom, 'c')]
+    for angmom in range(2, 25):
+        assert GBASIS_CONVENTIONS[(angmom, 'p')] == PSI4_CONVENTIONS[(angmom, 'p')]
     assert HORTON2_CONVENTIONS[(0, 'c')] == ['1']
+    assert GBASIS_CONVENTIONS[(0, 'c')] == ['1']
     assert HORTON2_CONVENTIONS[(1, 'c')] == ['x', 'y', 'z']
+    assert GBASIS_CONVENTIONS[(1, 'c')] == ['z', 'y', 'x']
     assert HORTON2_CONVENTIONS[(2, 'c')] == ['xx', 'xy', 'xz', 'yy', 'yz', 'zz']
+    assert GBASIS_CONVENTIONS[(2, 'c')] == ['zz', 'yz', 'yy', 'xz', 'xy', 'xx']
     assert (0, 'p') not in HORTON2_CONVENTIONS
     assert (0, 'p') not in PSI4_CONVENTIONS
+    assert (0, 'p') not in GBASIS_CONVENTIONS
     assert (1, 'p') not in HORTON2_CONVENTIONS
     assert (1, 'p') not in PSI4_CONVENTIONS
+    assert (1, 'p') not in GBASIS_CONVENTIONS
     assert HORTON2_CONVENTIONS[(2, 'p')] == ['dc0', 'dc1', 'ds1', 'dc2', 'ds2']
     assert PSI4_CONVENTIONS[(2, 'p')] == ['ds2', 'ds1', 'dc0', 'dc1', 'dc2']
     assert HORTON2_CONVENTIONS[(3, 'p')] == ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', 'fc3', 'fs3']


### PR DESCRIPTION
I'm adding this in the same spirit as the other conventions we already have defined in IOData, i.e. to facilitate interoperability.