### PR TITLE
Simplify strings in conventions for pure functions

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -150,16 +150,28 @@ class MolecularBasis(NamedTuple):
         .. code-block:: python
 
             {
+                ### Conventions for Cartesian functions
+                # E.g., alphabetically ordered Cartesian functions.
                 (0, 'c'): ['1'],
                 (1, 'c'): ['x', 'y', 'z'],
-                # alphabetically ordered Cartesian functions
                 (2, 'c'): ['xx', 'xy', 'xz', 'yy', 'yz', 'zz'],
-                # or Wikipedia-ordered real solid spherical harmonics
-                # c = cosine-like
-                # s = sine-like
-                (2, 'p'): ['dc2', 'dc1', 'dc0', '-ds1', '-ds2'],
-                ...
+                ### Conventions for pure functions.
+                # The notation is referring to real solid spherical harmonics.
+                # See https://en.wikipedia.org/wiki/Solid_harmonics#Real_form
+                # c = cosine of the azimuthal angle
+                # s = sine of the azimuthal angle
+                # For example, wikipedia-ordered real spherical harmonics,
+                # see https://en.wikipedia.org/wiki/Spherical_harmonics#Real_form
+                (2, 'p'): ['s2', 's1', 'c0', 'c1', 'c2'],
+                # Different quantum-chemistry codes may use incompatible
+                # orderings and sign conventions. E.g. Molden files written
+                # by Orca use the following convention for pure f functions:
+                (3, 'p'): ['c0', 'c1', 's1', 'c2', 's2', '-c3', '-s3'],
+                # Note the sign change of the last two basis functions.
             }
+
+        The basis function strings in the conventions dictionary are documented
+        here: TODO.
 
     primitive_normalization
         Either 'L1' or 'L2'.
@@ -332,11 +344,10 @@ def get_default_conventions():
         psi4[key] = conv_cart
         gbasis[key] = conv_cart[::-1]
         if angmom > 1:
-            char = angmom_its(angmom)
-            conv_pure = [char + 'c0']
+            conv_pure = ['c0']
             for absm in range(1, angmom + 1):
-                conv_pure.append('{}c{}'.format(char, absm))
-                conv_pure.append('{}s{}'.format(char, absm))
+                conv_pure.append('c{}'.format(absm))
+                conv_pure.append('s{}'.format(absm))
             key = (angmom, 'p')
             horton2[key] = conv_pure
             psi4[key] = conv_pure[:1:-2] + conv_pure[:1] + conv_pure[1::2]

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -158,8 +158,10 @@ class MolecularBasis(NamedTuple):
                 ### Conventions for pure functions.
                 # The notation is referring to real solid spherical harmonics.
                 # See https://en.wikipedia.org/wiki/Solid_harmonics#Real_form
-                # c = cosine of the azimuthal angle
-                # s = sine of the azimuthal angle
+                # 'c{m}' = solid harmonic containing cos(m phi)
+                # 's{m}' = solid harmonic containing sin(m phi)
+                # where m is the magnetic quantum number and phi is the
+                # azimuthal angle.
                 # For example, wikipedia-ordered real spherical harmonics,
                 # see https://en.wikipedia.org/wiki/Spherical_harmonics#Real_form
                 (2, 'p'): ['s2', 's1', 'c0', 'c1', 'c2'],
@@ -167,7 +169,8 @@ class MolecularBasis(NamedTuple):
                 # orderings and sign conventions. E.g. Molden files written
                 # by Orca use the following convention for pure f functions:
                 (3, 'p'): ['c0', 'c1', 's1', 'c2', 's2', '-c3', '-s3'],
-                # Note the sign change of the last two basis functions.
+                # Note that the minus sign in the last two basis functions
+                # denotes that the signs of these harmonics have been changed.
             }
 
         The basis function strings in the conventions dictionary are documented

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -379,11 +379,11 @@ def _fix_obasis_orca(obasis: MolecularBasis) -> MolecularBasis:
     orca_conventions = {
         (0, 'c'): ['1'],
         (1, 'c'): ['x', 'y', 'z'],
-        (2, 'p'): ['dc0', 'dc1', 'ds1', 'dc2', 'ds2'],
+        (2, 'p'): ['c0', 'c1', 's1', 'c2', 's2'],
         (2, 'c'): ['xx', 'yy', 'zz', 'xy', 'xz', 'yz'],
-        (3, 'p'): ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', '-fc3', '-fs3'],
+        (3, 'p'): ['c0', 'c1', 's1', 'c2', 's2', '-c3', '-s3'],
         (3, 'c'): ['xxx', 'yyy', 'zzz', 'xyy', 'xxy', 'xxz', 'xzz', 'yzz', 'yyz', 'xyz'],
-        (4, 'p'): ['gc0', 'gc1', 'gs1', 'gc2', 'gs2', '-gc3', '-gs3', '-gc4', '-gs4'],
+        (4, 'p'): ['c0', 'c1', 's1', 'c2', 's2', '-c3', '-s3', '-c4', '-s4'],
         (4, 'c'): ['xxxx', 'yyyy', 'zzzz', 'xxxy', 'xxxz', 'xyyy', 'yyyz', 'xzzz',
                    'yzzz', 'xxyy', 'xxzz', 'yyzz', 'xxyz', 'xyyz', 'xyzz'],
     }

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -266,7 +266,7 @@ def test_conventions():
     assert (1, 'p') not in HORTON2_CONVENTIONS
     assert (1, 'p') not in PSI4_CONVENTIONS
     assert (1, 'p') not in GBASIS_CONVENTIONS
-    assert HORTON2_CONVENTIONS[(2, 'p')] == ['dc0', 'dc1', 'ds1', 'dc2', 'ds2']
-    assert PSI4_CONVENTIONS[(2, 'p')] == ['ds2', 'ds1', 'dc0', 'dc1', 'dc2']
-    assert HORTON2_CONVENTIONS[(3, 'p')] == ['fc0', 'fc1', 'fs1', 'fc2', 'fs2', 'fc3', 'fs3']
-    assert PSI4_CONVENTIONS[(3, 'p')] == ['fs3', 'fs2', 'fs1', 'fc0', 'fc1', 'fc2', 'fc3']
+    assert HORTON2_CONVENTIONS[(2, 'p')] == ['c0', 'c1', 's1', 'c2', 's2']
+    assert PSI4_CONVENTIONS[(2, 'p')] == ['s2', 's1', 'c0', 'c1', 'c2']
+    assert HORTON2_CONVENTIONS[(3, 'p')] == ['c0', 'c1', 's1', 'c2', 's2', 'c3', 's3']
+    assert PSI4_CONVENTIONS[(3, 'p')] == ['s3', 's2', 's1', 'c0', 'c1', 'c2', 'c3']


### PR DESCRIPTION
The character for the angular momentum is omitted because it is redundant. With this change, the conventions are no longer limited in angular momentum by the availability of alphabetical characters.

Some mistakes in the docstring of `MolecularBasis` are also fixed. More elaborate documentation will be added in a separate PR. See #131 