### PR TITLE
Add dump_one() function for WFX

### DIFF
--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -358,7 +358,7 @@ def dump_one(f: TextIO, data: IOData):
     nuclear_names = [f' {num2sym[num]}{index + 1}' for index, num in enumerate(data.atnums)]
     _write_xml_iterator(tag=lbs["nuclear_names"], info=nuclear_names, file=f)
     _write_xml_iterator(tag=lbs["atnums"], info=data.atnums, file=f)
-    _write_xml_iterator(tag=lbs["nuclear_charge"], info=data.atcharges, file=f)
+    _write_xml_iterator_scientific(tag=lbs["nuclear_charge"], info=data.atnums, file=f)
 
     # write nuclear cartesian coordinates
     print("<Nuclear Cartesian Coordinates>", file=f)
@@ -558,7 +558,7 @@ def _write_xml_iterator(tag: str, info: Iterator, file: TextIO) -> None:
     print('</' + tag.lstrip('<'), file=file)
 
 
-def _write_xml_iterator_scientific(tag: str, info: str, file: TextIO) -> None:
+def _write_xml_iterator_scientific(tag: str, info: Iterator, file: TextIO) -> None:
     """Write list of arrays to file."""
     print(tag, file=file)
     # for list or 1d array works

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -175,6 +175,8 @@ def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:
         if section_start is None and line.startswith("<"):
             # set start & end of the section and add it to data dictionary
             section_start = line
+            if section_start in data.keys():
+                lit.error("Section with tag={} is repeated!".format(section_start))
             data[section_start] = []
             section_end = line[:1] + "/" + line[1:]
             # special handling of <Molecular Orbital Primitive Coefficients> section

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -562,42 +562,38 @@ def dump_one(f: TextIO, data: IOData):
         _write_xml_single(tag=labels_all["num_core_electrons"], info=num_core_electrons, file=f)
 
 
-def _write_xml_single(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
+def _write_xml_single(tag: str, info: str, file: TextIO) -> None:
     """Write header, tail and the data between them into the file."""
     print(tag, file=file)
-    print(info, end=end, file=file)
-    tail = '</' + tag.lstrip('<')
-    print(tail, file=file)
+    print(info, file=file)
+    print('</' + tag.lstrip('<'), file=file)
 
 
         # todo: check precision
-def _write_xml_single_scientific(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
+def _write_xml_single_scientific(tag: str, info: str, file: TextIO) -> None:
     """Write header, tail and the data between them into the file."""
     print(tag, file=file)
-    print('{: ,.14E}'.format(info), end=end, file=file)
-    tail = '</' + tag.lstrip('<')
-    print(tail, file=file)
+    print('{: ,.14E}'.format(info), file=file)
+    print('</' + tag.lstrip('<'), file=file)
 
 
-def _write_xml_iterator(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
+def _write_xml_iterator(tag: str, info: str, file: TextIO) -> None:
     """Write list of arrays to file."""
     print(tag, file=file)
     # for list or 1d array works
     for info_line in info:
-        print(info_line, end=end, file=file)
-    tail = '</' + tag.lstrip('<')
-    print(tail, file=file)
+        print(info_line, file=file)
+    print('</' + tag.lstrip('<'), file=file)
 
 
     # todo: check precision
-def _write_xml_iterator_scientific(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
+def _write_xml_iterator_scientific(tag: str, info: str, file: TextIO) -> None:
     """Write list of arrays to file."""
     print(tag, file=file)
     # for list or 1d array works
     for info_line in info:
-        print('{: ,.14E}'.format(info_line), end=end, file=file)
-    tail = '</' + tag.lstrip('<')
-    print(tail, file=file)
+        print('{: ,.14E}'.format(info_line), file=file)
+    print('</' + tag.lstrip('<'), file=file)
 
 
     # write array fload labels

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -158,7 +158,7 @@ def load_data_wfx(lit: LineIterator) -> dict:
     return result
 
 
-def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:
+def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:   # noqa: R0912
     """Load data in all sections existing in the given WFX file LineIterator."""
     data = {}
     mo_start = "<Molecular Orbital Primitive Coefficients>"
@@ -307,10 +307,10 @@ def load_one(lit: LineIterator) -> dict:
 # todo: check document_dump_one
 @document_dump_one("WFX", ['atcoords', 'atgradient', 'atnums', 'energy',
                            'exrtra', 'mo', 'obasis', 'title'])
-def dump_one(f: TextIO, data: IOData):
+def dump_one(f: TextIO, data: IOData):   # noqa: R0912
     """Do not edit this docstring. It will be overwritten."""
     # get all tags/labels that can be written into a WFX file
-    lbs_str, lbs_int, lbs_float, lbs_aint, lbs_afloat, lbs_other, required_tags = _wfx_labels()
+    lbs_str, lbs_int, lbs_float, lbs_aint, lbs_afloat, lbs_other, _ = _wfx_labels()
     # put all labels in one dictionary and flip key and value for easier use
     lbs = {**lbs_str, **lbs_int, **lbs_float, **lbs_aint, **lbs_afloat, **lbs_other}
     lbs = {v: k for k, v in lbs.items()}

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -295,6 +295,7 @@ def load_one(lit: LineIterator) -> dict:
         'atcoords': data['atcoords'],
         'atgradient': data.get('atgradient'),
         'atnums': data['atnums'],
+        'atcorenums': data['nuclear_charge'],
         'energy': data['energy'],
         'extra': extra,
         'mo': mo,
@@ -392,10 +393,10 @@ def dump_one(f: TextIO, data: IOData):
     # write nuclear names, atomic numbers, and nuclear charges
     # add ghost atom, represented by Bq and atomic number 0
     num2sym.update({0: 'Bq'})
-    nuclear_names = [f' {num2sym[num]}{index + 1}' for index, num in enumerate(data.atnums)]
+    nuclear_names = [f' {num2sym[num]}{index + 1}' for index, num in enumerate(data.atcorenums)]
     _write_xml_iterator(tag=lbs["nuclear_names"], info=nuclear_names, file=f)
     _write_xml_iterator(tag=lbs["atnums"], info=data.atnums, file=f)
-    _write_xml_iterator_scientific(tag=lbs["nuclear_charge"], info=data.atnums, file=f)
+    _write_xml_iterator_scientific(tag=lbs["nuclear_charge"], info=data.atcorenums, file=f)
 
     # write nuclear cartesian coordinates
     print("<Nuclear Cartesian Coordinates>", file=f)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -563,41 +563,41 @@ def dump_one(f: TextIO, data: IOData):
 
 
 def _write_xml_single(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
-        """Write header, tail and the data between them into the file."""
-        print(tag, file=file)
-        print(info, end=end, file=file)
-        tail = '</' + tag.lstrip('<')
-        print(tail, file=file)
+    """Write header, tail and the data between them into the file."""
+    print(tag, file=file)
+    print(info, end=end, file=file)
+    tail = '</' + tag.lstrip('<')
+    print(tail, file=file)
 
 
         # todo: check precision
 def _write_xml_single_scientific(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
-        """Write header, tail and the data between them into the file."""
-        print(tag, file=file)
-        print('{: ,.14E}'.format(info), end=end, file=file)
-        tail = '</' + tag.lstrip('<')
-        print(tail, file=file)
+    """Write header, tail and the data between them into the file."""
+    print(tag, file=file)
+    print('{: ,.14E}'.format(info), end=end, file=file)
+    tail = '</' + tag.lstrip('<')
+    print(tail, file=file)
 
 
 def _write_xml_iterator(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
-        """Write list of arrays to file."""
-        print(tag, file=file)
-        # for list or 1d array works
-        for info_line in info:
-            print(info_line, end=end, file=file)
-        tail = '</' + tag.lstrip('<')
-        print(tail, file=file)
+    """Write list of arrays to file."""
+    print(tag, file=file)
+    # for list or 1d array works
+    for info_line in info:
+        print(info_line, end=end, file=file)
+    tail = '</' + tag.lstrip('<')
+    print(tail, file=file)
 
 
     # todo: check precision
 def _write_xml_iterator_scientific(tag: str, info: str, file: TextIO, end: str = "\n") -> None:
-        """Write list of arrays to file."""
-        print(tag, file=file)
-        # for list or 1d array works
-        for info_line in info:
-            print('{: ,.14E}'.format(info_line), end=end, file=file)
-        tail = '</' + tag.lstrip('<')
-        print(tail, file=file)
+    """Write list of arrays to file."""
+    print(tag, file=file)
+    # for list or 1d array works
+    for info_line in info:
+        print('{: ,.14E}'.format(info_line), end=end, file=file)
+    tail = '</' + tag.lstrip('<')
+    print(tail, file=file)
 
 
     # write array fload labels

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -32,8 +32,9 @@ from ..periodic import num2sym
 from ..iodata import IOData
 from ..utils import LineIterator
 from ..overlap import gob_cart_normalization
+from ..basis import MolecularBasis, Shell
 
-from .wfn import build_obasis, get_mocoeff_scales
+from .wfn import build_obasis, get_mocoeff_scales, CONVENTIONS
 
 __all__ = []
 
@@ -251,6 +252,7 @@ def load_one(lit: LineIterator) -> dict:
     extra_labels = ['keywords', 'model_name', 'num_perturbations', 'num_core_electrons',
                     'spin_multi', 'virial_ratio', 'nuc_viral', 'full_virial_ratio', 'mo_spin']
     extra = {label: data.get(label, None) for label in extra_labels}
+    extra["permutations"] = permutation
 
     return {
         'atcoords': data['atcoords'],
@@ -276,54 +278,49 @@ def dump_one(f: TextIO, data: IOData):
     # required = [labels_all[tag] for tag in required_tags]
     # flip keys and values for further use
     labels_all = {v: k for k, v in labels_all.items()}
-    check = data.obasis.shells[0]
-    shell_info = []
-    for shell in data.obasis.shells:
-        # Creating a list with information of shells. Mostly to get sp split into two different
-        # shells. Instead of doing this maybe I can create a new obasis object
-        for _ in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
-            shell_info.append(list(_))
-            shell_info[-1].append(shell.exponents)
-            shell_info[-1].append(shell.icenter)
 
-    #print(shell_info)
+    # Creating new obasis in primitive basis set for contracted basis set IOData objects (e.g fchk)
+    if data.obasis.shells[0].exponents.shape[0] > 1:
+        shells = []
+        for shell in data.obasis.shells:
+            for i in range(shell.coeffs.shape[1]):
+                for j in range(shell.coeffs.shape[0]):
+                    shells.append(Shell(shell.icenter, [shell.angmoms[i]], ['c'],
+                                        np.array([shell.exponents[j]]),
+                                        np.array([shell.coeffs[j][i]])))
+
+        new_obasis = MolecularBasis(shells, CONVENTIONS, 'L2')
+        obasis = new_obasis
+        data.extra.setdefault("keywords", 'GTO')
+        data.extra.setdefault("num_perturbations", 0)
+        data.extra.setdefault("model_name", data.lot)
+        data.extra.setdefault("spin_multi", int(data.spinpol + 1))
+        data.extra.setdefault("virial_ratio", np.nan)
+        data.extra.setdefault("nuc_viral", None)
+        data.extra.setdefault("full_virial_ratio", None)
+        data.extra.setdefault("num_core_electrons", None)
+    else:
+        obasis = data.obasis
+
     # write string labels
     # _write_string(data=data, labels_all=labels_all, file=f)
     title = data.title or '<Created with IOData>'
     _write_xml_single(tag=labels_all["title"], info=title, file=f)
 
-    # keywords
-    if check.exponents.shape[0] > 1:
-        keywords = 'GTO'
-    else:
-        keywords = data.extra["keywords"]
+    keywords = data.extra["keywords"]
     _write_xml_single(tag=labels_all["keywords"], info=keywords, file=f)
 
     # number of atoms
     num_atoms = data.natom
     _write_xml_single(tag=labels_all["num_atoms"], info=num_atoms, file=f)
 
-    # number of primitives
-    if check.exponents.shape[0] > 1:
-        num_prim = 0
-        for shell in shell_info:
-            num_prim += len(data.obasis.conventions[shell[0], 'c']) * shell[2].shape[0]
-    else:
-        num_prim = data.obasis.nbasis
+    num_prim = obasis.nbasis
     _write_xml_single(tag=labels_all["num_primitives"], info=num_prim, file=f)
 
-    # number of occupied mo
-    if check.exponents.shape[0] > 1:
-        num_mo = len(data.mo.occs[data.mo.occs > 0.5])
-    else:
-        num_mo = data.mo.occs.shape[0]
+    num_mo = data.mo.occs.shape[0]
     _write_xml_single(tag=labels_all["num_occ_mo"], info=num_mo, file=f)
 
-    # number of perturbations
-    if check.exponents.shape[0] > 1:
-        num_perturbations = 0
-    else:
-        num_perturbations = data.extra["num_perturbations"]
+    num_perturbations = data.extra["num_perturbations"]
     _write_xml_single(tag=labels_all["num_perturbations"], info=num_perturbations, file=f)
 
     # Nuclear names
@@ -364,35 +361,19 @@ def dump_one(f: TextIO, data: IOData):
     num_beta_elec = sum(num_beta_elec)
     _write_xml_single(tag=labels_all["num_beta_electron"], info=int(round(num_beta_elec)), file=f)
 
-    # todo:  spin multiplicity
     # molecular orbital spin types
-    if check.exponents.shape[0] > 1:
-        mo_spin = int(data.spinpol + 1)
+    if data.extra["spin_multi"] is not None:
+        mo_spin = data.extra["spin_multi"]
         _write_xml_single(tag=labels_all["spin_multi"], info=mo_spin, file=f)
-    else:
-        if data.extra["spin_multi"] != None:
-            mo_spin = data.extra["spin_multi"]
-            _write_xml_single(tag=labels_all["spin_multi"], info=mo_spin, file=f)
 
-    # model name
-    if check.exponents.shape[0] > 1:
-        model = data.lot
-    else:
-        model = data.extra["model_name"]
+    model = data.extra["model_name"]
     _write_xml_single(tag=labels_all["model_name"], info=model, file=f)
 
-    # todo: primitive centers and types
     # Primitive centers
     prim_centers = []
-    if check.exponents.shape[0] > 1:
-        for s in shell_info:
-            # Decontraction of C-GTO shells into shells of primitives
-            rang = len(data.obasis.conventions[s[0], 'c']) * s[3].shape[0]
-            prim_centers.extend([(s[4] + 1) for ao in range(rang)])
-    else:
-        for shell in data.obasis.shells:
-            rang = len(data.obasis.conventions[shell.angmoms[0], 'c'])
-            prim_centers.extend([(shell.icenter + 1) for ao in range(rang)])
+    for shell in obasis.shells:
+        rang = len(obasis.conventions[shell.angmoms[0], 'c'])
+        prim_centers.extend([(shell.icenter + 1) for ao in range(rang)])
 
     print("<Primitive Centers>", file=f)
     for j in range(0, len(prim_centers), 10):
@@ -400,14 +381,9 @@ def dump_one(f: TextIO, data: IOData):
     print("</Primitive Centers>", file=f)
 
     # Primitive types
-    if check.exponents.shape[0] > 1:
-        raw_types = []
-        for s in shell_info:
-            raw_types.extend([s[0] for ang in range(s[2].shape[0])])
-    else:
-        raw_types = [shell.angmoms[0] for shell in data.obasis.shells]
-    ran_0 = [len(data.obasis.conventions[angmom, 'c']) for angmom in raw_types]
-    ran_1 = [sum([len(data.obasis.conventions[x, 'c']) for x in range(ang+1)]) for ang in raw_types]
+    raw_types = [shell.angmoms[0] for shell in obasis.shells]
+    ran_0 = [len(obasis.conventions[angmom, 'c']) for angmom in raw_types]
+    ran_1 = [sum([len(obasis.conventions[x, 'c']) for x in range(ang+1)]) for ang in raw_types]
 
     prim_types = []
     for elem in zip(ran_0, ran_1):
@@ -421,26 +397,16 @@ def dump_one(f: TextIO, data: IOData):
         print(' '.join(['{:d}'.format(c) for c in prim_types[j:j + 10]]), file=f)
     print("</Primitive Types>", file=f)
 
-    # todo: unit conversions
     # primitive exponents
     exponents = []
-    if check.exponents.shape[0] > 1:
-        raw_exponents = []
-        for s in shell_info:
-            rang = len(data.obasis.conventions[s[0], 'c'])
-            raw_exponents.extend([[exp] * rang for exp in s[3]])
-            exponents = [exp for sublist in raw_exponents for exp in sublist]
-    else:
-        for shell in data.obasis.shells:
-            rang = len(data.obasis.conventions[shell.angmoms[0], 'c'])
-            exponents.extend([shell.exponents[0] for ex in range(rang)])
+    for shell in obasis.shells:
+        rang = len(obasis.conventions[shell.angmoms[0], 'c'])
+        exponents.extend([shell.exponents[0] for ex in range(rang)])
     print("<Primitive Exponents>", file=f)
     for j in range(0, len(exponents), 4):
         print(' '.join(['{: ,.14E}'.format(e) for e in exponents[j:j + 4]]), file=f)
     print("</Primitive Exponents>", file=f)
 
-    # todo: MO numbers
-    # todo: number of occupied molecular orbitals
     # molecular orbital occupation numbers
     mo_occs = data.mo.occs
     _write_xml_iterator_scientific(tag=labels_all["mo_occs"], info=mo_occs, file=f)
@@ -462,11 +428,19 @@ def dump_one(f: TextIO, data: IOData):
 
     print("</Molecular Orbital Spin Types>", file=f)
 
-    # todo: primitive mo numbers and Coefficients, line 213 in wfx.py
     # Molecular Orbital Primitive Coefficients
-    if check.exponents.shape[0] > 1:
+    if data.obasis.shells[0].exponents.shape[0] > 1:
+        shell_info = []
         raw_data = []
         raw_scales = []
+        for shell in data.obasis.shells:
+            # Creating a list with information of fchk shells. Mostly to get sp split into
+            # two different shells. Instead of doing this maybe I can create a new obasis object
+            for item in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
+                shell_info.append(list(item))
+                shell_info[-1].append(shell.exponents)
+                shell_info[-1].append(shell.icenter)
+
         for s in shell_info:
             # Store for each AO its primitives
             rang = len(data.obasis.conventions[s[0], 'c'])
@@ -487,30 +461,35 @@ def dump_one(f: TextIO, data: IOData):
         prim_coeff = np.zeros((data.obasis.nbasis, len(max(raw_data, key=len))))
         scales = np.zeros((data.obasis.nbasis, len(max(raw_data, key=len))))
         for index in range(len(raw_data)):
-            zero = (max_prim - len(raw_data[index])) * [0]
+            zero = (max_prim - len(raw_data[index])) * ['nan']
             elem_prim = raw_data[index] + zero
             elem_scales = raw_scales[index] + zero
             prim_coeff[index] = elem_prim
             scales[index] = elem_scales
 
-        # Un-normalizing molecular coefficients (not really....)
-        coeffs_data = data.mo.coeffs.T[:, :, None] * (prim_coeff * scales)
-        coeffs_data = coeffs_data[:len(data.mo.occs[data.mo.occs > 0.5])]
-        coeffs_data = coeffs_data.reshape(len(data.mo.occs[data.mo.occs > 0.5]), -1)
-        coeffs_data = coeffs_data.T
+        # Un-normalizing molecular coefficients
+        raw_coeffs = data.mo.coeffs.T[:, :, None] * (prim_coeff * scales)
+        #raw_coeffs = raw_coeffs[:len(data.mo.occs[data.mo.occs > 0.5])]
+        raw_coeffs = raw_coeffs.reshape(len(data.mo.occs), -1)
+
+        # Masking 'nan' values
+        coeffs_data = []
+        for row in raw_coeffs:
+            coeffs_data.append(row[row == np.ma.masked_invalid(row)])
 
     else:
         coeffs_data = np.copy(data.mo.coeffs)
-        coeffs_data *= get_mocoeff_scales(data.obasis).reshape(-1,1)
+        coeffs_data *= get_mocoeff_scales(obasis).reshape(-1,1)
+        coeffs_data = coeffs_data[data.extra["permutations"]]
+        coeffs_data = coeffs_data.T
 
     print("<Molecular Orbital Primitive Coefficients>", file=f)
-    for mo in range(len(data.mo.occs[data.mo.occs > 0.5])):
+    for mo in range(len(data.mo.occs)):
         print("<MO Number>", file=f)
         print(str(mo + 1), file=f)
         print("</MO Number>", file=f)
-        #for j in range(0, data.obasis.nbasis, 4):
         for j in range(0, num_prim, 4):
-            print(' '.join(['{: ,.14E}'.format(c) for c in coeffs_data.T[mo][j:j + 4]]), file=f)
+            print(' '.join(['{: ,.14E}'.format(c) for c in coeffs_data[mo][j:j + 4]]), file=f)
     print("</Molecular Orbital Primitive Coefficients>", file=f)
 
     # energy
@@ -530,17 +509,17 @@ def dump_one(f: TextIO, data: IOData):
         print("</Nuclear Cartesian Energy Gradients>", file=f)
 
     # nuclear virial of energy gradient based forces on nuclei
-    if data.extra["nuc_viral"] != None:
+    if data.extra["nuc_viral"] is not None:
         nuc_viral = data.extra["nuc_viral"]
         _write_xml_single_scientific(tag=labels_all["nuc_viral"], info=nuc_viral, file=f)
 
     # full virial ratio
-    if data.extra["full_virial_ratio"] != None:
+    if data.extra["full_virial_ratio"] is not None:
         full_virial_ratio = data.extra["full_virial_ratio"]
         _write_xml_single_scientific(tag=labels_all["full_virial_ratio"], info=full_virial_ratio, file=f)
 
     # number of core electrons
-    if data.extra["num_core_electrons"] != None:
+    if data.extra["num_core_electrons"] is not None:
         num_core_electrons = data.extra["num_core_electrons"]
         _write_xml_single(tag=labels_all["num_core_electrons"], info=num_core_electrons, file=f)
 

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -469,7 +469,11 @@ def dump_one(f: TextIO, data: IOData):
     print("</Molecular Orbital Primitive Coefficients>", file=f)
 
     # write energy and virial ratio
-    _write_xml_single_scientific(tag=lbs["energy"], info=data.energy, file=f)
+    if data.energy is None:
+        _write_xml_single(tag=lbs["energy"], info=' NAN', file=f)
+    else:
+        _write_xml_single_scientific(tag=lbs["energy"], info=data.energy, file=f)
+
     _write_xml_single_scientific(tag=lbs["virial_ratio"], info=data.extra["virial_ratio"], file=f)
 
     # write nuclear Cartesian energy gradients
@@ -504,7 +508,7 @@ def _write_xml_single(tag: str, info: [str, int], file: TextIO) -> None:
     print('</' + tag.lstrip('<'), file=file)
 
 
-def _write_xml_single_scientific(tag: str, info: str, file: TextIO) -> None:
+def _write_xml_single_scientific(tag: str, info: float, file: TextIO) -> None:
     """Write header, tail and the data between them into the file."""
     print(tag, file=file)
     print('{: ,.14E}'.format(info), file=file)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -43,12 +43,15 @@ PATTERNS = ['*.wfx']
 
 def _wfx_labels() -> tuple:
     """Build labels for wfx parser."""
+    # labels of various sections in WFX file grouped based on their data type
+
+    # section labels with string data types
     labels_str = {
         '<Title>': 'title',
         '<Keywords>': 'keywords',
         '<Model>': 'model_name',
     }
-    # integer numbers
+    # section labels with integer number data types
     labels_int = {
         '<Number of Nuclei>': 'num_atoms',
         '<Number of Occupied Molecular Orbitals>': 'num_occ_mo',
@@ -60,7 +63,7 @@ def _wfx_labels() -> tuple:
         '<Number of Primitives>': 'num_primitives',
         '<Electronic Spin Multiplicity>': 'spin_multi',
     }
-    # float numbers
+    # section labels with float number data types
     labels_float = {
         '<Net Charge>': 'charge',
         '<Energy = T + Vne + Vee + Vnn>': 'energy',
@@ -68,12 +71,14 @@ def _wfx_labels() -> tuple:
         '<Nuclear Virial of Energy-Gradient-Based Forces on Nuclei, W>': 'nuc_viral',
         '<Full Virial Ratio, -(V - W)/T>': 'full_virial_ratio',
     }
+    # section labels with array of integer data types
     labels_array_int = {
         '<Atomic Numbers>': 'atnums',
         '<Primitive Centers>': 'centers',
         '<Primitive Types>': 'types',
         '<MO Numbers>': 'mo_numbers',  # This is constructed in parse_wfx.
     }
+    # section labels with array of float data types
     labels_array_float = {
         '<Nuclear Cartesian Coordinates>': 'atcoords',
         '<Nuclear Charges>': 'nuclear_charge',
@@ -82,17 +87,17 @@ def _wfx_labels() -> tuple:
         '<Molecular Orbital Occupation Numbers>': 'mo_occs',
         '<Molecular Orbital Primitive Coefficients>': 'mo_coeffs',
     }
+    # section labels with other data types
     labels_other = {
         '<Nuclear Names>': 'nuclear_names',
         '<Molecular Orbital Spin Types>': 'mo_spins',
         '<Nuclear Cartesian Energy Gradients>': 'nuclear_gradient',
     }
 
-    # list of required section tags
-    required_tags = (
-            list(labels_str) + list(labels_int) + list(labels_float)
-            + list(labels_array_int) + list(labels_array_float) + list(labels_other)
-    )
+    # list of tags corresponding to required sections based on WFX format specifications
+    required_tags = list(labels_str) + list(labels_int) + list(labels_float)
+    required_tags += list(labels_array_float) + list(labels_array_int) + list(labels_other)
+    # remove tags corresponding to optional sections
     required_tags.remove('<Model>')
     required_tags.remove('<Number of Core Electrons>')
     required_tags.remove('<Electronic Spin Multiplicity>')

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -101,38 +101,31 @@ def _wfx_labels() -> tuple:
     required_tags.remove('<Nuclear Virial of Energy-Gradient-Based Forces on Nuclei, W>')
     required_tags.remove('<Nuclear Cartesian Energy Gradients>')
 
-    return labels_str, labels_int, labels_float, labels_array_int, \
-           labels_array_float, labels_other, required_tags
-
-
-labels_str, labels_int, labels_float, labels_array_int, \
-labels_array_float, labels_other, required_tags = _wfx_labels()
+    return (labels_str, labels_int, labels_float, labels_array_int, labels_array_float,
+            labels_other, required_tags)
 
 
 def load_data_wfx(lit: LineIterator) -> dict:
     """Process loaded WFX data."""
     # load raw data & check required tags
+    lbs_str, lbs_int, lbs_float, lbs_aint, lbs_afloat, lbs_other, required_tags = _wfx_labels()
     data = parse_wfx(lit, required_tags)
 
     # process raw data
     result = {}
     for key, value in data.items():
-        if key in labels_str:
-            result[labels_str[key]] = value[0]
-        elif key in labels_int:
-            result[labels_int[key]] = int(value[0])
-        elif key in labels_float:
-            result[labels_float[key]] = float(value[0])
-        elif key in labels_array_float:
-            result[labels_array_float[key]] = np.fromstring(" ".join(value),
-                                                            dtype=np.float,
-                                                            sep=" ")
-        elif key in labels_array_int:
-            result[labels_array_int[key]] = np.fromstring(" ".join(value),
-                                                          dtype=np.int,
-                                                          sep=" ")
-        elif key in labels_other:
-            result[labels_other[key]] = value
+        if key in lbs_str:
+            result[lbs_str[key]] = value[0]
+        elif key in lbs_int:
+            result[lbs_int[key]] = int(value[0])
+        elif key in lbs_float:
+            result[lbs_float[key]] = float(value[0])
+        elif key in lbs_afloat:
+            result[lbs_afloat[key]] = np.fromstring(" ".join(value), dtype=np.float, sep=" ")
+        elif key in lbs_aint:
+            result[lbs_aint[key]] = np.fromstring(" ".join(value), dtype=np.int, sep=" ")
+        elif key in lbs_other:
+            result[lbs_other[key]] = value
         else:
             warnings.warn("Not recognized label, skip {0}".format(key))
 
@@ -272,8 +265,8 @@ def load_one(lit: LineIterator) -> dict:
 def dump_one(f: TextIO, data: IOData):
     """Do not edit this docstring. It will be overwritten."""
     # all the labels
-    labels_all = {**labels_str, **labels_int, **labels_float, **labels_array_int,
-                  **labels_array_float, **labels_other}
+    lbs_str, lbs_int, lbs_float, lbs_aint, lbs_afloat, lbs_other, required_tags = _wfx_labels()
+    labels_all = {**lbs_str, **lbs_int, **lbs_float, **lbs_aint, **lbs_afloat, **lbs_other}
     # the required_tags for WFX files
     # required = [labels_all[tag] for tag in required_tags]
     # flip keys and values for further use

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -382,7 +382,9 @@ def dump_one(f: TextIO, data: IOData):
     _write_xml_single(tag=lbs["num_primitives"], info=obasis.nbasis, file=f)
 
     # write number of occupied molecular orbitals
-    # TODO: This is not correct when mo contains virtual orbitals
+    # in practice wfx prints the total number of MO, even though the section title specifies
+    # "Number of Occupied Molecular Orbitals", which is different from total number of MO when
+    # you print virtual orbitals in wfx file.
     num_mo = data.mo.occs.shape[0]
     _write_xml_single(tag=lbs["num_occ_mo"], info=num_mo, file=f)
 

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -409,10 +409,7 @@ def dump_one(f: TextIO, data: IOData):
     print("</Primitive Types>", file=f)
 
     # write primitive exponents
-    exponents = []
-    for shell in obasis.shells:
-        rang = len(obasis.conventions[shell.angmoms[0], 'c'])
-        exponents.extend([shell.exponents[0] for ex in range(rang)])
+    exponents = [shell.exponents[0] for shell in obasis.shells for _ in range(shell.nbasis)]
     print("<Primitive Exponents>", file=f)
     for j in range(0, len(exponents), 4):
         print(' '.join(['{: ,.14E}'.format(e) for e in exponents[j:j + 4]]), file=f)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -355,8 +355,7 @@ def dump_one(f: TextIO, data: IOData):
     _write_xml_single(tag=lbs["num_perturbations"], info=data.extra["num_perturbations"], file=f)
 
     # write nuclear names, atomic numbers, and nuclear charges
-    # TODO: Add nuclear index to nuclear symbols
-    nuclear_names = [num2sym[i] for i in data.atnums]
+    nuclear_names = [f' {num2sym[num]}{index + 1}' for index, num in enumerate(data.atnums)]
     _write_xml_iterator(tag=lbs["nuclear_names"], info=nuclear_names, file=f)
     _write_xml_iterator(tag=lbs["atnums"], info=data.atnums, file=f)
     _write_xml_iterator(tag=lbs["nuclear_charge"], info=data.atcharges, file=f)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -304,9 +304,8 @@ def load_one(lit: LineIterator) -> dict:
     }
 
 
-# todo: check document_dump_one
-@document_dump_one("WFX", ['atcoords', 'atgradient', 'atnums', 'energy',
-                           'exrtra', 'mo', 'obasis', 'title'])
+@document_dump_one("WFX", ['atcoords', 'atnums', 'atcorenums', 'mo', 'obasis', 'charge'],
+                   ['title', 'energy', 'spinpol', 'lot', 'atgradient', 'extra'])
 def dump_one(f: TextIO, data: IOData):   # noqa: R0912
     """Do not edit this docstring. It will be overwritten."""
     # get all tags/labels that can be written into a WFX file

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -158,8 +158,9 @@ def load_data_wfx(lit: LineIterator) -> dict:
     return result
 
 
-def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:   # noqa: R0912
+def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:
     """Load data in all sections existing in the given WFX file LineIterator."""
+    # pylint: disable=too-many-branches
     data = {}
     mo_start = "<Molecular Orbital Primitive Coefficients>"
     section_start = None
@@ -306,8 +307,9 @@ def load_one(lit: LineIterator) -> dict:
 
 @document_dump_one("WFX", ['atcoords', 'atnums', 'atcorenums', 'mo', 'obasis', 'charge'],
                    ['title', 'energy', 'spinpol', 'lot', 'atgradient', 'extra'])
-def dump_one(f: TextIO, data: IOData):   # noqa: R0912
+def dump_one(f: TextIO, data: IOData):
     """Do not edit this docstring. It will be overwritten."""
+    # pylint: disable=too-many-branches,too-many-statements
     # get all tags/labels that can be written into a WFX file
     lbs_str, lbs_int, lbs_float, lbs_aint, lbs_afloat, lbs_other, _ = _wfx_labels()
     # put all labels in one dictionary and flip key and value for easier use

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -406,14 +406,10 @@ def dump_one(f: TextIO, data: IOData):
     # write net charge, number of electrons, number of alpha electrons, and number beta electrons
     _write_xml_single_scientific(tag=lbs["charge"], info=data.charge, file=f)
     _write_xml_single(tag=lbs["num_electrons"], info=int(data.nelec), file=f)
-    # TODO: This needs to be clarified
-    num_alpha_elec = data.mo.occsa[data.mo.occsa > 0.5]
-    num_alpha_elec = sum(num_alpha_elec)
-    _write_xml_single(tag=lbs["num_alpha_electron"], info=int(round(num_alpha_elec)), file=f)
-    # TODO: This needs to be clarified
-    num_beta_elec = data.mo.occsb[data.mo.occsb > 0.5]
-    num_beta_elec = sum(num_beta_elec)
-    _write_xml_single(tag=lbs["num_beta_electron"], info=int(round(num_beta_elec)), file=f)
+    # wfx expects integer values for number of alpha/beta electrons but int rounds down the float
+    # so round is used before turning it to integer to get the correct number.
+    _write_xml_single(tag=lbs["num_alpha_electron"], info=int(round(sum(data.mo.occsa))), file=f)
+    _write_xml_single(tag=lbs["num_beta_electron"], info=int(round(sum(data.mo.occsb))), file=f)
 
     # write electronic spin multiplicity and model (both optional)
     if data.extra["spin_multi"] is not None:

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -433,14 +433,10 @@ def dump_one(f: TextIO, data: IOData):
     # write molecular orbital spin types
     print("<Molecular Orbital Spin Types>", file=f)
     if data.mo.kind == 'restricted':
-        for mo in data.mo.occs:
-            print('Alpha and Beta ', file=f)
+        mo_spin = ['Alpha and Beta '] * len(data.mo.occs)
     else:
-        for mo in data.mo.occsa:
-            print('Alpha', file=f)
-        for mo in data.mo.occsb:
-            print('Beta', file=f)
-
+        mo_spin = ['Alpha'] * len(data.mo.occsa) + ['Beta'] * len(data.mo.occsb)
+    print('\n'.join(mo_spin), file=f)
     print("</Molecular Orbital Spin Types>", file=f)
 
     # write molecular orbital primitive coefficients

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -392,17 +392,12 @@ def dump_one(f: TextIO, data: IOData):
     print("</Primitive Centers>", file=f)
 
     # write primitive types
-    raw_types = [shell.angmoms[0] for shell in obasis.shells]
-    ran_0 = [len(obasis.conventions[angmom, 'c']) for angmom in raw_types]
-    ran_1 = [sum([len(obasis.conventions[x, 'c']) for x in range(ang + 1)]) for ang in raw_types]
-
-    prim_types = []
-    for elem in zip(ran_0, ran_1):
-        if elem[0] != elem[1]:
-            prim_types.extend(range((elem[1]-elem[0])+1, elem[1]+1))
-        else:
-            prim_types.append(1)
-
+    angmom_prim = {}
+    count = 1
+    for angmom in range(max([shell.angmoms[0] for shell in obasis.shells]) + 1):
+        angmom_prim[angmom] = [count + i for i in range(len(obasis.conventions[angmom, 'c']))]
+        count += len(obasis.conventions[angmom, 'c'])
+    prim_types = [item for shell in obasis.shells for item in angmom_prim[shell.angmoms[0]]]
     print("<Primitive Types>", file=f)
     for j in range(0, len(prim_types), 10):
         print(' '.join(['{:d}'.format(c) for c in prim_types[j:j + 10]]), file=f)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -385,11 +385,7 @@ def dump_one(f: TextIO, data: IOData):
         _write_xml_single(tag=lbs["model_name"], info=data.extra["model_name"], file=f)
 
     # write primitive centers
-    prim_centers = []
-    for shell in obasis.shells:
-        rang = len(obasis.conventions[shell.angmoms[0], 'c'])
-        prim_centers.extend([(shell.icenter + 1) for ao in range(rang)])
-
+    prim_centers = [shell.icenter + 1 for shell in obasis.shells for _ in range(shell.nbasis)]
     print("<Primitive Centers>", file=f)
     for j in range(0, len(prim_centers), 10):
         print(' '.join(['{:d}'.format(c) for c in prim_centers[j:j + 10]]), file=f)

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -361,8 +361,6 @@ def dump_one(f: TextIO, data: IOData):
     for index in range(mo_coeffs.shape[1]):
         mo_coeffs[:, index] *= contractions * scales
 
-    # TODO: Ghost atom
-
     # set required values if not available
     data.extra.setdefault("keywords", 'GTO')
     data.extra.setdefault("num_perturbations", 0)
@@ -392,6 +390,8 @@ def dump_one(f: TextIO, data: IOData):
     _write_xml_single(tag=lbs["num_perturbations"], info=data.extra["num_perturbations"], file=f)
 
     # write nuclear names, atomic numbers, and nuclear charges
+    # add ghost atom, represented by Bq and atomic number 0
+    num2sym.update({0: 'Bq'})
     nuclear_names = [f' {num2sym[num]}{index + 1}' for index, num in enumerate(data.atnums)]
     _write_xml_iterator(tag=lbs["nuclear_names"], info=nuclear_names, file=f)
     _write_xml_iterator(tag=lbs["atnums"], info=data.atnums, file=f)

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -87,6 +87,20 @@ def test_load_dump_consistency_lih_cation_rohf(tmpdir):
 
 
 def compare_mulliken_charges(fname, tmpdir, rtol=1.0e-7, atol=0.0):
+    """Check if charges are computed correctly after dumping and loading WFX file format.
+
+    Parameters
+    ----------
+    fname : str
+        The filename to be load.
+    tmpdir : str
+        The temporary directory to dump and load the file.
+    rtole : float, optional
+        Relative tolerance when comparing charges.
+    atol : float, optional
+        Absolute tolerance when comparing charges.
+
+    """
     with path('iodata.test.data', fname) as file_name:
         mol1 = load_one(str(file_name))
     # dump WFX and check that file exists

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -18,17 +18,18 @@
 # --
 """Test iodata.formats.wfn module."""
 
+import os
 
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
-from ..api import load_one
+from ..api import load_one, dump_one
 from ..formats.wfx import load_data_wfx, parse_wfx
 from ..overlap import compute_overlap
 from ..utils import LineIterator
 
-from .common import check_orthonormal, truncated_file
+from .common import check_orthonormal, truncated_file, compare_mols
 
 try:
     from importlib_resources import path
@@ -41,6 +42,42 @@ def helper_load_data_wfx(fn_wfx):
     with path('iodata.test.data', fn_wfx) as fx:
         lit = LineIterator(str(fx))
         return load_data_wfx(lit)
+
+def check_load_dump_consistency(fn, tmpdir):
+    """Check if data is preserved after dumping and loading a Wfx file.
+    Parameters
+    ----------
+    fn : str
+        The Molekel filename to load
+    tmpdir : str
+        The temporary directory to dump and load the file.
+    """
+    with path('iodata.test.data', fn) as file_name:
+        mol1 = load_one(str(file_name), fmt='wfx')
+    fn_tmp = os.path.join(tmpdir, 'foo.bar')
+    print(fn_tmp)
+    dump_one(mol1, fn_tmp, fmt='wfx')
+    mol2 = load_one(fn_tmp, fmt='wfx')
+    compare_mols(mol1, mol2)
+
+
+def test_load_dump_consistency_water(tmpdir):
+    check_load_dump_consistency('water_sto3g_hf.wfx', tmpdir)
+
+def test_load_dump_consistency_h2(tmpdir):
+    check_load_dump_consistency('h2_ub3lyp_ccpvtz.wfx', tmpdir)
+
+
+def test_load_dump_consistency_lih_cation_cisd(tmpdir):
+    check_load_dump_consistency('lih_cation_cisd.wfx', tmpdir)
+
+
+def test_load_dump_consistency_lih_cation_uhf(tmpdir):
+    check_load_dump_consistency('lih_cation_uhf.wfx', tmpdir)
+
+
+def test_load_dump_consistency_lih_cation_rohf(tmpdir):
+    check_load_dump_consistency('lih_cation_rohf.wfx', tmpdir)
 
 
 def test_load_data_wfx_h2():

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -46,6 +46,7 @@ def helper_load_data_wfx(fn_wfx):
 
 def check_load_dump_consistency(fn, tmpdir):
     """Check if data is preserved after dumping and loading a Wfx file.
+
     Parameters
     ----------
     fn : str

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -43,6 +43,7 @@ def helper_load_data_wfx(fn_wfx):
         lit = LineIterator(str(fx))
         return load_data_wfx(lit)
 
+
 def check_load_dump_consistency(fn, tmpdir):
     """Check if data is preserved after dumping and loading a Wfx file.
     Parameters
@@ -63,6 +64,7 @@ def check_load_dump_consistency(fn, tmpdir):
 
 def test_load_dump_consistency_water(tmpdir):
     check_load_dump_consistency('water_sto3g_hf.wfx', tmpdir)
+
 
 def test_load_dump_consistency_h2(tmpdir):
     check_load_dump_consistency('h2_ub3lyp_ccpvtz.wfx', tmpdir)

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -85,7 +85,7 @@ def test_load_dump_consistency_lih_cation_rohf(tmpdir):
     check_load_dump_consistency('lih_cation_rohf.wfx', tmpdir)
 
 
-def compare_mulliken_charges(fname, tmpdir):
+def compare_mulliken_charges(fname, tmpdir, rtol=1.0e-7, atol=0.0):
     with path('iodata.test.data', fname) as file_name:
         mol1 = load_one(str(file_name))
     # dump WFX and check that file exists
@@ -96,7 +96,7 @@ def compare_mulliken_charges(fname, tmpdir):
     mol2 = load_one(fn_tmp)
     charges1 = compute_mulliken_charges(mol1)
     charges2 = compute_mulliken_charges(mol2)
-    assert_allclose(charges1, charges2, rtol=1.0e-7, atol=0)
+    assert_allclose(charges1, charges2, rtol=rtol, atol=atol)
 
 
 def test_dump_one_from_fchk_h2o(tmpdir):
@@ -116,6 +116,14 @@ def test_dump_one_from_fchk_ch3_unrestricted(tmpdir):
 def test_dump_one_from_wfn_h2o(tmpdir):
     compare_mulliken_charges('h2o_sto3g.wfn', tmpdir)
     compare_mulliken_charges('h2o_sto3g_decontracted.wfn', tmpdir)
+
+def test_dump_one_from_molden(tmpdir):
+    compare_mulliken_charges('h2o.molden.input', tmpdir)
+    compare_mulliken_charges('he2_ghost_psi4_1.0.molden', tmpdir)
+    compare_mulliken_charges('neon_turbomole_def2-qzvp.molden', tmpdir, atol=1.0e-10)
+    compare_mulliken_charges('nh3_molden_cart.molden', tmpdir)
+    compare_mulliken_charges('nh3_molpro2012.molden', tmpdir)
+    compare_mulliken_charges('nh3_turbomole.molden', tmpdir)
 
 
 def test_dump_one_from_wfn_lih(tmpdir):

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -118,21 +118,67 @@ def test_dump_one_from_wfn_h2o(tmpdir):
     compare_mulliken_charges('h2o_sto3g_decontracted.wfn', tmpdir)
 
 
-def test_dump_one_from_molden(tmpdir):
+def test_dump_one_from_wfn_o2(tmpdir):
+    compare_mulliken_charges('o2_uhf.wfn', tmpdir)
+    compare_mulliken_charges('o2_uhf_virtual.wfn', tmpdir)
+
+
+def test_dump_one_from_wfn_atom(tmpdir):
+    # Li atom
+    compare_mulliken_charges('li_sp_orbital.wfn', tmpdir)
+    compare_mulliken_charges('li_sp_virtual.wfn', tmpdir)
+    # He atom
+    compare_mulliken_charges('he_s_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_s_virtual.wfn', tmpdir)
+    compare_mulliken_charges('he_p_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_d_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_sp_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_spd_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_spdf_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_spdfgh_orbital.wfn', tmpdir)
+    compare_mulliken_charges('he_spdfgh_virtual.wfn', tmpdir)
+
+
+def test_dump_one_from_wfn_lih(tmpdir):
+    compare_mulliken_charges('lih_cation_uhf.wfn', tmpdir)
+    compare_mulliken_charges('lih_cation_rohf.wfn', tmpdir)
+    compare_mulliken_charges('lih_cation_cisd.wfn', tmpdir)
+    compare_mulliken_charges('lih_cation_fci.wfn', tmpdir)
+
+
+def test_dump_one_from_wfn_lif(tmpdir):
+    compare_mulliken_charges('lif_fci.wfn', tmpdir)
+
+
+def test_dump_one_from_molden_h2o(tmpdir):
     compare_mulliken_charges('h2o.molden.input', tmpdir)
+
+
+def test_dump_one_from_molden_he2(tmpdir):
     compare_mulliken_charges('he2_ghost_psi4_1.0.molden', tmpdir)
+
+
+def test_dump_one_from_molden_neon(tmpdir):
     compare_mulliken_charges('neon_turbomole_def2-qzvp.molden', tmpdir, atol=1.0e-10)
+
+
+def test_dump_one_from_molden_nh3(tmpdir):
     compare_mulliken_charges('nh3_molden_cart.molden', tmpdir)
     compare_mulliken_charges('nh3_molpro2012.molden', tmpdir)
     compare_mulliken_charges('nh3_turbomole.molden', tmpdir)
 
 
-def test_dump_one_from_wfn_lih(tmpdir):
-    compare_mulliken_charges('lif_fci.wfn', tmpdir)
-    compare_mulliken_charges('lih_cation_uhf.wfn', tmpdir)
-    compare_mulliken_charges('lih_cation_rohf.wfn', tmpdir)
-    compare_mulliken_charges('lih_cation_cisd.wfn', tmpdir)
-    compare_mulliken_charges('lih_cation_fci.wfn', tmpdir)
+def test_dump_one_from_mkl_methanol(tmpdir):
+    compare_mulliken_charges('ethanol.mkl', tmpdir)
+
+
+def test_dump_one_from_mkl_h2(tmpdir):
+    compare_mulliken_charges('h2_sto3g.mkl', tmpdir)
+
+
+# add this test when pure to Cartesian basis set conversion is supported
+# def test_dump_one_from_mkl_li2(tmpdir):
+#     compare_mulliken_charges('li2.mkl', tmpdir)
 
 
 def test_load_data_wfx_h2():

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -235,7 +235,7 @@ def test_parse_wfx_missing_tag_h2o():
         lit = LineIterator(fn_wfx)
         with pytest.raises(IOError) as error:
             parse_wfx(lit, required_tags=["<Foo Bar>"])
-    assert str(error.value).endswith("Section <Foo Bar> is missing.")
+    assert str(error.value).endswith("Section <Foo Bar> is missing from loaded WFX data.")
 
 
 def test_load_data_wfx_h2o_error():

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -117,6 +117,7 @@ def test_dump_one_from_wfn_h2o(tmpdir):
     compare_mulliken_charges('h2o_sto3g.wfn', tmpdir)
     compare_mulliken_charges('h2o_sto3g_decontracted.wfn', tmpdir)
 
+
 def test_dump_one_from_molden(tmpdir):
     compare_mulliken_charges('h2o.molden.input', tmpdir)
     compare_mulliken_charges('he2_ghost_psi4_1.0.molden', tmpdir)


### PR DESCRIPTION
With the help of Leila, we have added the functionality of `dump_one()` for WFX format.

- [x] Implementation `dump_one()` support for WFX 
- [x] Add tests for dump_one()
- [x] Fix pylinter errors: missing shite spaces, docstring formatting, identation 

Thanks for the nice contributions! @leila-pujal 