### PR TITLE
Remove GBASIS_CONVENTIONS

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -26,8 +26,7 @@ import numpy as np
 
 __all__ = ['angmom_sti', 'angmom_its', 'Shell', 'MolecularBasis',
            'convert_convention_shell', 'convert_conventions',
-           'iter_cart_alphabet', 'HORTON2_CONVENTIONS', 'PSI4_CONVENTIONS',
-           'GBASIS_CONVENTIONS']
+           'iter_cart_alphabet', 'HORTON2_CONVENTIONS', 'PSI4_CONVENTIONS']
 
 ANGMOM_CHARS = 'spdfghiklmnoqrtuvwxyzabce'
 
@@ -338,14 +337,12 @@ def get_default_conventions():
     """
     horton2 = {(0, 'c'): ['1']}
     psi4 = horton2.copy()
-    gbasis = horton2.copy()
     for angmom in range(1, 25):
         conv_cart = list('x' * nx + 'y' * ny + 'z' * nz
                          for nx, ny, nz in iter_cart_alphabet(angmom))
         key = (angmom, 'c')
         horton2[key] = conv_cart
         psi4[key] = conv_cart
-        gbasis[key] = conv_cart[::-1]
         if angmom > 1:
             conv_pure = ['c0']
             for absm in range(1, angmom + 1):
@@ -354,8 +351,7 @@ def get_default_conventions():
             key = (angmom, 'p')
             horton2[key] = conv_pure
             psi4[key] = conv_pure[:1:-2] + conv_pure[:1] + conv_pure[1::2]
-            gbasis[key] = psi4[key]
-    return horton2, psi4, gbasis
+    return horton2, psi4
 
 
-HORTON2_CONVENTIONS, PSI4_CONVENTIONS, GBASIS_CONVENTIONS = get_default_conventions()
+HORTON2_CONVENTIONS, PSI4_CONVENTIONS = get_default_conventions()

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -25,8 +25,7 @@ from pytest import raises
 
 from ..basis import (angmom_sti, angmom_its, Shell, MolecularBasis,
                      convert_convention_shell, convert_conventions,
-                     iter_cart_alphabet, HORTON2_CONVENTIONS, PSI4_CONVENTIONS,
-                     GBASIS_CONVENTIONS)
+                     iter_cart_alphabet, HORTON2_CONVENTIONS, PSI4_CONVENTIONS)
 from ..formats.cp2k import CONVENTIONS as CP2K_CONVENTIONS
 
 
@@ -252,20 +251,13 @@ def test_iter_cart_alphabet():
 def test_conventions():
     for angmom in range(25):
         assert HORTON2_CONVENTIONS[(angmom, 'c')] == PSI4_CONVENTIONS[(angmom, 'c')]
-    for angmom in range(2, 25):
-        assert GBASIS_CONVENTIONS[(angmom, 'p')] == PSI4_CONVENTIONS[(angmom, 'p')]
     assert HORTON2_CONVENTIONS[(0, 'c')] == ['1']
-    assert GBASIS_CONVENTIONS[(0, 'c')] == ['1']
     assert HORTON2_CONVENTIONS[(1, 'c')] == ['x', 'y', 'z']
-    assert GBASIS_CONVENTIONS[(1, 'c')] == ['z', 'y', 'x']
     assert HORTON2_CONVENTIONS[(2, 'c')] == ['xx', 'xy', 'xz', 'yy', 'yz', 'zz']
-    assert GBASIS_CONVENTIONS[(2, 'c')] == ['zz', 'yz', 'yy', 'xz', 'xy', 'xx']
     assert (0, 'p') not in HORTON2_CONVENTIONS
     assert (0, 'p') not in PSI4_CONVENTIONS
-    assert (0, 'p') not in GBASIS_CONVENTIONS
     assert (1, 'p') not in HORTON2_CONVENTIONS
     assert (1, 'p') not in PSI4_CONVENTIONS
-    assert (1, 'p') not in GBASIS_CONVENTIONS
     assert HORTON2_CONVENTIONS[(2, 'p')] == ['c0', 'c1', 's1', 'c2', 's2']
     assert PSI4_CONVENTIONS[(2, 'p')] == ['s2', 's1', 'c0', 'c1', 'c2']
     assert HORTON2_CONVENTIONS[(3, 'p')] == ['c0', 'c1', 's1', 'c2', 's2', 'c3', 's3']


### PR DESCRIPTION
Fixes #132 
It was outdated and no longer useful because GBasis has its own wrapper for IOData.