### PR TITLE
Fix pylint issues

### DIFF
--- a/.roberto.yaml
+++ b/.roberto.yaml
@@ -1,3 +1,4 @@
+abs: true  # Force absolute comparison for cardboardlint
 project:
   name: iodata
   conda_requirements: [sympy]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -32,8 +32,8 @@ import subprocess
 
 on_rtd = os.environ.get('READTHEDOCS', None) == 'True'
 if on_rtd:
-    subprocess.run(['python', '-m', 'pip', 'install', '..'], )
-    subprocess.run(['./gen_docs.sh'], shell=True)
+    subprocess.run(['python', '-m', 'pip', 'install', '..'], check=True)
+    subprocess.run(['./gen_docs.sh'], shell=True, check=True)
 
 # Custom sidebar templates, must be a dictionary that maps document names
 # to template names.

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -68,7 +68,7 @@ def _select_format_module(filename: str, attrname: str, fmt: str = None) -> Modu
     """
     basename = os.path.basename(filename)
     if fmt is None:
-        for name, format_module in FORMAT_MODULES.items():
+        for format_module in FORMAT_MODULES.values():
             if any(fnmatch(basename, pattern) for pattern in format_module.PATTERNS):
                 if hasattr(format_module, attrname):
                     return format_module

--- a/iodata/formats/cp2k.py
+++ b/iodata/formats/cp2k.py
@@ -393,7 +393,7 @@ def load_one(lit: LineIterator) -> dict:
             if 'U' in line:
                 restricted = False
                 break
-            elif 'R' in line:
+            if 'R' in line:
                 restricted = True
                 break
 
@@ -404,7 +404,7 @@ def load_one(lit: LineIterator) -> dict:
             atcorenum = float(line[70:])
             assert atcorenum == int(atcorenum)
             break
-        elif line.startswith(' Electronic structure'):
+        if line.startswith(' Electronic structure'):
             atcorenum = float(atnum)
             break
 

--- a/iodata/formats/gaussianlog.py
+++ b/iodata/formats/gaussianlog.py
@@ -58,7 +58,7 @@ def load_one(lit: LineIterator) -> dict:
         line = next(lit)
         if line.startswith(" Normal termination of Gaussian"):
             break
-        elif line.startswith(' *** Overlap ***'):
+        if line.startswith(' *** Overlap ***'):
             one_ints['olp'] = _load_twoindex_g09(lit, nbasis)
         elif line.startswith(' *** Kinetic Energy ***'):
             one_ints['kin_ao'] = _load_twoindex_g09(lit, nbasis)

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -58,6 +58,7 @@ def validate_shape(*shape):
     return validator
 
 
+# pylint: disable=too-many-instance-attributes
 @attr.s(auto_attribs=True, slots=True)
 class IOData:
     """A container class for data loaded from (or to be written to) a file.

--- a/iodata/test/test_cli.py
+++ b/iodata/test/test_cli.py
@@ -57,14 +57,15 @@ def test_convert_one_manfmt(tmpdir):
 
 def test_script_one_autofmt(tmpdir):
     def myconvert(infn, outfn):
-        subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn])
+        subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn],
+                       check=True)
     _check_convert_one(myconvert, tmpdir)
 
 
 def test_script_one_manfmt(tmpdir):
     def myconvert(infn, outfn):
         subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn,
-                        '-i', 'fchk', '-o', 'xyz'])
+                        '-i', 'fchk', '-o', 'xyz'], check=True)
     _check_convert_one(myconvert, tmpdir)
 
 
@@ -95,12 +96,13 @@ def test_convert_many_manfmt(tmpdir):
 
 def test_script_many_autofmt(tmpdir):
     def myconvert(infn, outfn):
-        subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn, '-m'])
+        subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn, '-m'],
+                       check=True)
     _check_convert_many(myconvert, tmpdir)
 
 
 def test_script_many_manfmt(tmpdir):
     def myconvert(infn, outfn):
         subprocess.run(['python', '-m', 'iodata.__main__', infn, outfn,
-                        '-m', '-i', 'fchk', '-o', 'xyz'])
+                        '-m', '-i', 'fchk', '-o', 'xyz'], check=True)
     _check_convert_many(myconvert, tmpdir)


### PR DESCRIPTION
This PR also stops cardboardlint from filtering out issues related to code that was not changed in a PR. This change will reduce the probability to have failures on the master branch, but it may sometimes result in errors in the PR for things that are unrelated to the PR, e.g. when a newer version of pylint can detect new style issues.