### PR TITLE
Add mkl dump functionality 

### DIFF
--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -19,7 +19,7 @@
 """Molden file format.
 
 Many QC codes can write out Molden files, e.g. `Molpro <https://www.molpro.net/>`_,
-`Orca <https://orcaforum.cec.mpg.de/>`_, `PSI4 <http://www.psicode.org/>`_,
+`Orca <https://sites.google.com/site/orcainputlibrary/>`_, `PSI4 <http://www.psicode.org/>`_,
 `Molden <http://www.cmbi.ru.nl/molden/>`_, `Turbomole <http://www.turbomole.com/>`_. Keep
 in mind that several of these write incorrect versions of the file format, but these
 errors are corrected when loading them with IOData.

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -295,9 +295,10 @@ def dump_one(f: TextIO, data: IOData):
         iatom_new = shell.icenter
         if iatom_new != iatom_last:
             f.write('$$\n')
-        for iangmom, angmom in enumerate(shell.angmoms):
+        for iangmom, (angmom, kind) in enumerate(zip(shell.angmoms, shell.kinds)):
             iatom_last = shell.icenter
-            f.write(' {} {:1s} 1.00\n'.format(shell.nbasis, angmom_its(angmom).capitalize()))
+            nbasis = len(CONVENTIONS[(angmom, kind)])
+            f.write(' {} {:1s} 1.00\n'.format(nbasis, angmom_its(angmom).capitalize()))
             for exponent, coeff in zip(shell.exponents, shell.coeffs[:, iangmom]):
                 f.write('{:20.10f} {:17.10f}\n'.format(exponent, coeff))
     f.write('\n')
@@ -355,10 +356,10 @@ def _dump_helper_coeffs(f, data, spin=None):
         else:
             f.write(' a1g' * 5 + '\n')
 
-        en = ' '.join(['   {: ,.7f}'.format(e) for e in ener[j:j + 5]])
+        en = ' '.join(['   {: ,.12f}'.format(e) for e in ener[j:j + 5]])
         f.write(en + '\n')
         for orb in coeff[:, j:j + 5]:
-            coeffs = ' '.join(['  {: ,.7f}'.format(c) for c in orb])
+            coeffs = ' '.join(['  {: ,.12f}'.format(c) for c in orb])
             f.write(coeffs + '\n')
 
     f.write(' $END\n')

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -126,7 +126,6 @@ def _load_helper_coeffs(lit: LineIterator, nbasis: int) -> Tuple[np.ndarray, np.
             ncol = len(words)
             assert ncol > 0
             for word in words:
-                # assert word == 'a1g'
                 irreps.append(word)
             cols = [np.zeros((nbasis, 1), float) for _ in range(ncol)]
             in_orb = 1
@@ -262,7 +261,7 @@ def dump_one(f: TextIO, data: IOData):
     # Header
     f.write('$MKL\n')
     f.write('#\n')
-    f.write('# MKL format file produced by ORCA\n')
+    f.write('# MKL format file produced by IOData\n')
     f.write('#\n')
 
     # CHAR_MUL
@@ -274,9 +273,8 @@ def dump_one(f: TextIO, data: IOData):
     # COORD
     atcoords = data.atcoords / angstrom
     f.write('$COORD\n')
-    for x in range(len(data.atnums)):
-        f.write('   {:d}   {: ,.6f}  {: ,.6f}  {: ,.6f}\n'.format(data.atnums[x], atcoords[x][0],
-                                                                  atcoords[x][1], atcoords[x][2]))
+    for n, coord in zip(data.atnums, atcoords):
+        f.write('   {:d}   {: ,.6f}  {: ,.6f}  {: ,.6f}\n'.format(n, coord[0], coord[1], coord[2]))
     f.write('$END\n')
     f.write('\n')
 
@@ -285,7 +283,7 @@ def dump_one(f: TextIO, data: IOData):
         charges = data.atcharges['mulliken']
     else:
         charges = {}
-        warnings.warn('Mulliken charges not stored in IOData. Proceeding without printing them.')
+        warnings.warn('Skip writing Mulliken charges, because they are not stored in IOData.')
     f.write('$CHARGES\n')
     for charge in charges:
         f.write('  {: ,.6f}\n'.format(charge))
@@ -336,6 +334,9 @@ def dump_one(f: TextIO, data: IOData):
         # OCC_BETA
         f.write('$OCC_BETA\n')
         _dump_helper_occ(f, data, spin='b')
+
+    else:
+        raise ValueError(f"The MKL format does not support {data.mo.kind} orbitals.")
 
 
 # Defining help dumping functions

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -252,7 +252,7 @@ def load_one(lit: LineIterator) -> dict:
     return result
 
 
-@document_dump_one("Molekel", ['atcoords', 'atnums', 'mo', 'obasis'])
+@document_dump_one("Molekel", ['atcoords', 'atnums', 'mo', 'obasis'], ['atcharges'])
 def dump_one(f: TextIO, data: IOData):
     """Do not edit this docstring. It will be overwritten."""
     # Header
@@ -271,10 +271,8 @@ def dump_one(f: TextIO, data: IOData):
     atcoords = data.atcoords / angstrom
     f.write('$COORD\n')
     for x in range(len(data.atnums)):
-        f.write('   {:d}   {: ,.6f}  {: ,.6f}  {: ,.6f}\n'.format(data.atnums[x],
-                                                                  atcoords[x][0], atcoords[x][1],
-                                                                  atcoords[x][2]))
-
+        f.write('   {:d}   {: ,.6f}  {: ,.6f}  {: ,.6f}\n'.format(data.atnums[x], atcoords[x][0],
+                                                                  atcoords[x][1], atcoords[x][2]))
     f.write('$END\n')
     f.write('\n')
 
@@ -283,31 +281,25 @@ def dump_one(f: TextIO, data: IOData):
         charges = data.atcharges['mulliken']
     else:
         charges = {}
-        warnings.warn('Mulliken charges not stored in IOData. Proceding without printing them')
+        warnings.warn('Mulliken charges not stored in IOData. Proceeding without printing them.')
     f.write('$CHARGES\n')
     for charge in charges:
         f.write('  {: ,.6f}\n'.format(charge))
-
     f.write('$END\n')
     f.write('\n')
 
     # BASIS
     f.write('$BASIS\n')
-
-    iatom_new = 0
     iatom_last = 0
     for shell in data.obasis.shells:
         iatom_new = shell.icenter
         if iatom_new != iatom_last:
             f.write('$$\n')
-
         for iangmom, angmom in enumerate(shell.angmoms):
             iatom_last = shell.icenter
-            f.write(' {} {:1s} 1.00\n'.format(shell.nbasis,
-                                              angmom_its(angmom).capitalize()))
+            f.write(' {} {:1s} 1.00\n'.format(shell.nbasis, angmom_its(angmom).capitalize()))
             for exponent, coeff in zip(shell.exponents, shell.coeffs[:, iangmom]):
                 f.write('{:20.10f} {:17.10f}\n'.format(exponent, coeff))
-
     f.write('\n')
     f.write('$END\n')
     f.write('\n')
@@ -321,7 +313,7 @@ def dump_one(f: TextIO, data: IOData):
         f.write('$OCC_ALPHA\n')
         _dump_helper_occ(f, data, spin='ab')
 
-    # Not taking into account genralized.
+    # Not taking into account generalized.
     elif data.mo.kind == 'unrestricted':
         # COEFF_ALPHA
         f.write('$COEFF_ALPHA\n')
@@ -389,5 +381,4 @@ def _dump_helper_occ(f, data, spin=None):
     for j in range(0, norb, 5):
         occs = ' '.join(['  {: ,.7f}'.format(o) for o in occ[j:j + 5]])
         f.write(occs + '\n')
-
     f.write(' $END\n')

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -47,6 +47,17 @@ def _load_helper_charge_spinpol(lit: LineIterator) -> List[int]:
     return charge, spinpol
 
 
+def _load_helper_charges(lit: LineIterator) -> dict:
+    atcharges = []
+    for line in lit:
+        line = line.strip()
+        if line == '$END':
+            break
+        atcharges.append(float(line))
+
+    return {'mulliken': np.array(atcharges)}
+
+
 def _load_helper_atoms(lit: LineIterator) -> Tuple[np.ndarray, np.ndarray]:
     atnums = []
     atcoords = []
@@ -149,7 +160,7 @@ def _load_helper_occ(lit: LineIterator) -> np.ndarray:
 
 
 # pylint: disable=too-many-branches,too-many-statements
-@document_load_one("Molekel", ['atcoords', 'atnums', 'mo', 'obasis'])
+@document_load_one("Molekel", ['atcoords', 'atnums', 'mo', 'obasis'], ['atcharges'])
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     charge = None
@@ -162,6 +173,7 @@ def load_one(lit: LineIterator) -> dict:
     coeffsb = None
     energiesb = None
     occsb = None
+    atcharges = None
     # Using a loop because we're not entirely sure if sections in an MKL file
     # have a fixed order.
     while True:
@@ -173,6 +185,8 @@ def load_one(lit: LineIterator) -> dict:
             break
         if line == '$CHAR_MULT':
             charge, spinpol = _load_helper_charge_spinpol(lit)
+        elif line == '$CHARGES':
+            atcharges = _load_helper_charges(lit)
         elif line == '$COORD':
             atnums, atcoords = _load_helper_atoms(lit)
         elif line == '$BASIS':
@@ -230,6 +244,7 @@ def load_one(lit: LineIterator) -> dict:
         'atnums': atnums,
         'obasis': obasis,
         'mo': mo,
+        'atcharges': atcharges,
     }
     _fix_molden_from_buggy_codes(result, lit)
     return result

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -20,7 +20,7 @@
 
 This format is used by two programs:
 `Molekel <http://ugovaretto.github.io/molekel/wiki/pmwiki.php/Main/HomePage.html>`_ and
-`Orca <https://orcaforum.cec.mpg.de/>`_.
+`Orca <https://sites.google.com/site/orcainputlibrary/>`_.
 """
 
 import warnings

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -105,6 +105,10 @@ def compare_mols(mol1, mol2):
             s2 = set(word.lstrip('-') for word in mol2.obasis.conventions[key])
             assert s1 == s2, (s1, s2)
         assert mol1.obasis.primitive_normalization == mol2.obasis.primitive_normalization
+        # compute and compare Mulliken charges
+        charges1 = compute_mulliken_charges(mol1)
+        charges2 = compute_mulliken_charges(mol2)
+        assert_allclose(charges1, charges2, rtol=0.0, atol=1.0e-6)
     else:
         assert mol2.obasis is None
     # wfn

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -24,7 +24,7 @@ import os
 from numpy.testing import assert_equal, assert_allclose
 import pytest
 
-from .common import check_orthonormal, compare_mols
+from .common import check_orthonormal, compare_mols, compute_mulliken_charges
 from ..basis import convert_conventions
 from ..api import load_one, dump_one
 from ..overlap import compute_overlap
@@ -50,6 +50,10 @@ def compare_mols_diff_formats(mol1, mol2):
     assert_allclose(mol1.mo.occs, mol2.mo.occs)
     assert_allclose(mol1.mo.coeffs[permutation] * signs.reshape(-1, 1), mol2.mo.coeffs, atol=1e-8)
     assert_allclose(mol1.mo.energies, mol2.mo.energies)
+    # compute and compare Mulliken charges
+    charges1 = compute_mulliken_charges(mol1)
+    charges2 = compute_mulliken_charges(mol2)
+    assert_allclose(charges1, charges2, rtol=0.0, atol=1.0e-6)
 
 
 def check_load_dump_consistency(fn, tmpdir):

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -47,6 +47,9 @@ def test_load_mkl_ethanol():
     assert_equal(mol.atcoords.shape, (9, 3))
     assert_allclose(mol.atcoords[2, 1] / angstrom, 2.239037, atol=1.e-5)
     assert_allclose(mol.atcoords[5, 2] / angstrom, 0.948420, atol=1.e-5)
+    assert_equal(mol.atcharges['mulliken'].shape, (9,))
+    q = [0.143316, -0.445861, 0.173045, 0.173021, 0.024542, 0.143066, 0.143080, -0.754230, 0.400021]
+    assert_allclose(mol.atcharges['mulliken'], q)
     assert mol.obasis.nbasis == 39
     assert_allclose(mol.obasis.shells[0].exponents[0], 18.731137000)
     assert_allclose(mol.obasis.shells[4].exponents[0], 7.868272400)
@@ -77,6 +80,8 @@ def test_load_mkl_li2():
             mol = load_one(str(fn_mkl))
     assert len(record) == 1
     assert "ORCA" in record[0].message.args[0]
+    assert_equal(mol.atcharges['mulliken'].shape, (2,))
+    assert_allclose(mol.atcharges['mulliken'], [0.5, 0.5])
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffsa, olp)
@@ -89,6 +94,8 @@ def test_load_mkl_h2():
             mol = load_one(str(fn_mkl))
     assert len(record) == 1
     assert "ORCA" in record[0].message.args[0]
+    assert_equal(mol.atcharges['mulliken'].shape, (2,))
+    assert_allclose(mol.atcharges['mulliken'], [0, 0])
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -75,6 +75,14 @@ def test_load_dump_consistency_li2(tmpdir):
     assert "ORCA" in record[0].message.args[0]
 
 
+def check_load_molden_dump_molekel_li2(tmpdir):
+    check_load_dump_consistency('li2.molden.input', tmpdir)
+
+
+def check_load_fchk_dump_molekel_li2(tmpdir):
+    check_load_dump_consistency('li2_g09_nbasis_indep.fchk', tmpdir)
+
+
 def test_load_mkl_ethanol():
     with path('iodata.test.data', 'ethanol.mkl') as fn_mkl:
         with pytest.warns(FileFormatWarning) as record:


### PR DESCRIPTION
I added `dump_one` function for molekel file format and tested it similar to molden `dump_one` function. 