### PR TITLE
Add `load_one` for Q-Chem log file

### DIFF
--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -84,7 +84,7 @@ def load_one(lit: LineIterator) -> dict:
     moments_labels = ['dipole_moment', 'quadrupole_moments', 'dipole_tol']
     moments = {label: data.get(label, None) for label in moments_labels}
     # extra information
-    extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'nbasis', 'charge',
+    extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'charge',
                     'polarizability_tensor', 'hessian',
                     'imaginary_freq', 'vib_energy']
     extra = {label: data.get(label, None) for label in extra_labels}

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -50,7 +50,9 @@ def load_one(lit: LineIterator) -> dict:
     result = {label: data[label] for label in result_labels if data.get(label) is not None}
 
     # mulliken charges
-    result["atcharges"] = {"mulliken": data.get("mulliken_charges")}
+    if data.get("mulliken_charges") is not None:
+        result["atcharges"] = {"mulliken": data["mulliken_charges"]}
+
     # build molecular orbitals
     # ------------------------
     # restricted case

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -30,7 +30,7 @@ import numpy as np
 from ..docstrings import document_load_one
 from ..orbitals import MolecularOrbitals
 from ..periodic import sym2num
-from ..utils import LineIterator, kcalmol
+from ..utils import LineIterator, kcalmol, calmol
 
 __all__ = []
 
@@ -83,14 +83,16 @@ def load_one(lit: LineIterator) -> dict:
     # extra information
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'nbasis', 'charge',
                     'mulliken_charges', 'polarizability_tensor', 'hessian',
-                    'imaginary_freq', 'vib_energy', 'entropy_dict']
+                    'imaginary_freq', 'vib_energy']
     extra = {label: data.get(label, None) for label in extra_labels}
     # unit conversions for vibrational energy
     extra['vib_energy'] = extra.get('vib_energy') * kcalmol
     # convert kcal/mol to atomic units
     enthalpy_dict = {k: v * kcalmol for k, v in data['enthalpy_dict'].items()}
-    # todo: unit conversions for entropy
     extra['enthalpy_dict'] = enthalpy_dict
+    # unit conversions for entropy, atomic units + Kalvin
+    entropy_dict = {k: v * calmol for k, v in data['entropy_dict'].items()}
+    extra['entropy_dict'] = entropy_dict
     extra['moments'] = moments
     result['extra'] = extra
     return result

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -43,9 +43,11 @@ PATTERNS = ['*.qchemlog']
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     data = load_qchemlog_low(lit)
-    result_labels = ['atcoords', 'atmasses', 'atnums', 'charge',
-                     'charge', 'energy', 'g_rot', 'run_type']
-    result = {label: data.get(label, None) for label in result_labels}
+
+    # add these labels if they are loaded
+    result_labels = ['atcoords', 'atmasses', 'atnums', 'charge', 'charge', 'energy', 'g_rot',
+                     'run_type']
+    result = {label: data[label] for label in result_labels if data.get(label) is not None}
     # hessian matrix
     result["athessian"] = data.get("hessian")
     # mulliken charges
@@ -91,10 +93,12 @@ def load_one(lit: LineIterator) -> dict:
         moments[(2, 'c')] = data['quadrupole_moments'][[0, 1, 3, 2, 4, 5]]
     if moments:
         result['moments'] = moments
-    # extra information
+
+    # extra dictionary
+    # add these labels if they are loaded
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy',
                     'polarizability_tensor', 'imaginary_freq', 'vib_energy']
-    extra = {label: data.get(label, None) for label in extra_labels}
+    extra = {label: data[label] for label in extra_labels if data.get(label) is not None}
     # unit conversions for vibrational energy
     extra['vib_energy'] = extra.get('vib_energy') * kcalmol
     # convert kcal/mol to atomic units

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -171,23 +171,22 @@ def _helper_job(lit: LineIterator) -> Tuple:
     for line in lit:
         if line.strip() == '$end':
             break
-        else:
-            line_str = line.strip()
-            # https://manual.q-chem.com/5.2/A3.S4.html
-            # ideriv: the order of derivatives that are evaluated analytically
-            # incdft: iteration number after which incremental Fock matrix algorithm is initiated
-            # job type
-            if line_str.startswith('jobtype'):
-                run_type = line_str.split()[1]
-            elif line_str.startswith('method'):
-                method = line_str.split()[1]
-            elif line_str.startswith('unrestricted'):
-                unrestricted = int(line_str.split()[1])
-            elif line_str.startswith('basis'):
-                basis_set = line_str.split()[1]
-            # the symmetry
-            elif line_str.startswith('symmetry'):
-                symm = int(line_str.split()[1])
+        line_str = line.strip()
+        # https://manual.q-chem.com/5.2/A3.S4.html
+        # ideriv: the order of derivatives that are evaluated analytically
+        # incdft: iteration number after which incremental Fock matrix algorithm is initiated
+        # job type
+        if line_str.startswith('jobtype'):
+            run_type = line_str.split()[1]
+        elif line_str.startswith('method'):
+            method = line_str.split()[1]
+        elif line_str.startswith('unrestricted'):
+            unrestricted = int(line_str.split()[1])
+        elif line_str.startswith('basis'):
+            basis_set = line_str.split()[1]
+        # the symmetry
+        elif line_str.startswith('symmetry'):
+            symm = int(line_str.split()[1])
     return run_type, method, basis_set, unrestricted, symm
 
 
@@ -200,10 +199,9 @@ def _helper_electron(lit: LineIterator) -> Tuple:
     for line in lit:
         if line.strip().startswith('-------------'):
             break
-        else:
-            # print(line.strip())
-            atom_symbols.append(line.strip().split()[1])
-            atcoords.append([float(i) for i in line.strip().split()[2:]])
+        # print(line.strip())
+        atom_symbols.append(line.strip().split()[1])
+        atcoords.append([float(i) for i in line.strip().split()[2:]])
     atnums = np.array([sym2num[i] for i in atom_symbols])
     atcoords = np.array(atcoords)
     # nuclear_replusion_energy = float(re.findall('\d+\.\d+', next(line).strip())[-2])
@@ -271,8 +269,7 @@ def _helper_mulliken(lit: LineIterator) -> np.ndarray:
     for line in lit:
         if line.strip().startswith('--------'):
             break
-        else:
-            mulliken_charges.append(line.strip().split()[-2])
+        mulliken_charges.append(line.strip().split()[-2])
     return np.array(mulliken_charges, dtype=np.float)
 
 
@@ -303,8 +300,7 @@ def _helper_polar(lit: LineIterator) -> np.ndarray:
     for line in lit:
         if line.strip().startswith('Calculating analytic Hessian'):
             break
-        else:
-            polarizability_tensor.append(line.strip().split()[1:])
+        polarizability_tensor.append(line.strip().split()[1:])
     return np.array(polarizability_tensor, dtype=np.float)
 
 
@@ -316,13 +312,12 @@ def _helper_hessian(lit: LineIterator, natoms: int) -> np.ndarray:
     for line in lit:
         if line.strip().startswith('****************'):
             break
+        if not line.startswith('            '):
+            line_list = line.strip().split()
+            row_idx = int(line_list[0]) - 1
+            hessian[row_idx, col_idx[0] - 1:col_idx[-1]] = line_list[1:]
         else:
-            if not line.startswith('            '):
-                line_list = line.strip().split()
-                row_idx = int(line_list[0]) - 1
-                hessian[row_idx, col_idx[0] - 1:col_idx[-1]] = line_list[1:]
-            else:
-                col_idx = [int(i) for i in line.strip().split()]
+            col_idx = [int(i) for i in line.strip().split()]
     return hessian.astype(np.float)
 
 
@@ -338,8 +333,7 @@ def _helper_vibrational(lit: LineIterator) -> Tuple:
     for line in lit:
         if line.strip().startswith('Molecular Mass:'):
             break
-        else:
-            atmasses.append(line.strip().split()[-1])
+        atmasses.append(line.strip().split()[-1])
     atmasses = np.array(atmasses, dtype=np.float)
     return imaginary_freq, vib_energy, atmasses
 
@@ -352,23 +346,20 @@ def _helper_thermo(lit: LineIterator) -> Tuple:
         line_str = line.strip()
         if line_str.startswith('Archival summary:'):
             break
-        else:
-            if line_str.startswith('Translational Enthalpy'):
-                enthalpy_dict['trans_enthalpy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Rotational Enthalpy'):
-                enthalpy_dict['rot_enthalpy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Vibrational Enthalpy'):
-                enthalpy_dict['vib_enthalpy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Total Enthalpy'):
-                enthalpy_dict['enthalpy_total'] = float(line_str.split()[-2])
-            elif line_str.startswith('Translational Entropy'):
-                entropy_dict['trans_entropy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Rotational Entropy'):
-                entropy_dict['rot_entropy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Vibrational Entropy'):
-                entropy_dict['vib_entropy'] = float(line_str.split()[-2])
-            elif line_str.startswith('Total Entropy'):
-                entropy_dict['entropy_total'] = float(line_str.split()[-2])
-            else:
-                continue
+        if line_str.startswith('Translational Enthalpy'):
+            enthalpy_dict['trans_enthalpy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Rotational Enthalpy'):
+            enthalpy_dict['rot_enthalpy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Vibrational Enthalpy'):
+            enthalpy_dict['vib_enthalpy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Total Enthalpy'):
+            enthalpy_dict['enthalpy_total'] = float(line_str.split()[-2])
+        elif line_str.startswith('Translational Entropy'):
+            entropy_dict['trans_entropy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Rotational Entropy'):
+            entropy_dict['rot_entropy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Vibrational Entropy'):
+            entropy_dict['vib_entropy'] = float(line_str.split()[-2])
+        elif line_str.startswith('Total Entropy'):
+            entropy_dict['entropy_total'] = float(line_str.split()[-2])
     return enthalpy_dict, entropy_dict

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -84,7 +84,7 @@ def load_one(lit: LineIterator) -> dict:
     moments_labels = ['dipole_moment', 'quadrupole_moments', 'dipole_tol']
     moments = {label: data.get(label, None) for label in moments_labels}
     # extra information
-    extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'charge',
+    extra_labels = ['spin_multi', 'nuclear_repulsion_energy',
                     'polarizability_tensor', 'hessian',
                     'imaginary_freq', 'vib_energy']
     extra = {label: data.get(label, None) for label in extra_labels}

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -46,6 +46,8 @@ def load_one(lit: LineIterator) -> dict:
     result_labels = ['atcoords', 'atmasses', 'atnums', 'charge',
                      'charge', 'energy', 'g_rot', 'run_type']
     result = {label: data.get(label, None) for label in result_labels}
+    # hessian matrix
+    result["athessian"] = data.get("hessian")
     # mulliken charges
     result["atcharges"] = {"mulliken": data.get("mulliken_charges")}
     # build molecular orbitals
@@ -85,8 +87,7 @@ def load_one(lit: LineIterator) -> dict:
     moments = {label: data.get(label, None) for label in moments_labels}
     # extra information
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy',
-                    'polarizability_tensor', 'hessian',
-                    'imaginary_freq', 'vib_energy']
+                    'polarizability_tensor', 'imaginary_freq', 'vib_energy']
     extra = {label: data.get(label, None) for label in extra_labels}
     # unit conversions for vibrational energy
     extra['vib_energy'] = extra.get('vib_energy') * kcalmol

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -1,0 +1,314 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Q-Chem Log file format.
+
+"""
+import re
+from typing import List, Tuple
+
+import numpy as np
+
+from ..docstrings import document_load_one
+from ..orbitals import MolecularOrbitals
+from ..periodic import sym2num
+from ..utils import LineIterator, kcalmol
+
+__all__ = []
+
+PATTERNS = ['*.qchemlog']
+
+
+def load_qchemlog_low(lit: LineIterator) -> dict:
+    """Load the information from Q-Chem log file."""
+    data = {}
+    while True:
+        try:
+            line = next(lit).strip()
+        except StopIteration:
+            # Read until the end of the file.
+            break
+
+        # get the atomic information
+        if line.startswith('$molecule'):
+            data['charge'], data['spin_multi'], data['natom'], \
+              data['atnums'], data['atcoords'] = _helper_atoms(lit)
+            natoms = len(data['atnums'])
+        # job specifications
+        elif line.startswith('$rem'):
+            data['run_type'], data['method'], data['basis_set'], \
+              data['unrestricted'], data['symm'] = _helper_job(lit)
+        # standard nuclear orientation
+        elif line.startswith('Standard Nuclear Orientation (Angstroms)'):
+            # atnums, alpha_elec, beta_elec, nbasis, nuclear_replusion_energy, energy, atcoords
+            _, data['alpha_elec'], data['beta_elec'], data['nbasis'], \
+              data['nuclear_repulsion_energy'], data['energy'], _ = _helper_electron(lit)
+        # orbital energies
+        elif line.startswith('Orbital Energies (a.u.)'):
+            data['alpha_mo_occupied'], data['beta_mo_occupied'], data['alpha_mo_unoccupied'], \
+              data['beta_mo_unoccupied'], data['norba'], data['norbb'] = _helper_orbital_energies(lit)
+        # mulliken charges
+        elif line.startswith('Ground-State Mulliken Net Atomic Charges'):
+            data['mulliken_charges'] = _helper_mulliken(lit)
+        #  cartesian multipole moments
+        elif line.startswith('Cartesian Multipole Moments'):
+            data['dipole_moment'], data['quadrupole_moments'], data[
+                'dipole_tol'] = _helper_dipole_moments(lit)
+        # polarizability matrix
+        elif line.startswith('Polarizability Matrix (a.u.)'):
+            data['polarizability_tensor'] = _helper_polar(lit)
+        # hessian matrix
+        elif line.startswith('Hessian of the SCF Energy'):
+            data['hessian'] = _helper_hessian(lit, natoms)
+        # vibrational analysis
+        elif line.startswith('**                       VIBRATIONAL ANALYSIS'):
+            data['imaginary_freq'], data['vib_energy'], data['atmasses'] = _helper_vibrational(lit)
+        elif line.startswith('Rotational Symmetry Number'):
+            # rotational symmetry number
+            data['g_rot'] = int(line.split()[-1])
+            data['enthalpy_dict'], data['entropy_dict'] = _helper_thermo(lit)
+
+    return data
+
+
+def _helper_atoms(lit: LineIterator) -> Tuple:
+    """Load list of coordinates from an Q-Chem log output file format."""
+    # net charge and spin multiplicity
+    charge, spin_multi = [int(i) for i in next(lit).strip().split()]
+    natom = 0
+    atom_symbols = []
+    atcoords = []
+    for line in lit:
+        if line.strip() == '$end':
+            break
+        else:
+            atom_symbols.append(line.strip().split()[0])
+            atcoords.append([float(i) for i in line.strip().split()[1:]])
+            natom += 1
+    atnums = np.array([sym2num[i] for i in atom_symbols])
+    # coordinates in angstroms
+    atcoords = np.array(atcoords)
+    return charge, spin_multi, natom, atnums, atcoords
+
+
+def _helper_job(lit: LineIterator) -> Tuple:
+    """Load job specifications from Q-Chem log out file format."""
+    for line in lit:
+        if line.strip() == '$end':
+            break
+        else:
+            line_str = line.strip()
+            # https://manual.q-chem.com/5.2/A3.S4.html
+            # ideriv: the order of derivatives that are evaluated analytically
+            # incdft: iteration number after which incremental Fock matrix algorithm is initiated
+            # job type
+            if line_str.startswith('jobtype'):
+                run_type = line_str.split()[1]
+            elif line_str.startswith('method'):
+                method = line_str.split()[1]
+            elif line_str.startswith('unrestricted'):
+                unrestricted = int(line_str.split()[1])
+            elif line_str.startswith('basis'):
+                basis_set = line_str.split()[1]
+            # the symmetry
+            elif line_str.startswith('symmetry'):
+                symm = int(line_str.split()[1])
+    return run_type, method, basis_set, unrestricted, symm
+
+
+def _helper_electron(lit: LineIterator) -> Tuple:
+    """Load electron information from Q-Chem log out file format."""
+    next(lit)
+    next(lit)
+    atom_symbols = []
+    atcoords = []
+    for line in lit:
+        if line.strip().startswith('-------------'):
+            break
+        else:
+            # print(line.strip())
+            atom_symbols.append(line.strip().split()[1])
+            atcoords.append([float(i) for i in line.strip().split()[2:]])
+    atnums = np.array([sym2num[i] for i in atom_symbols])
+    atcoords = np.array(atcoords)
+    # nuclear_replusion_energy = float(re.findall('\d+\.\d+', next(line).strip())[-2])
+    nuclear_replusion_energy = float(next(lit).strip().split()[-2])
+    # number of num alpha electron and beta elections
+    alpha_elec, beta_elec = [int(i) for i in re.findall(r'\d', next(lit).strip())]
+    # number of basis
+    next(lit)
+    nbasis = int(next(lit).strip().split()[-3])
+    # total energy
+    for line in lit:
+        if line.strip().startswith('Total energy in the final basis set'):
+            break
+    energy = float(line.strip().split()[-1])
+    return atnums, alpha_elec, beta_elec, nbasis, nuclear_replusion_energy, energy, atcoords
+
+
+def _helper_orbital_energies(lit: LineIterator) -> Tuple:
+    """Load orbital energies."""
+    # alpha occupied MOs
+    alpha_mo_occupied = _helper_section('-- Occupied --', '-- Virtual --', lit, backward=True)
+    # alpha unoccupied MOs
+    alpha_mo_unoccupied = _helper_section('-- Virtual --', '', lit, backward=False)
+    # beta occupied MOs
+    beta_mo_occupied = _helper_section('-- Occupied --', '-- Virtual --', lit, backward=True)
+    # beta unoccupied MOs
+    beta_mo_unoccupied = _helper_section('-- Virtual --', '-' * 62, lit, backward=False)
+
+    # number of alpha molecular orbitals
+    norba = len(alpha_mo_occupied + alpha_mo_unoccupied)
+    # number of beta molecular orbitals
+    norbb = len(beta_mo_occupied + beta_mo_unoccupied)
+    # todo: not sure how to arrange the four type of molecular orbital energies here
+    return np.array(alpha_mo_occupied, dtype=np.float), \
+           np.array(beta_mo_occupied, dtype=np.float), \
+           np.array(alpha_mo_unoccupied, dtype=np.float), \
+           np.array(beta_mo_unoccupied, dtype=np.float), \
+           norba, norbb
+
+
+def _helper_section(start: str, end: str, lit: LineIterator, backward: bool = False) -> List:
+    """Load data between starting and ending strings."""
+    data = []
+    for line in lit:
+        line_str = line.strip()
+        if line_str == start:
+            break
+    for line in lit:
+        if line.strip() == end:
+            break
+        else:
+            data.extend(line.strip().split())
+    if backward:
+        lit.back(line)
+    return data
+
+
+def _helper_mulliken(lit: LineIterator) -> np.ndarray:
+    """Load mulliken net atomic charges."""
+    while True:
+        line = next(lit).strip()
+        if line.startswith('------'):
+            break
+    mulliken_charges = []
+    for line in lit:
+        if line.strip().startswith('--------'):
+            break
+        else:
+            mulliken_charges.append(line.strip().split()[-2])
+    return np.array(mulliken_charges, dtype=np.float)
+
+
+def _helper_dipole_moments(lit: LineIterator) -> Tuple:
+    """Load cartesian multiple moments."""
+    for line in lit:
+        if line.strip().startswith('Dipole Moment (Debye)'):
+            break
+    dipole_moment = next(lit).strip().split()
+    # only load the float numbers
+    dipole_moment = [dipole for idx, dipole in enumerate(dipole_moment) if idx % 2 != 0]
+    # total dipole_moments
+    dipole_tol = float(next(lit).strip().split()[-1])
+    # quadrupole_moments
+    next(lit)
+    quadrupole_moments = []
+    quadrupole_moments.extend(next(lit).strip().split())
+    quadrupole_moments.extend(next(lit).strip().split())
+    quadrupole_moments = [dipole for idx, dipole in enumerate(quadrupole_moments) if idx % 2 != 0]
+    return np.array(dipole_moment, dtype=np.float), \
+           np.array(quadrupole_moments, dtype=np.float), dipole_tol
+
+
+def _helper_polar(lit: LineIterator) -> np.ndarray:
+    """Load polarizability matrix."""
+    next(lit)
+    polarizability_tensor = []
+    for line in lit:
+        if line.strip().startswith('Calculating analytic Hessian'):
+            break
+        else:
+            polarizability_tensor.append(line.strip().split()[1:])
+    return np.array(polarizability_tensor, dtype=np.float)
+
+
+def _helper_hessian(lit: LineIterator, natoms: int) -> np.ndarray:
+    """Load hessian matrix."""
+    # hessian in Cartesian coordinates, shape(3 * natom, 3 * natom)
+    col_idx = [int(i) for i in next(lit).strip().split()]
+    hessian = np.empty((natoms*3, natoms*3), dtype=object)
+    for line in lit:
+        if line.strip().startswith('****************'):
+            break
+        else:
+            if not line.startswith('            '):
+                line_list = line.strip().split()
+                row_idx = int(line_list[0]) - 1
+                hessian[row_idx, col_idx[0]-1:col_idx[-1]] = line_list[1:]
+            else:
+                col_idx = [int(i) for i in line.strip().split()]
+    return hessian.astype(np.float)
+
+
+def _helper_vibrational(lit: LineIterator) -> Tuple:
+    """Load vibrational analysis."""
+    for line in lit:
+        if line.strip().startswith('This Molecule has'):
+            break
+    imaginary_freq = int(line.strip().split()[3])
+    vib_energy = float(next(lit).strip().split()[-2])
+    next(lit)
+    atmasses = []
+    for line in lit:
+        if line.strip().startswith('Molecular Mass:'):
+            break
+        else:
+            atmasses.append(line.strip().split()[-1])
+    atmasses = np.array(atmasses, dtype=np.float)
+    return imaginary_freq, vib_energy, atmasses
+
+
+def _helper_thermo(lit: LineIterator) -> Tuple:
+    """Load thermodynamics properties."""
+    enthalpy_dict = {}
+    entropy_dict = {}
+    for line in lit:
+        line_str = line.strip()
+        if line_str.startswith('Archival summary:'):
+            break
+        else:
+            if line_str.startswith('Translational Enthalpy'):
+                enthalpy_dict['trans_enthalpy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Rotational Enthalpy'):
+                enthalpy_dict['rot_enthalpy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Vibrational Enthalpy'):
+                enthalpy_dict['vib_enthalpy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Total Enthalpy'):
+                enthalpy_dict['enthalpy_total'] = float(line_str.split()[-2])
+            elif line_str.startswith('Translational Entropy'):
+                entropy_dict['trans_entropy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Rotational Entropy'):
+                entropy_dict['rot_entropy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Vibrational Entropy'):
+                entropy_dict['vib_entropy'] = float(line_str.split()[-2])
+            elif line_str.startswith('Total Entropy'):
+                entropy_dict['entropy_total'] = float(line_str.split()[-2])
+            else:
+                continue
+    return enthalpy_dict, entropy_dict

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -48,24 +48,31 @@ def load_one(lit: LineIterator) -> dict:
     # build molecular orbitals
     # todo: double check if this is right
     # mo_energies
-    # # restricted case
-    # if not data['unrestricted']:
-    #     mo_energies = np.concatenate(
-    #         (data['alpha_mo_occupied'], data['alpha_mo_unoccupied']), axis=0)
-    #     mo_coeffs = np.empty((data['nbasis'], data['norba'])) * np.nan
-    #     mo_occs = np.zeros(mo_coeffs.shape[1]) * np.nan
-    #     mo = MolecularOrbitals("restricted", data['norba'], data['norba'],
-    #                            mo_occs, mo_coeffs, mo_energies, None)
-    # # unrestricted case
-    # else:
-    #     mo_energies = np.concatenate(
-    #         (data['alpha_mo_occupied'], data['alpha_mo_unoccupied'],
-    #          data['beta_mo_occupied'], data['beta_mo_unoccupied']), axis=0)
-    #     mo_coeffs = np.empty((data['nbasis'], data['norba']+data['norbb'])) * np.nan
-    #     mo_occs = np.zeros(mo_coeffs.shape[1]) * np.nan
-    #     mo = MolecularOrbitals("unrestricted", data['norba'], data['norbb'],
-    #                            mo_occs, mo_coeffs, mo_energies, None)
-    # result['mo'] = mo
+    # restricted case
+    if not data['unrestricted']:
+        mo_energies = np.concatenate(
+            (data['alpha_mo_occupied'], data['alpha_mo_unoccupied']), axis=0)
+        mo_coeffs = np.empty((data['nbasis'], data['norba'])) * np.nan
+        mo_occs = np.zeros(mo_coeffs.shape[1])
+        mo_occs[:data['alpha_elec']] = 1.0
+        mo_occs[:data['beta_elec']] += 1.0
+        mo = MolecularOrbitals("restricted", data['norba'], data['norba'],
+                               mo_occs, mo_coeffs, mo_energies, None)
+    # unrestricted case
+    else:
+        mo_energies = np.concatenate(
+            (data['alpha_mo_occupied'], data['alpha_mo_unoccupied'],
+             data['beta_mo_occupied'], data['beta_mo_unoccupied']), axis=0)
+        mo_coeffs = np.empty((data['nbasis'], data['norba']+data['norbb'])) * np.nan
+        mo_occs = np.zeros(mo_coeffs.shape[1])
+        # number of alpha & beta electrons and number of alpha molecular orbitals
+        na, nb = data['alpha_elec'], data['beta_elec']
+        na_mo = len(data['alpha_mo_occupied']) + len(data['alpha_mo_unoccupied'])
+        mo_occs[:na] = 1.0
+        mo_occs[na_mo: na_mo + nb] = 1.0
+        mo = MolecularOrbitals("unrestricted", data['norba'], data['norbb'],
+                               mo_occs, mo_coeffs, mo_energies, None)
+    result['mo'] = mo
 
     result['lot'] = data['method']
     result['nelec'] = data['alpha_elec'] + data['beta_elec']

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -130,8 +130,7 @@ def load_qchemlog_low(lit: LineIterator) -> dict:
             data['natom'] = len(data['atnums'])
         # job specifications
         elif line.startswith('$rem'):
-            data['run_type'], data['lot'], data['obasis_name'], \
-                data['unrestricted'], data['symm'] = _helper_job(lit)
+            data.update(_helper_job(lit))
         # standard nuclear orientation
         elif line.startswith('Standard Nuclear Orientation (Angstroms)'):
             # atnums, alpha_elec, beta_elec, nbasis, nuclear_replusion_energy, energy, atcoords
@@ -186,26 +185,23 @@ def _helper_atoms(lit: LineIterator) -> Tuple:
 
 def _helper_job(lit: LineIterator) -> Tuple:
     """Load job specifications from Q-Chem log out file format."""
+    data_rem = {}
     for line in lit:
         if line.strip() == '$end':
             break
         line = line.strip()
-        # https://manual.q-chem.com/5.2/A3.S4.html
-        # ideriv: the order of derivatives that are evaluated analytically
-        # incdft: iteration number after which incremental Fock matrix algorithm is initiated
-        # job type
+        # parse job type section; some sections might not be available
         if line.lower().startswith('jobtype'):
-            run_type = line.split()[1].lower()
+            data_rem['run_type'] = line.split()[1].lower()
         elif line.lower().startswith('method'):
-            method = line.split()[1].lower()
+            data_rem['lot'] = line.split()[1].lower()
         elif line.lower().startswith('unrestricted'):
-            unrestricted = int(line.split()[1])
+            data_rem['unrestricted'] = int(line.split()[1])
         elif line.lower().startswith('basis'):
-            basis_set = line.split()[1].lower()
-        # the symmetry
+            data_rem['obasis_name'] = line.split()[1].lower()
         elif line.lower().startswith('symmetry'):
-            symm = int(line.split()[1])
-    return run_type, method, basis_set, unrestricted, symm
+            data_rem['symm'] = int(line.split()[1])
+    return data_rem
 
 
 def _helper_electron(lit: LineIterator) -> Tuple:

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -23,7 +23,7 @@ This module will load Q-Chem log file into IODATA.
 
 
 import re
-from typing import List, Tuple
+from typing import Tuple
 
 import numpy as np
 

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -189,22 +189,22 @@ def _helper_job(lit: LineIterator) -> Tuple:
     for line in lit:
         if line.strip() == '$end':
             break
-        line_str = line.strip()
+        line = line.strip()
         # https://manual.q-chem.com/5.2/A3.S4.html
         # ideriv: the order of derivatives that are evaluated analytically
         # incdft: iteration number after which incremental Fock matrix algorithm is initiated
         # job type
-        if line_str.startswith('jobtype'):
-            run_type = line_str.split()[1]
-        elif line_str.startswith('method'):
-            method = line_str.split()[1].lower()
-        elif line_str.startswith('unrestricted'):
-            unrestricted = int(line_str.split()[1])
-        elif line_str.startswith('basis'):
-            basis_set = line_str.split()[1].lower()
+        if line.lower().startswith('jobtype'):
+            run_type = line.split()[1].lower()
+        elif line.lower().startswith('method'):
+            method = line.split()[1].lower()
+        elif line.lower().startswith('unrestricted'):
+            unrestricted = int(line.split()[1])
+        elif line.lower().startswith('basis'):
+            basis_set = line.split()[1].lower()
         # the symmetry
-        elif line_str.startswith('symmetry'):
-            symm = int(line_str.split()[1])
+        elif line.lower().startswith('symmetry'):
+            symm = int(line.split()[1])
     return run_type, method, basis_set, unrestricted, symm
 
 

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -37,8 +37,9 @@ __all__ = []
 PATTERNS = ['*.qchemlog']
 
 
-@document_load_one("qchemlog", ['atcoords', 'athessian', 'atmasses', 'atnums', 'charge', 'energy',
-                                'g_rot', 'mo', 'lot', 'nelec', 'obasis_name', 'run_type', 'extra'])
+@document_load_one("qchemlog", ['atcoords', 'atmasses', 'atnums', 'charge', 'energy', 'g_rot',
+                                'mo', 'lot', 'nelec', 'obasis_name', 'run_type', 'extra'],
+                   ['athessian'])
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     data = load_qchemlog_low(lit)

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -46,6 +46,8 @@ def load_one(lit: LineIterator) -> dict:
     result_labels = ['atcoords', 'atmasses', 'atnums', 'charge',
                      'charge', 'energy', 'g_rot', 'run_type']
     result = {label: data.get(label, None) for label in result_labels}
+    # mulliken charges
+    result["atcharges"] = {"mulliken": data.get("mulliken_charges")}
     # build molecular orbitals
     # todo: double check if this is right
     # mo_energies
@@ -83,7 +85,7 @@ def load_one(lit: LineIterator) -> dict:
     moments = {label: data.get(label, None) for label in moments_labels}
     # extra information
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'nbasis', 'charge',
-                    'mulliken_charges', 'polarizability_tensor', 'hessian',
+                    'polarizability_tensor', 'hessian',
                     'imaginary_freq', 'vib_energy']
     extra = {label: data.get(label, None) for label in extra_labels}
     # unit conversions for vibrational energy

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -46,10 +46,9 @@ def load_one(lit: LineIterator) -> dict:
 
     # add these labels if they are loaded
     result_labels = ['atcoords', 'atmasses', 'atnums', 'charge', 'charge', 'energy', 'g_rot',
-                     'run_type']
+                     'run_type', 'athessian']
     result = {label: data[label] for label in result_labels if data.get(label) is not None}
-    # hessian matrix
-    result["athessian"] = data.get("hessian")
+
     # mulliken charges
     result["atcharges"] = {"mulliken": data.get("mulliken_charges")}
     # build molecular orbitals
@@ -152,7 +151,7 @@ def load_qchemlog_low(lit: LineIterator) -> dict:
             data['polarizability_tensor'] = _helper_polar(lit)
         # hessian matrix
         elif line.startswith('Hessian of the SCF Energy'):
-            data['hessian'] = _helper_hessian(lit, data['natom'])
+            data['athessian'] = _helper_hessian(lit, data['natom'])
         # vibrational analysis
         elif line.startswith('**                       VIBRATIONAL ANALYSIS'):
             data['imaginary_freq'], data['vib_energy'], data['atmasses'] = _helper_vibrational(lit)

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -250,10 +250,10 @@ def _helper_section(start: str, end: str, lit: LineIterator, backward: bool = Fa
         if line_str == start:
             break
     for line in lit:
-        if line.strip() == end:
-            break
-        else:
+        if line.strip() != end:
             data.extend(line.strip().split())
+        else:
+            break
     if backward:
         lit.back(line)
     return data
@@ -326,6 +326,7 @@ def _helper_vibrational(lit: LineIterator) -> Tuple:
     for line in lit:
         if line.strip().startswith('This Molecule has'):
             break
+    # pylint: disable= W0631
     imaginary_freq = int(line.strip().split()[3])
     vib_energy = float(next(lit).strip().split()[-2])
     next(lit)

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -34,6 +34,58 @@ __all__ = []
 PATTERNS = ['*.qchemlog']
 
 
+@document_load_one("qchemlog", ['atcoords', 'athessian', 'atmasses', 'atnums', 'charge', 'energy',
+                                'g_rot', 'mo', 'lot', 'nelec', 'obasis_name', 'run_type', 'extra'])
+def load_one(lit: LineIterator) -> dict:
+    """Do not edit this docstring. It will be overwritten."""
+    data = load_qchemlog_low(lit)
+    result_labels = ['atcoords', 'atmasses', 'atnums','charge',
+                     'charge', 'energy', 'g_rot', 'run_type']
+    result = {label: data.get(label, None) for label in result_labels}
+    # build molecular orbitals
+    # todo: double check if this is right
+    # mo_energies
+    # # restricted case
+    # if not data['unrestricted']:
+    #     mo_energies = np.concatenate(
+    #         (data['alpha_mo_occupied'], data['alpha_mo_unoccupied']), axis=0)
+    #     mo_coeffs = np.empty((data['nbasis'], data['norba'])) * np.nan
+    #     mo_occs = np.zeros(mo_coeffs.shape[1]) * np.nan
+    #     mo = MolecularOrbitals("restricted", data['norba'], data['norba'],
+    #                            mo_occs, mo_coeffs, mo_energies, None)
+    # # unrestricted case
+    # else:
+    #     mo_energies = np.concatenate(
+    #         (data['alpha_mo_occupied'], data['alpha_mo_unoccupied'],
+    #          data['beta_mo_occupied'], data['beta_mo_unoccupied']), axis=0)
+    #     mo_coeffs = np.empty((data['nbasis'], data['norba']+data['norbb'])) * np.nan
+    #     mo_occs = np.zeros(mo_coeffs.shape[1]) * np.nan
+    #     mo = MolecularOrbitals("unrestricted", data['norba'], data['norbb'],
+    #                            mo_occs, mo_coeffs, mo_energies, None)
+    # result['mo'] = mo
+
+    result['lot'] = data['method']
+    result['nelec'] = data['alpha_elec'] + data['beta_elec']
+    result['obasis_name'] = data['basis_set'].lower()
+    # moments
+    moments_labels = ['dipole_moment', 'quadrupole_moments', 'dipole_tol']
+    moments = {label: data.get(label, None) for label in moments_labels}
+    # extra information
+    extra_labels = ['spin_multi', 'nuclear_repulsion_energy', 'nbasis', 'charge',
+                    'mulliken_charges', 'polarizability_tensor', 'hessian',
+                    'imaginary_freq', 'vib_energy', 'entropy_dict']
+    extra = {label: data.get(label, None) for label in extra_labels}
+    # unit conversions for vibrational energy
+    extra['vib_energy'] = extra.get('vib_energy') * kcalmol
+    # convert kcal/mol to atomic units
+    enthalpy_dict = {k: v * kcalmol for k, v in data['enthalpy_dict'].items()}
+    # todo: unit conversions for entropy
+    extra['enthalpy_dict'] = enthalpy_dict
+    extra['moments'] = moments
+    result['extra'] = extra
+    return result
+
+
 def load_qchemlog_low(lit: LineIterator) -> dict:
     """Load the information from Q-Chem log file."""
     data = {}

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -46,7 +46,7 @@ def load_one(lit: LineIterator) -> dict:
 
     # add these labels if they are loaded
     result_labels = ['atcoords', 'atmasses', 'atnums', 'charge', 'charge', 'energy', 'g_rot',
-                     'run_type', 'athessian']
+                     'run_type', 'athessian', 'lot', 'obasis_name']
     result = {label: data[label] for label in result_labels if data.get(label) is not None}
 
     # mulliken charges
@@ -80,9 +80,7 @@ def load_one(lit: LineIterator) -> dict:
                                mo_occs, mo_coeffs, mo_energies, None)
     result['mo'] = mo
 
-    result['lot'] = data['method']
     result['nelec'] = data['alpha_elec'] + data['beta_elec']
-    result['obasis_name'] = data['basis_set'].lower()
     # moments
     moments = {}
     if 'dipole_moment' in data:
@@ -127,7 +125,7 @@ def load_qchemlog_low(lit: LineIterator) -> dict:
             data['natom'] = len(data['atnums'])
         # job specifications
         elif line.startswith('$rem'):
-            data['run_type'], data['method'], data['basis_set'], \
+            data['run_type'], data['lot'], data['obasis_name'], \
                 data['unrestricted'], data['symm'] = _helper_job(lit)
         # standard nuclear orientation
         elif line.startswith('Standard Nuclear Orientation (Angstroms)'):
@@ -193,11 +191,11 @@ def _helper_job(lit: LineIterator) -> Tuple:
         if line_str.startswith('jobtype'):
             run_type = line_str.split()[1]
         elif line_str.startswith('method'):
-            method = line_str.split()[1]
+            method = line_str.split()[1].lower()
         elif line_str.startswith('unrestricted'):
             unrestricted = int(line_str.split()[1])
         elif line_str.startswith('basis'):
-            basis_set = line_str.split()[1]
+            basis_set = line_str.split()[1].lower()
         # the symmetry
         elif line_str.startswith('symmetry'):
             symm = int(line_str.split()[1])

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -63,7 +63,7 @@ def load_one(lit: LineIterator) -> dict:
         mo_energies = np.concatenate(
             (data['alpha_mo_occupied'], data['alpha_mo_unoccupied'],
              data['beta_mo_occupied'], data['beta_mo_unoccupied']), axis=0)
-        mo_coeffs = np.empty((data['nbasis'], data['norba']+data['norbb'])) * np.nan
+        mo_coeffs = np.empty((data['nbasis'], data['norba'] + data['norbb'])) * np.nan
         mo_occs = np.zeros(mo_coeffs.shape[1])
         # number of alpha & beta electrons and number of alpha molecular orbitals
         na, nb = data['alpha_elec'], data['beta_elec']

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -60,7 +60,7 @@ def load_one(lit: LineIterator) -> dict:
     # restricted case
     if not data['unrestricted']:
         mo_energies = np.concatenate((data['mo_a_occ'], data['mo_a_vir']), axis=0)
-        mo_coeffs = np.empty((data['nbasis'], data['norba'])) * np.nan
+        mo_coeffs = np.full((data['nbasis'], data['norba']), np.nan)
         mo_occs = np.zeros(mo_coeffs.shape[1])
         mo_occs[:data['alpha_elec']] = 1.0
         mo_occs[:data['beta_elec']] += 1.0
@@ -70,7 +70,7 @@ def load_one(lit: LineIterator) -> dict:
     else:
         mo_energies = np.concatenate((data['mo_a_occ'], data['mo_a_vir'],
                                       data['mo_b_occ'], data['mo_b_vir']), axis=0)
-        mo_coeffs = np.empty((data['nbasis'], data['norba'] + data['norbb'])) * np.nan
+        mo_coeffs = np.full((data['nbasis'], data['norba'] + data['norbb']), np.nan)
         mo_occs = np.zeros(mo_coeffs.shape[1])
         # number of alpha & beta electrons and number of alpha molecular orbitals
         na, nb = data['alpha_elec'], data['beta_elec']

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -92,18 +92,23 @@ def load_one(lit: LineIterator) -> dict:
         result['moments'] = moments
 
     # extra dictionary
-    # add these labels if they are loaded
+    # ----------------
+    # add labels to extra dictionary if they are loaded
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy',
                     'polarizability_tensor', 'imaginary_freq', 'vib_energy']
     extra = {label: data[label] for label in extra_labels if data.get(label) is not None}
-    # unit conversions for vibrational energy
-    extra['vib_energy'] = extra.get('vib_energy') * kcalmol
-    # convert kcal/mol to atomic units
-    enthalpy_dict = {k: v * kcalmol for k, v in data['enthalpy_dict'].items()}
-    extra['enthalpy_dict'] = enthalpy_dict
-    # unit conversions for entropy, atomic units + Kalvin
-    entropy_dict = {k: v * calmol for k, v in data['entropy_dict'].items()}
-    extra['entropy_dict'] = entropy_dict
+    # if present, convert vibrational energy from kcal/mol to "atomic units + K"
+    if 'vib_energy' in extra:
+        extra['vib_energy'] *= kcalmol
+
+    # if present, convert enthalpy terms from kcal/mol to "atomic units + K"
+    if 'enthalpy_dict' in data:
+        extra['enthalpy_dict'] = {k: v * kcalmol for k, v in data['enthalpy_dict'].items()}
+
+    # if present, convert entropy terms from cal/mol.K to "atomic units + Kalvin"
+    if 'entropy_dict' in data:
+        extra['entropy_dict'] = {k: v * calmol for k, v in data['entropy_dict'].items()}
+
     result['extra'] = extra
     return result
 

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -83,8 +83,14 @@ def load_one(lit: LineIterator) -> dict:
     result['nelec'] = data['alpha_elec'] + data['beta_elec']
     result['obasis_name'] = data['basis_set'].lower()
     # moments
-    moments_labels = ['dipole_moment', 'quadrupole_moments', 'dipole_tol']
-    moments = {label: data.get(label, None) for label in moments_labels}
+    moments = {}
+    if 'dipole_moment' in data:
+        moments[(1, 'c')] = data['dipole_moment']
+    if 'quadrupole_moments' in data:
+        # Convert to alphabetical ordering: xx, xy, xz, yy, yz, zz
+        moments[(2, 'c')] = data['quadrupole_moments'][[0, 1, 3, 2, 4, 5]]
+    if moments:
+        result['moments'] = moments
     # extra information
     extra_labels = ['spin_multi', 'nuclear_repulsion_energy',
                     'polarizability_tensor', 'imaginary_freq', 'vib_energy']
@@ -97,7 +103,6 @@ def load_one(lit: LineIterator) -> dict:
     # unit conversions for entropy, atomic units + Kalvin
     entropy_dict = {k: v * calmol for k, v in data['entropy_dict'].items()}
     extra['entropy_dict'] = entropy_dict
-    extra['moments'] = moments
     result['extra'] = extra
     return result
 

--- a/iodata/test/data/water_hf_ccpvtz_freq_qchem.out
+++ b/iodata/test/data/water_hf_ccpvtz_freq_qchem.out
@@ -1,0 +1,421 @@
+You are running Q-Chem version: 5.2.0
+
+#
+# job setting
+#
+local host:  cori02
+current dir: /global/cscratch1/sd/farnazhz/test_iodata/h2o_freq
+input file:  water_hf_ccpvtz_freq_qchem.in
+output file: 
+nprocs     : 0
+nthreads   : 16
+#
+# qchem installation setting
+#
+QC:          /global/common/cori/software/qchem/5.2
+QCAUX:       /global/common/cori/software/qchem/5.2/qcaux
+QCPROG:      /global/common/cori/software/qchem/5.2/exe/qcprog.exe_s
+QCPROG_S:    /global/common/cori/software/qchem/5.2/exe/qcprog.exe_s
+PARALLEL:    -DSERIAL
+QCMPI:       mpich3
+#
+# qchem directory setting
+#
+qcrun:       qchem24177
+QCSCRATCH:   /global/cscratch1/sd/farnazhz
+QCLOCALSCR:  /tmp
+QCTMPDIR:    /tmp
+QCFILEPREF:  /tmp/qchem24177
+QCSAVEDIR:   
+workdirs:    /tmp/qchem24177
+workdir0:    /tmp/qchem24177
+partmpdirs =  
+#
+# parallel setting
+#
+QCRSH:           ssh
+QCMPI:           mpich3
+QCMPIRUN:        mpirun
+QCMACHINEFILE:   
+
+#
+# env setting
+#
+exported envs:   QC QCAUX QCSCRATCH QCRUNNAME QCFILEPREF QCPROG QCPROG_S GUIFILE
+
+Running Job 1 of 1 water_hf_ccpvtz_freq_qchem.in
+qchem water_hf_ccpvtz_freq_qchem.in_24177.0 /tmp/qchem24177/ 0
+/global/common/cori/software/qchem/5.2/exe/qcprog.exe_s water_hf_ccpvtz_freq_qchem.in_24177.0 /tmp/qchem24177/
+                  Welcome to Q-Chem
+     A Quantum Leap Into The Future Of Chemistry
+
+
+ Q-Chem 5.2, Q-Chem, Inc., Pleasanton, CA (2019)
+
+ License issued to: National Energy Research Scientific Computing Center
+
+ Yihan Shao,  Zhengting Gan,  E. Epifanovsky,  A. T. B. Gilbert,  M. Wormit,  
+ J. Kussmann,  A. W. Lange,  A. Behn,  Jia Deng,  Xintian Feng,  D. Ghosh,  
+ M. Goldey,  P. R. Horn,  L. D. Jacobson,  I. Kaliman,  T. Kus,  A. Landau,  
+ Jie Liu,  E. I. Proynov,  R. M. Richard,  R. P. Steele,  E. J. Sundstrom,  
+ H. L. Woodcock III,  P. M. Zimmerman,  D. Zuev,  B. Albrecht,  E. Alguire,  
+ S. A. Baeppler,  D. Barton,  Z. Benda,  Y. A. Bernard,  E. J. Berquist,  
+ K. B. Bravaya,  H. Burton,  D. Casanova,  Chun-Min Chang,  Yunqing Chen,  
+ A. Chien,  K. D. Closser,  M. P. Coons,  S. Coriani,  S. Dasgupta,  
+ A. L. Dempwolff,  M. Diedenhofen,  Hainam Do,  R. G. Edgar,  Po-Tung Fang,  
+ S. Faraji,  S. Fatehi,  Qingguo Feng,  K. D. Fenk,  J. Fosso-Tande,  
+ J. Gayvert,  Qinghui Ge,  A. Ghysels,  G. Gidofalvi,  J. Gomes,  
+ J. Gonthier,  A. Gunina,  D. Hait,  M. W. D. Hanson-Heine,  
+ P. H. P. Harbach,  A. W. Hauser,  M. F. Herbst,  J. E. Herr,  
+ E. G. Hohenstein,  Z. C. Holden,  Kerwin Hui,  B. C. Huynh,  T.-C. Jagau,  
+ Hyunjun Ji,  B. Kaduk,  K. Khistyaev,  Jaehoon Kim,  P. Klunzinger,  K. Koh,  
+ D. Kosenkov,  L. Koulias,  T. Kowalczyk,  C. M. Krauter,  A. Kunitsa,  
+ Ka Un Lao,  A. Laurent,  K. V. Lawler,  Joonho Lee,  D. Lefrancois,  
+ S. Lehtola,  D. S. Levine,  Yi-Pei Li,  You-Sheng Lin,  Fenglai Liu,  
+ E. Livshits,  A. Luenser,  P. Manohar,  E. Mansoor,  S. F. Manzer,  
+ Shan-Ping Mao,  Yuezhi Mao,  N. Mardirossian,  A. V. Marenich,  
+ T. Markovich,  L. A. Martinez-Martinez,  S. A. Maurer,  N. J. Mayhall,  
+ S. C. McKenzie,  J.-M. Mewes,  P. Morgante,  A. F. Morrison,  
+ J. W. Mullinax,  K. Nanda,  T. S. Nguyen-Beck,  R. Olivares-Amaya,  
+ J. A. Parkhill,  Zheng Pei,  T. M. Perrine,  F. Plasser,  P. Pokhilko,  
+ S. Prager,  A. Prociuk,  E. Ramos,  D. R. Rehn,  F. Rob,  M. Scheurer,  
+ M. Schneider,  N. Sergueev,  S. M. Sharada,  S. Sharma,  D. W. Small,  
+ T. Stauch,  T. Stein,  Yu-Chuan Su,  A. J. W. Thom,  A. Tkatchenko,  
+ T. Tsuchimochi,  N. M. Tubman,  L. Vogt,  M. L. Vidal,  O. Vydrov,  
+ M. A. Watson,  J. Wenzel,  M. de Wergifosse,  T. A. Wesolowski,  A. White,  
+ J. Witte,  A. Yamada,  Jun Yang,  K. Yao,  S. Yeganeh,  S. R. Yost,  
+ Zhi-Qiang You,  A. Zech,  Igor Ying Zhang,  Xing Zhang,  Yan Zhao,  
+ Ying Zhu,  B. R. Brooks,  G. K. L. Chan,  C. J. Cramer,  M. S. Gordon,  
+ W. J. Hehre,  A. Klamt,  M. W. Schmidt,  C. D. Sherrill,  D. G. Truhlar,  
+ A. Aspuru-Guzik,  R. Baer,  A. T. Bell,  N. A. Besley,  Jeng-Da Chai,  
+ A. E. DePrince, III,  R. A. DiStasio Jr.,  A. Dreuw,  B. D. Dunietz,  
+ T. R. Furlani,  Chao-Ping Hsu,  Yousung Jung,  Jing Kong,  D. S. Lambrecht,  
+ WanZhen Liang,  C. Ochsenfeld,  V. A. Rassolov,  L. V. Slipchenko,  
+ J. E. Subotnik,  T. Van Voorhis,  J. M. Herbert,  A. I. Krylov,  
+ P. M. W. Gill,  M. Head-Gordon
+
+ Contributors to earlier versions of Q-Chem not listed above: 
+ R. D. Adamson,  B. Austin,  J. Baker,  G. J. O. Beran,  K. Brandhorst,  
+ S. T. Brown,  E. F. C. Byrd,  A. K. Chakraborty,  C.-L. Cheng,  
+ Siu Hung Chien,  D. M. Chipman,  D. L. Crittenden,  H. Dachsel,  
+ R. J. Doerksen,  A. D. Dutoi,  L. Fusti-Molnar,  W. A. Goddard III,  
+ A. Golubeva-Zadorozhnaya,  S. R. Gwaltney,  G. Hawkins,  A. Heyden,  
+ S. Hirata,  G. Kedziora,  F. J. Keil,  C. Kelley,  Jihan Kim,  R. A. King,  
+ R. Z. Khaliullin,  P. P. Korambath,  W. Kurlancheek,  A. M. Lee,  M. S. Lee,  
+ S. V. Levchenko,  Ching Yeh Lin,  D. Liotard,  R. C. Lochan,  I. Lotan,  
+ P. E. Maslen,  N. Nair,  D. P. O'Neill,  D. Neuhauser,  E. Neuscamman,  
+ C. M. Oana,  R. Olson,  B. Peters,  R. Peverati,  P. A. Pieniazek,  
+ Y. M. Rhee,  J. Ritchie,  M. A. Rohrdanz,  E. Rosta,  N. J. Russ,  
+ H. F. Schaefer III,  N. E. Schultz,  N. Shenvi,  A. C. Simmonett,  A. Sodt,  
+ D. Stuck,  K. S. Thanthiriwatte,  V. Vanovschi,  Tao Wang,  A. Warshel,  
+ C. F. Williams,  Q. Wu,  X. Xu,  W. Zhang
+
+ Please cite Q-Chem as follows:
+ Y. Shao et al., Mol. Phys. 113, 184-215 (2015)
+ DOI: 10.1080/00268976.2014.952696
+
+ Q-Chem 5.2.0 for Intel X86 EM64T Linux
+
+ Parts of Q-Chem use Armadillo 8.300.2 (Tropical Shenanigans).
+ http://arma.sourceforge.net/
+
+ Q-Chem begins on Thu Jun 11 09:50:59 2020  
+
+Host: cori02
+0
+
+     Scratch files written to /tmp/qchem24177//
+ May1019 |scratch|qcdevops|jenkins|workspace|build_RNUM -1
+Processing $rem in /global/common/cori/software/qchem/5.2/config/preferences:
+	 MEM_TOTAL  96000 
+NAlpha2: 10
+NElect   10
+Mult     1
+
+Checking the input file for inconsistencies... 	...done.
+
+--------------------------------------------------------------
+User input:
+--------------------------------------------------------------
+$molecule
+0 1
+O          0.00575        0.00426       -0.00301
+H          0.27588        0.88612        0.25191
+H          0.60257       -0.23578       -0.71140
+$end
+
+$rem
+ideriv                  2
+incdft                  0
+incfock                 0
+jobtype                 freq
+method                  hf
+unrestricted            1
+basis                   cc-pvtz
+scf_algorithm           gdm
+scf_max_cycles          1000
+scf_guess               sad
+thresh                  14
+xc_grid                 000099000590
+symmetry                0
+sym_ignore              1
+purecart                1111
+gen_scfman              true
+! internal_stability      true
+complex                 false
+$end
+
+--------------------------------------------------------------
+ ----------------------------------------------------------------
+             Standard Nuclear Orientation (Angstroms)
+    I     Atom           X                Y                Z
+ ----------------------------------------------------------------
+    1      O       0.0057500000     0.0042600000    -0.0030100000
+    2      H       0.2758800000     0.8861200000     0.2519100000
+    3      H       0.6025700000    -0.2357800000    -0.7114000000
+ ----------------------------------------------------------------
+ Nuclear Repulsion Energy =           9.19775748 hartrees
+ There are        5 alpha and        5 beta electrons
+ Requested basis set is cc-pVTZ
+ There are 22 shells and 58 basis functions
+
+ Total QAlloc Memory Limit  96000 MB
+ Mega-Array Size       188 MB
+ MEM_STATIC part       192 MB
+
+                       Distance Matrix (Angstroms)
+             O (  1)   H (  2)
+   H (  2)  0.956886
+   H (  3)  0.956885  1.514382
+ 
+ A cutoff of  1.0D-14 yielded    253 shell pairs
+ There are      1793 function pairs (      2271 Cartesian)
+ Smallest overlap matrix eigenvalue = 2.52E-03
+ Guess from superposition of atomic densities
+ Warning:  Energy on first SCF cycle will be non-variational
+ SAD guess density has 10.000000 electrons
+
+ -----------------------------------------------------------------------
+  General SCF calculation program by
+  Eric Jon Sundstrom, Paul Horn, Yuezhi Mao, Dmitri Zuev, Alec White,
+  David Stuck, Shaama M.S., Shane Yost, Joonho Lee, David Small,
+  Daniel Levine, Susi Lehtola, Hugh Burton, Evgeny Epifanovsky
+ -----------------------------------------------------------------------
+ Hartree-Fock
+ using 16 threads for integral computing
+ -------------------------------------------------------
+ OpenMP Integral computing Module                
+ Release: version 1.0, May 2013, Q-Chem Inc. Pittsburgh 
+ -------------------------------------------------------
+ A unrestricted SCF calculation will be
+ performed using Roothaan-Hall, GDM
+ SCF converges when RMS gradient is below 1.0e-08
+ ---------------------------------------
+  Cycle       Energy         DIIS error
+ ---------------------------------------
+    1     -75.9296644208      2.95e-02  Roothaan Step
+ ---------------------------------------
+  Cycle       Energy        RMS Gradient
+ ---------------------------------------
+    1     -76.0233841923      9.22e-02   Normal BFGS step
+    2     -76.0480309861      5.93e-02   Normal BFGS step
+    3     -76.0570647512      3.78e-03   Normal BFGS step
+    4     -76.0571819206      1.79e-03   Normal BFGS step
+    5     -76.0571933268      2.39e-04   Normal BFGS step
+    6     -76.0571936135      7.08e-05   Normal BFGS step
+    7     -76.0571936386      9.18e-06   Normal BFGS step
+    8     -76.0571936393      1.95e-06   Normal BFGS step
+    9     -76.0571936393      3.89e-07   Normal BFGS step
+   10     -76.0571936393      1.45e-07   Normal BFGS step
+   11     -76.0571936393      2.07e-08   Normal BFGS step
+   12     -76.0571936393      6.04e-09  Convergence criterion met
+ ---------------------------------------
+ SCF time:   CPU 23.44s  wall 2.00s 
+<S^2> =         -0.000000000
+ SCF   energy in the final basis set =      -76.0571936393
+ Total energy in the final basis set =      -76.0571936393
+ 
+ --------------------------------------------------------------
+ 
+                    Orbital Energies (a.u.)
+ --------------------------------------------------------------
+ 
+ Alpha MOs
+ -- Occupied --
+-20.5546  -1.3458  -0.7102  -0.5776  -0.5045
+ -- Virtual --
+  0.1423   0.2041   0.5445   0.6021   0.6682   0.7874   0.8014   0.8052
+  0.8610   0.9557   1.1314   1.1970   1.5276   1.5667   2.0366   2.0520
+  2.0664   2.1712   2.2342   2.5910   2.9639   3.3568   3.4919   3.5814
+  3.6562   3.8012   3.8795   3.8849   3.9617   4.0196   4.0768   4.1932
+  4.3149   4.3900   4.5839   4.6857   4.8666   5.1595   5.2529   5.5288
+  6.0522   6.5707   6.9264   6.9442   7.0027   7.0224   7.0680   7.1668
+  7.2377   7.4574   7.7953   8.2906  12.8843
+ 
+ Beta MOs
+ -- Occupied --
+-20.5546  -1.3458  -0.7102  -0.5776  -0.5045
+ -- Virtual --
+  0.1423   0.2041   0.5445   0.6021   0.6682   0.7874   0.8014   0.8052
+  0.8610   0.9557   1.1314   1.1970   1.5276   1.5667   2.0366   2.0520
+  2.0664   2.1712   2.2342   2.5910   2.9639   3.3568   3.4919   3.5814
+  3.6562   3.8012   3.8795   3.8849   3.9617   4.0196   4.0768   4.1932
+  4.3149   4.3900   4.5839   4.6857   4.8666   5.1595   5.2529   5.5288
+  6.0522   6.5707   6.9264   6.9442   7.0027   7.0224   7.0680   7.1668
+  7.2377   7.4574   7.7953   8.2906  12.8843
+ --------------------------------------------------------------
+ 
+          Ground-State Mulliken Net Atomic Charges
+
+     Atom                 Charge (a.u.)    Spin (a.u.)
+  --------------------------------------------------------
+      1 O                    -0.482641      -0.000000
+      2 H                     0.241321       0.000000
+      3 H                     0.241321       0.000000
+  --------------------------------------------------------
+  Sum of atomic charges =    -0.000000
+  Sum of spin   charges =     0.000000
+
+ -----------------------------------------------------------------
+                    Cartesian Multipole Moments
+ -----------------------------------------------------------------
+    Charge (ESU x 10^10)
+                -0.0000
+    Dipole Moment (Debye)
+         X       1.4989      Y       1.1097      Z      -0.7840
+       Tot       2.0231
+    Quadrupole Moments (Debye-Ang)
+        XX      -6.1922     XY       0.2058     YY      -5.0469
+        XZ      -0.9308     YZ       1.1096     ZZ      -5.7620
+    Octopole Moments (Debye-Ang^2)
+       XXX      -0.8647    XXY      -0.3834    XYY       0.0837
+       YYY       0.4654    XXZ      -0.2802    XYZ       0.3565
+       YYZ       0.5886    XZZ       0.2424    YZZ      -0.4808
+       ZZZ      -0.0266
+    Hexadecapole Moments (Debye-Ang^3)
+      XXXX      -6.0874   XXXY      -0.2172   XXYY      -2.0423
+      XYYY       0.3384   YYYY      -5.4026   XXXZ      -0.0586
+      XXYZ       0.1046   XYYZ       0.1789   YYYZ       0.2211
+      XXZZ      -1.6745   XYZZ      -0.2041   YYZZ      -2.0323
+      XZZZ      -0.2326   YZZZ      -0.0176   ZZZZ      -5.8786
+ -----------------------------------------------------------------
+ Calculating MO derivatives via CPSCF
+    1     0    12    0.0679519  
+    2     0    12    0.0099080  
+    3     0    12    0.0025173  
+    4     0    12    0.0004784  
+    5     0    12    0.0000802  
+    6     1    11    0.0000073  
+    7    12     0    0.0000008  Converged
+ Time for AOints: 2.5 s (CPU) 0.2 s (wall)
+ ------------------------------------------------------------------------------
+                     AOints        : Timing summary (seconds)
+ ------------------------------------------------------------------------------
+     job step          cpu (% of tot)      sys (% of tot)     wall (% of tot)
+ ------------------------------------------------------------------------------
+  AOints            0.2537E+01 ( 7.9)   0.4000E-05 ( 1.3)   0.1613E+00 ( 7.3)
+ ------------------------------------------------------------------------------
+   Grand Totals     0.3208E+02          0.3080E-03          0.2208E+01
+ ------------------------------------------------------------------------------
+ Polarizability Matrix (a.u.)
+            1           2           3
+    1  -6.1256608  -0.1911917   0.8593603
+    2  -0.1911917  -7.1808540  -1.0224452
+    3   0.8593603  -1.0224452  -6.5208800
+ Calculating analytic Hessian of the SCF energy
+ 
+ Direct stationary perturbation theory relativistic correction:
+ 
+ rels  =       0.032334871977
+ relv  =      -0.111627185191
+ rel2e =       0.024300014013
+ E_rel =      -0.054992299201
+ 
+ Hessian of the SCF Energy
+            1           2           3           4           5           6
+    1   0.3162861   0.0836606  -0.2326701  -0.0825382  -0.1226155  -0.0026760
+    2   0.0836606   0.5460341   0.2252114  -0.1647100  -0.4652302  -0.1071603
+    3  -0.2326701   0.2252114   0.3738573  -0.0271357  -0.1472865  -0.0703190
+    4  -0.0825382  -0.1647100  -0.0271357   0.0745504   0.1315365   0.0147474
+    5  -0.1226155  -0.4652302  -0.1472865   0.1315365   0.4787640   0.1470895
+    6  -0.0026760  -0.1071603  -0.0703190   0.0147474   0.1470895   0.0812514
+    7  -0.2337479   0.0810494   0.2598057   0.0079878  -0.0089210  -0.0120714
+    8   0.0389548  -0.0808039  -0.0779249   0.0331735  -0.0135338  -0.0399291
+    9   0.2353461  -0.1180510  -0.3035382   0.0123883   0.0001970  -0.0109323
+            7           8           9
+    1  -0.2337479   0.0389548   0.2353461
+    2   0.0810494  -0.0808039  -0.1180510
+    3   0.2598057  -0.0779249  -0.3035382
+    4   0.0079878   0.0331735   0.0123883
+    5  -0.0089210  -0.0135338   0.0001970
+    6  -0.0120714  -0.0399291  -0.0109323
+    7   0.2257601  -0.0721284  -0.2477343
+    8  -0.0721284   0.0943377   0.1178541
+    9  -0.2477343   0.1178541   0.3144706
+ **********************************************************************
+ **                                                                  **
+ **                       VIBRATIONAL ANALYSIS                       **
+ **                       --------------------                       **
+ **                                                                  **
+ **        VIBRATIONAL FREQUENCIES (CM**-1) AND NORMAL MODES         **
+ **     FORCE CONSTANTS (mDYN/ANGSTROM) AND REDUCED MASSES (AMU)     **
+ **                  INFRARED INTENSITIES (KM/MOL)                   **
+ **                                                                  **
+ **********************************************************************
+ 
+
+ Mode:                 1                      2                      3
+ Frequency:      1806.46                3908.95                3995.00
+ Force Cnst:      2.0812                 9.4112                10.1742
+ Red. Mass:       1.0825                 1.0454                 1.0820
+ IR Active:          YES                    YES                    YES
+ IR Intens:       86.773                 13.894                 67.097
+ Raman Active:       YES                    YES                    YES
+               X      Y      Z        X      Y      Z        X      Y      Z
+ O         -0.052 -0.039  0.027   -0.037 -0.027  0.019    0.015 -0.052 -0.045
+ H          0.507 -0.011 -0.490    0.168  0.651  0.218    0.199  0.650  0.188
+ H          0.322  0.625  0.056    0.420 -0.215 -0.525   -0.440  0.177  0.522
+ TransDip   0.221  0.164 -0.116    0.088  0.065 -0.046   -0.057  0.194  0.167
+
+ STANDARD THERMODYNAMIC QUANTITIES AT   298.15 K  AND     1.00 ATM
+
+   This Molecule has  0 Imaginary Frequencies
+   Zero point vibrational energy:       13.882 kcal/mol
+
+   Atom    1 Element O  Has Mass   15.99491
+   Atom    2 Element H  Has Mass    1.00783
+   Atom    3 Element H  Has Mass    1.00783
+   Molecular Mass:    18.010570 amu
+   Principal axes and moments of inertia in amu*Bohr^2:
+                             1           2           3
+    Eigenvalues --        2.18810     4.12692     6.31502
+          X              -0.21572     0.74091     0.63602
+          Y               0.74083     0.54851    -0.38770
+          Z               0.63611    -0.38754     0.66722
+   Rotational Symmetry Number is   1
+   The Molecule is an Asymmetric Top
+   Translational Enthalpy:        0.889 kcal/mol
+   Rotational Enthalpy:           0.889 kcal/mol
+   Vibrational Enthalpy:         13.883 kcal/mol
+   gas constant (RT):             0.592 kcal/mol
+   Translational Entropy:        34.608  cal/mol.K
+   Rotational Entropy:           11.820  cal/mol.K
+   Vibrational Entropy:           0.003  cal/mol.K
+
+   Total Enthalpy:               16.253 kcal/mol
+   Total Entropy:                46.432  cal/mol.K
+Archival summary:
+1\1\cori02\FREQ\HF\BasisUnspecified\12\farnazhz\ThuJun1109:51:042020ThuJun1109:51:042020\0\\#,FREQ,HF,BasisUnspecified,\\0,1\O\H,1,0.956885\H,1,0.956886,2,104.616\\HF=-76.0571936\\@
+
+ Total job time:  5.45s(wall), 69.88s(cpu) 
+ Thu Jun 11 09:51:04 2020
+
+        *************************************************************
+        *                                                           *
+        *  Thank you very much for using Q-Chem.  Have a nice day.  *
+        *                                                           *
+        *************************************************************
+
+
+remove work dirs /tmp/qchem24177.0 -- /tmp/qchem24177.-1
+rm -rf /tmp/qchem24177

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -95,8 +95,8 @@ def test_load_data_qchemlog_h2o():
                                    7.4574, 7.7953, 8.2906, 12.8843])
     assert_equal(data['mo_b_vir'], beta_mo_unoccupied)
     assert_equal(data['mulliken_charges'], np.array([-0.482641, 0.241321, 0.241321]))
-    assert_equal(data['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
-    assert_equal(data['quadrupole_moments'],
+    assert_equal(data['dipole'], np.array([1.4989, 1.1097, -0.784]))
+    assert_equal(data['quadrupole'],
                  np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
     assert_equal(data['polarizability_tensor'], np.array([[-6.1256608, -0.1911917, 0.8593603],
                                                           [-0.1911917, -7.180854, -1.0224452],

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -155,13 +155,12 @@ def test_load_one_qchemlog():
     assert mol.extra['entropy_dict']['rot_entropy'] == 11.82
     assert mol.extra['entropy_dict']['vib_entropy'] == 0.003
     assert mol.extra['entropy_dict']['entropy_total'] == 46.432
-    assert mol.extra['enthalpy_dict']['trans_enthalpy'] == 0.0014167116787071256
-    assert mol.extra['enthalpy_dict']['rot_enthalpy'] == 0.0014167116787071256
-    assert mol.extra['enthalpy_dict']['vib_enthalpy'] == 0.022123968768831298
-    assert mol.extra['enthalpy_dict']['enthalpy_total'] == 0.025900804177758054
     assert mol.extra['moments']['dipole_tol'] == 2.0231
     assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
-
+    assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)
+    assert_allclose(mol.extra['enthalpy_dict']['rot_enthalpy'], 0.0014167116787071256)
+    assert_allclose(mol.extra['enthalpy_dict']['vib_enthalpy'], 0.022123968768831298)
+    assert_allclose(mol.extra['enthalpy_dict']['enthalpy_total'], 0.025900804177758054)
     assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
     assert_equal(mol.extra['moments']['quadrupole_moments'],
                  np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -151,11 +151,11 @@ def test_load_one_qchemlog():
     assert mol.extra['nbasis'] == 58
     assert mol.extra['imaginary_freq'] == 0
     # todo: unit conversion for entropy terms
-    assert mol.extra['entropy_dict']['trans_entropy'] == 34.608
-    assert mol.extra['entropy_dict']['rot_entropy'] == 11.82
-    assert mol.extra['entropy_dict']['vib_entropy'] == 0.003
-    assert mol.extra['entropy_dict']['entropy_total'] == 46.432
-    assert mol.extra['moments']['dipole_tol'] == 2.0231
+    assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608)
+    assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82)
+    assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003)
+    assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432)
+    assert_allclose(mol.extra['moments']['dipole_tol'], 2.0231)
     assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
     assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)
     assert_allclose(mol.extra['enthalpy_dict']['rot_enthalpy'], 0.0014167116787071256)

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -143,8 +143,6 @@ def test_load_one_qchemlog():
     assert mol.run_type == 'freq'
     assert mol.lot == 'hf'
     assert mol.obasis_name == 'cc-pvtz'
-    # todo: the implementation of qchem log file lead to charge=NaN, resulting in an error of charge
-    # put charge to extra dictionary for now
     assert mol.extra['charge'] == 0
     assert mol.extra['spin_multi'] == 1
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
@@ -204,3 +202,27 @@ def test_load_one_qchemlog():
                          1.970000e-04, -1.093230e-02, -2.477343e-01, 1.178541e-01,
                          3.144706e-01]])
     assert_equal(mol.extra['hessian'], hessian)
+    # molecule orbital related
+    # check number of orbitals and occupation numbers
+    assert mol.mo.kind == 'unrestricted'
+    assert mol.mo.norba == 58
+    assert mol.mo.norbb == 58
+    assert mol.mo.norb == 116
+    assert_equal(mol.mo.occsa, [1, 1, 1, 1, 1] + [0] * 53)
+    assert_equal(mol.mo.occsb, [1, 1, 1, 1, 1] + [0] * 53)
+    # alpha occupied orbital energies
+    occupied = np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045])
+    assert_allclose(mol.mo.energies[:5], occupied)
+    # beta occupied orbital energies
+    assert_allclose(mol.mo.energies[58:63], occupied)
+    # alpha virtual orbital energies
+    virtual = np.array([0.1423, 0.2041, 0.5445, 0.6021, 0.6682, 0.7874, 0.8014, 0.8052,
+                        0.8610, 0.9557, 1.1314, 1.1970, 1.5276, 1.5667, 2.0366, 2.0520,
+                        2.0664, 2.1712, 2.2342, 2.5910, 2.9639, 3.3568, 3.4919, 3.5814,
+                        3.6562, 3.8012, 3.8795, 3.8849, 3.9617, 4.0196, 4.0768, 4.1932,
+                        4.3149, 4.3900, 4.5839, 4.6857, 4.8666, 5.1595, 5.2529, 5.5288,
+                        6.0522, 6.5707, 6.9264, 6.9442, 7.0027, 7.0224, 7.0680, 7.1668,
+                        7.2377, 7.4574, 7.7953, 8.2906, 12.8843])
+    assert_allclose(mol.mo.energies[5:58], virtual)
+    # beta virtual orbital energies
+    assert_allclose(mol.mo.energies[63:], virtual)

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -143,6 +143,7 @@ def test_load_one_qchemlog():
     assert mol.run_type == 'freq'
     assert mol.lot == 'hf'
     assert mol.obasis_name == 'cc-pvtz'
+    assert_allclose(mol.atcharges['mulliken'], np.array([-0.482641, 0.241321, 0.241321]))
     assert mol.extra['charge'] == 0
     assert mol.extra['spin_multi'] == 1
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
@@ -162,7 +163,6 @@ def test_load_one_qchemlog():
     assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
     assert_equal(mol.extra['moments']['quadrupole_moments'],
                  np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
-    assert_equal(mol.extra['mulliken_charges'], np.array([-0.482641, 0.241321, 0.241321]))
     polarizability_tensor = np.array([[-6.1256608, -0.1911917, 0.8593603],
                                       [-0.1911917, -7.180854, -1.0224452],
                                       [0.8593603, -1.0224452, -6.52088]])

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -144,34 +144,6 @@ def test_load_one_qchemlog():
     assert mol.lot == 'hf'
     assert mol.obasis_name == 'cc-pvtz'
     assert_allclose(mol.atcharges['mulliken'], np.array([-0.482641, 0.241321, 0.241321]))
-    assert mol.extra['spin_multi'] == 1
-    assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
-    assert mol.extra['imaginary_freq'] == 0
-    # unit conversion for entropy terms, used atomic units + Kalvin
-    assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608 * 1.593601437640628e-06)
-    assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82 * 1.593601437640628e-06)
-    assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003 * 1.593601437640628e-06)
-    assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432 * 1.593601437640628e-06)
-    assert_allclose(mol.extra['moments']['dipole_tol'], 2.0231)
-    assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
-    assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)
-    assert_allclose(mol.extra['enthalpy_dict']['rot_enthalpy'], 0.0014167116787071256)
-    assert_allclose(mol.extra['enthalpy_dict']['vib_enthalpy'], 0.022123968768831298)
-    assert_allclose(mol.extra['enthalpy_dict']['enthalpy_total'], 0.025900804177758054)
-    assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
-    assert_equal(mol.extra['moments']['quadrupole_moments'],
-                 np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
-    polarizability_tensor = np.array([[-6.1256608, -0.1911917, 0.8593603],
-                                      [-0.1911917, -7.180854, -1.0224452],
-                                      [0.8593603, -1.0224452, -6.52088]])
-    assert_equal(mol.extra['polarizability_tensor'], polarizability_tensor)
-    atcoords = np.array([[0.00575, 0.00426, -0.00301],
-                         [0.27588, 0.88612, 0.25191],
-                         [0.60257, -0.23578, -0.7114]])
-    assert_equal(mol.atcoords, atcoords)
-    assert_equal(mol.atmasses, np.array([15.99491, 1.00783, 1.00783]))
-    assert_equal(mol.atnums, np.array([8, 1, 1]))
-
     hessian = np.array([[3.162861e-01, 8.366060e-02, -2.326701e-01, -8.253820e-02,
                          -1.226155e-01, -2.676000e-03, -2.337479e-01, 3.895480e-02,
                          2.353461e-01],
@@ -199,7 +171,34 @@ def test_load_one_qchemlog():
                         [2.353461e-01, -1.180510e-01, -3.035382e-01, 1.238830e-02,
                          1.970000e-04, -1.093230e-02, -2.477343e-01, 1.178541e-01,
                          3.144706e-01]])
-    assert_equal(mol.extra['hessian'], hessian)
+    assert_equal(mol.athessian, hessian)
+    assert mol.extra['spin_multi'] == 1
+    assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
+    assert mol.extra['imaginary_freq'] == 0
+    # unit conversion for entropy terms, used atomic units + Kalvin
+    assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['moments']['dipole_tol'], 2.0231)
+    assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
+    assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)
+    assert_allclose(mol.extra['enthalpy_dict']['rot_enthalpy'], 0.0014167116787071256)
+    assert_allclose(mol.extra['enthalpy_dict']['vib_enthalpy'], 0.022123968768831298)
+    assert_allclose(mol.extra['enthalpy_dict']['enthalpy_total'], 0.025900804177758054)
+    assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
+    assert_equal(mol.extra['moments']['quadrupole_moments'],
+                 np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
+    polarizability_tensor = np.array([[-6.1256608, -0.1911917, 0.8593603],
+                                      [-0.1911917, -7.180854, -1.0224452],
+                                      [0.8593603, -1.0224452, -6.52088]])
+    assert_equal(mol.extra['polarizability_tensor'], polarizability_tensor)
+    atcoords = np.array([[0.00575, 0.00426, -0.00301],
+                         [0.27588, 0.88612, 0.25191],
+                         [0.60257, -0.23578, -0.7114]])
+    assert_equal(mol.atcoords, atcoords)
+    assert_equal(mol.atmasses, np.array([15.99491, 1.00783, 1.00783]))
+    assert_equal(mol.atnums, np.array([8, 1, 1]))
     # molecule orbital related
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -144,6 +144,9 @@ def test_load_one_qchemlog():
     assert mol.lot == 'hf'
     assert mol.obasis_name == 'cc-pvtz'
     assert_allclose(mol.atcharges['mulliken'], np.array([-0.482641, 0.241321, 0.241321]))
+    assert_equal(mol.moments[(1, 'c')], np.array([1.4989, 1.1097, -0.784]))
+    assert_equal(mol.moments[(2, 'c')],
+                 np.array([-6.1922,  0.2058, -0.9308, -5.0469,  1.1096, -5.762]))
     hessian = np.array([[3.162861e-01, 8.366060e-02, -2.326701e-01, -8.253820e-02,
                          -1.226155e-01, -2.676000e-03, -2.337479e-01, 3.895480e-02,
                          2.353461e-01],
@@ -180,15 +183,11 @@ def test_load_one_qchemlog():
     assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82 * 1.593601437640628e-06)
     assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003 * 1.593601437640628e-06)
     assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432 * 1.593601437640628e-06)
-    assert_allclose(mol.extra['moments']['dipole_tol'], 2.0231)
     assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
     assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)
     assert_allclose(mol.extra['enthalpy_dict']['rot_enthalpy'], 0.0014167116787071256)
     assert_allclose(mol.extra['enthalpy_dict']['vib_enthalpy'], 0.022123968768831298)
     assert_allclose(mol.extra['enthalpy_dict']['enthalpy_total'], 0.025900804177758054)
-    assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
-    assert_equal(mol.extra['moments']['quadrupole_moments'],
-                 np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
     polarizability_tensor = np.array([[-6.1256608, -0.1911917, 0.8593603],
                                       [-0.1911917, -7.180854, -1.0224452],
                                       [0.8593603, -1.0224452, -6.52088]])

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -144,7 +144,6 @@ def test_load_one_qchemlog():
     assert mol.lot == 'hf'
     assert mol.obasis_name == 'cc-pvtz'
     assert_allclose(mol.atcharges['mulliken'], np.array([-0.482641, 0.241321, 0.241321]))
-    assert mol.extra['charge'] == 0
     assert mol.extra['spin_multi'] == 1
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
     assert mol.extra['imaginary_freq'] == 0

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -1,0 +1,132 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Test iodata.formats.qchemlog module."""
+
+import numpy as np
+from numpy.testing import assert_equal
+
+from ..formats.qchemlog import load_qchemlog_low
+from ..utils import LineIterator
+
+try:
+    from importlib_resources import path
+except ImportError:
+    from importlib.resources import path
+
+
+def helper_load_data_qchemlog_helper(fn_qchemlog):
+    """Load a testing Q-Chem log file with iodata.formats.wfx.load_qchemlog_low."""
+    with path('iodata.test.data', fn_qchemlog) as fq:
+        lit = LineIterator(str(fq))
+        return load_qchemlog_low(lit)
+
+
+def test_load_data_qchemlog_h2o():
+    """Test load_qchemlog_low with water_hf_ccpvtz_freq_qchem.out."""
+    data = helper_load_data_qchemlog_helper('water_hf_ccpvtz_freq_qchem.out')
+    # check loaded data
+    assert data['charge'] == 0
+    assert data['natom'] == 3
+    assert data['spin_multi'] == 1
+    assert data['run_type'] == 'freq'
+    assert data['method'] == 'hf'
+    assert data['basis_set'] == 'cc-pvtz'
+    assert data['unrestricted'] == 1
+    assert data['symm'] == 0
+    assert data['g_rot'] == 1
+    assert data['alpha_elec'] == 5
+    assert data['beta_elec'] == 5
+    assert data['nuclear_repulsion_energy'] == 9.19775748
+    assert data['energy'] == -76.0571936393
+    assert data['norba'] == 58
+    assert data['norbb'] == 58
+    assert data['dipole_tol'] == 2.0231
+    assert data['enthalpy_dict']['trans_enthalpy'] == 0.889
+    assert data['enthalpy_dict']['rot_enthalpy'] == 0.889
+    assert data['enthalpy_dict']['vib_enthalpy'] == 13.883
+    assert data['enthalpy_dict']['enthalpy_total'] == 16.253
+    assert data['entropy_dict']['trans_entropy'] == 34.608
+    assert data['entropy_dict']['rot_entropy'] == 11.82
+    assert data['entropy_dict']['vib_entropy'] == 0.003
+    assert data['entropy_dict']['entropy_total'] == 46.432
+    assert data['imaginary_freq'] == 0
+    assert data['vib_energy'] == 13.882
+    assert_equal(data['atnums'], np.array([8, 1, 1]))
+    assert_equal(data['atmasses'], [15.99491, 1.00783, 1.00783])
+    atcoords = np.array([[0.00575, 0.00426, -0.00301],
+                         [0.27588, 0.88612, 0.25191],
+                         [0.60257, -0.23578, -0.7114]])
+    assert_equal(data['atcoords'], atcoords)
+    assert_equal(data['alpha_mo_occupied'],
+                 np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
+    assert_equal(data['beta_mo_occupied'],
+                 np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
+    alpha_mo_unoccupied = np.array([0.1423, 0.2041, 0.5445, 0.6021, 0.6682, 0.7874, 0.8014,
+                                    0.8052, 0.861, 0.9557, 1.1314, 1.197, 1.5276, 1.5667,
+                                    2.0366, 2.052, 2.0664, 2.1712, 2.2342, 2.591, 2.9639,
+                                    3.3568, 3.4919, 3.5814, 3.6562, 3.8012, 3.8795, 3.8849,
+                                    3.9617, 4.0196, 4.0768, 4.1932, 4.3149, 4.39, 4.5839,
+                                    4.6857, 4.8666, 5.1595, 5.2529, 5.5288, 6.0522, 6.5707,
+                                    6.9264, 6.9442, 7.0027, 7.0224, 7.068, 7.1668, 7.2377,
+                                    7.4574, 7.7953, 8.2906, 12.8843])
+    assert_equal(data['alpha_mo_unoccupied'], alpha_mo_unoccupied)
+    beta_mo_unoccupied = np.array([0.1423, 0.2041, 0.5445, 0.6021, 0.6682, 0.7874, 0.8014,
+                                   0.8052, 0.861, 0.9557, 1.1314, 1.197, 1.5276, 1.5667,
+                                   2.0366, 2.052, 2.0664, 2.1712, 2.2342, 2.591, 2.9639,
+                                   3.3568, 3.4919, 3.5814, 3.6562, 3.8012, 3.8795, 3.8849,
+                                   3.9617, 4.0196, 4.0768, 4.1932, 4.3149, 4.39, 4.5839,
+                                   4.6857, 4.8666, 5.1595, 5.2529, 5.5288, 6.0522, 6.5707,
+                                   6.9264, 6.9442, 7.0027, 7.0224, 7.068, 7.1668, 7.2377,
+                                   7.4574, 7.7953, 8.2906, 12.8843])
+    assert_equal(data['beta_mo_unoccupied'], beta_mo_unoccupied)
+    assert_equal(data['mulliken_charges'], np.array([-0.482641, 0.241321, 0.241321]))
+    assert_equal(data['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
+    assert_equal(data['quadrupole_moments'],
+                 np.array([-6.1922, 0.2058, -5.0469, -0.9308, 1.1096, -5.762]))
+    assert_equal(data['polarizability_tensor'], np.array([[-6.1256608, -0.1911917, 0.8593603],
+                                                          [-0.1911917, -7.180854, -1.0224452],
+                                                          [0.8593603, -1.0224452, -6.52088]]))
+    hessian = np.array([[3.162861e-01, 8.366060e-02, -2.326701e-01, -8.253820e-02,
+                         -1.226155e-01, -2.676000e-03, -2.337479e-01, 3.895480e-02,
+                         2.353461e-01],
+                        [8.366060e-02, 5.460341e-01, 2.252114e-01, -1.647100e-01,
+                         -4.652302e-01, -1.071603e-01, 8.104940e-02, -8.080390e-02,
+                         -1.180510e-01],
+                        [-2.326701e-01, 2.252114e-01, 3.738573e-01, -2.713570e-02,
+                         -1.472865e-01, -7.031900e-02, 2.598057e-01, -7.792490e-02,
+                         -3.035382e-01],
+                        [-8.253820e-02, -1.647100e-01, -2.713570e-02, 7.455040e-02,
+                         1.315365e-01, 1.474740e-02, 7.987800e-03, 3.317350e-02,
+                         1.238830e-02],
+                        [-1.226155e-01, -4.652302e-01, -1.472865e-01, 1.315365e-01,
+                         4.787640e-01, 1.470895e-01, -8.921000e-03, -1.353380e-02,
+                         1.970000e-04],
+                        [-2.676000e-03, -1.071603e-01, -7.031900e-02, 1.474740e-02,
+                         1.470895e-01, 8.125140e-02, -1.207140e-02, -3.992910e-02,
+                         -1.093230e-02],
+                        [-2.337479e-01, 8.104940e-02, 2.598057e-01, 7.987800e-03,
+                         -8.921000e-03, -1.207140e-02, 2.257601e-01, -7.212840e-02,
+                         -2.477343e-01],
+                        [3.895480e-02, -8.080390e-02, -7.792490e-02, 3.317350e-02,
+                         -1.353380e-02, -3.992910e-02, -7.212840e-02, 9.433770e-02,
+                         1.178541e-01],
+                        [2.353461e-01, -1.180510e-01, -3.035382e-01, 1.238830e-02,
+                         1.970000e-04, -1.093230e-02, -2.477343e-01, 1.178541e-01,
+                         3.144706e-01]])
+    assert_equal(data['hessian'], hessian)

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -148,11 +148,11 @@ def test_load_one_qchemlog():
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
     assert mol.extra['nbasis'] == 58
     assert mol.extra['imaginary_freq'] == 0
-    # todo: unit conversion for entropy terms
-    assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608)
-    assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82)
-    assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003)
-    assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432)
+    # unit conversion for entropy terms, used atomic units + Kalvin
+    assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['rot_entropy'], 11.82 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['vib_entropy'], 0.003 * 1.593601437640628e-06)
+    assert_allclose(mol.extra['entropy_dict']['entropy_total'], 46.432 * 1.593601437640628e-06)
     assert_allclose(mol.extra['moments']['dipole_tol'], 2.0231)
     assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
     assert_allclose(mol.extra['enthalpy_dict']['trans_enthalpy'], 0.0014167116787071256)

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -146,7 +146,7 @@ def test_load_one_qchemlog():
     assert_allclose(mol.atcharges['mulliken'], np.array([-0.482641, 0.241321, 0.241321]))
     assert_equal(mol.moments[(1, 'c')], np.array([1.4989, 1.1097, -0.784]))
     assert_equal(mol.moments[(2, 'c')],
-                 np.array([-6.1922,  0.2058, -0.9308, -5.0469,  1.1096, -5.762]))
+                 np.array([-6.1922, 0.2058, -0.9308, -5.0469, 1.1096, -5.762]))
     hessian = np.array([[3.162861e-01, 8.366060e-02, -2.326701e-01, -8.253820e-02,
                          -1.226155e-01, -2.676000e-03, -2.337479e-01, 3.895480e-02,
                          2.353461e-01],

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -130,7 +130,7 @@ def test_load_data_qchemlog_h2o():
                         [2.353461e-01, -1.180510e-01, -3.035382e-01, 1.238830e-02,
                          1.970000e-04, -1.093230e-02, -2.477343e-01, 1.178541e-01,
                          3.144706e-01]])
-    assert_equal(data['hessian'], hessian)
+    assert_equal(data['athessian'], hessian)
 
 
 def test_load_one_qchemlog():

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -19,7 +19,7 @@
 """Test iodata.formats.qchemlog module."""
 
 import numpy as np
-from numpy.testing import assert_equal
+from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one
 from ..formats.qchemlog import load_qchemlog_low
@@ -150,7 +150,6 @@ def test_load_one_qchemlog():
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
     assert mol.extra['nbasis'] == 58
     assert mol.extra['imaginary_freq'] == 0
-    assert mol.extra['vib_energy'] == 0.022122375167392933
     # todo: unit conversion for entropy terms
     assert mol.extra['entropy_dict']['trans_entropy'] == 34.608
     assert mol.extra['entropy_dict']['rot_entropy'] == 11.82
@@ -161,6 +160,7 @@ def test_load_one_qchemlog():
     assert mol.extra['enthalpy_dict']['vib_enthalpy'] == 0.022123968768831298
     assert mol.extra['enthalpy_dict']['enthalpy_total'] == 0.025900804177758054
     assert mol.extra['moments']['dipole_tol'] == 2.0231
+    assert_allclose(mol.extra['vib_energy'], 0.022122375167392933)
 
     assert_equal(mol.extra['moments']['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
     assert_equal(mol.extra['moments']['quadrupole_moments'],

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -147,7 +147,6 @@ def test_load_one_qchemlog():
     assert mol.extra['charge'] == 0
     assert mol.extra['spin_multi'] == 1
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
-    assert mol.extra['nbasis'] == 58
     assert mol.extra['imaginary_freq'] == 0
     # unit conversion for entropy terms, used atomic units + Kalvin
     assert_allclose(mol.extra['entropy_dict']['trans_entropy'], 34.608 * 1.593601437640628e-06)

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -46,8 +46,8 @@ def test_load_data_qchemlog_h2o():
     assert data['natom'] == 3
     assert data['spin_multi'] == 1
     assert data['run_type'] == 'freq'
-    assert data['method'] == 'hf'
-    assert data['basis_set'] == 'cc-pvtz'
+    assert data['lot'] == 'hf'
+    assert data['obasis_name'] == 'cc-pvtz'
     assert data['unrestricted'] == 1
     assert data['symm'] == 0
     assert data['g_rot'] == 1

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -74,10 +74,8 @@ def test_load_data_qchemlog_h2o():
                          [0.27588, 0.88612, 0.25191],
                          [0.60257, -0.23578, -0.7114]])
     assert_equal(data['atcoords'], atcoords)
-    assert_equal(data['alpha_mo_occupied'],
-                 np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
-    assert_equal(data['beta_mo_occupied'],
-                 np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
+    assert_equal(data['mo_a_occ'], np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
+    assert_equal(data['mo_b_occ'], np.array([-20.5546, -1.3458, -0.7102, -0.5776, -0.5045]))
     alpha_mo_unoccupied = np.array([0.1423, 0.2041, 0.5445, 0.6021, 0.6682, 0.7874, 0.8014,
                                     0.8052, 0.861, 0.9557, 1.1314, 1.197, 1.5276, 1.5667,
                                     2.0366, 2.052, 2.0664, 2.1712, 2.2342, 2.591, 2.9639,
@@ -86,7 +84,7 @@ def test_load_data_qchemlog_h2o():
                                     4.6857, 4.8666, 5.1595, 5.2529, 5.5288, 6.0522, 6.5707,
                                     6.9264, 6.9442, 7.0027, 7.0224, 7.068, 7.1668, 7.2377,
                                     7.4574, 7.7953, 8.2906, 12.8843])
-    assert_equal(data['alpha_mo_unoccupied'], alpha_mo_unoccupied)
+    assert_equal(data['mo_a_vir'], alpha_mo_unoccupied)
     beta_mo_unoccupied = np.array([0.1423, 0.2041, 0.5445, 0.6021, 0.6682, 0.7874, 0.8014,
                                    0.8052, 0.861, 0.9557, 1.1314, 1.197, 1.5276, 1.5667,
                                    2.0366, 2.052, 2.0664, 2.1712, 2.2342, 2.591, 2.9639,
@@ -95,7 +93,7 @@ def test_load_data_qchemlog_h2o():
                                    4.6857, 4.8666, 5.1595, 5.2529, 5.5288, 6.0522, 6.5707,
                                    6.9264, 6.9442, 7.0027, 7.0224, 7.068, 7.1668, 7.2377,
                                    7.4574, 7.7953, 8.2906, 12.8843])
-    assert_equal(data['beta_mo_unoccupied'], beta_mo_unoccupied)
+    assert_equal(data['mo_b_vir'], beta_mo_unoccupied)
     assert_equal(data['mulliken_charges'], np.array([-0.482641, 0.241321, 0.241321]))
     assert_equal(data['dipole_moment'], np.array([1.4989, 1.1097, -0.784]))
     assert_equal(data['quadrupole_moments'],

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -39,7 +39,7 @@ electronvolt: float = 1 / spc.value(u'hartree-electron volt relationship')
 # atomic mass unit (not atomic unit of mass!)
 amu: float = 1e-3 / (spc.value(u'electron mass') * spc.value(u'Avogadro constant'))
 kcalmol: float = 1e3 * spc.calorie / spc.value('Avogadro constant') / spc.value('Hartree energy')
-
+calmol: float = spc.calorie / spc.value('Avogadro constant') / spc.value('Hartree energy')
 
 class FileFormatError(IOError):
     """Raised when incorrect content is encountered when loading files."""

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -38,6 +38,7 @@ angstrom: float = spc.angstrom / spc.value(u'atomic unit of length')
 electronvolt: float = 1 / spc.value(u'hartree-electron volt relationship')
 # atomic mass unit (not atomic unit of mass!)
 amu: float = 1e-3 / (spc.value(u'electron mass') * spc.value(u'Avogadro constant'))
+kcalmol: float = 1e3 * spc.calorie / spc.value('Avogadro constant') / spc.value('Hartree energy')
 
 
 class FileFormatError(IOError):

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -41,6 +41,7 @@ amu: float = 1e-3 / (spc.value(u'electron mass') * spc.value(u'Avogadro constant
 kcalmol: float = 1e3 * spc.calorie / spc.value('Avogadro constant') / spc.value('Hartree energy')
 calmol: float = spc.calorie / spc.value('Avogadro constant') / spc.value('Hartree energy')
 
+
 class FileFormatError(IOError):
     """Raised when incorrect content is encountered when loading files."""
 


### PR DESCRIPTION
Implementation includes
- [x] Lower level parser for Q-Chem log file, 509ba22
- [x] Higher level `load_one` function for Q-Chem log file, 33d2a25
- [x] Tests for Lower level parser and higher level `load_one` function, f8a791a and 9622008
- [x] Molecular orbital object for Q-Chem return
- [x] Fix pycodestyle errors 7e522b3
- [x] Add tests for molecular object opbject in 4132217