### PR TITLE
Convert all remaining namedtuples to attr classes

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -325,7 +325,42 @@ to avoid duplicate efforts.
     results in minor corrections at worst. We'll do our best to avoid larger
     problems in step 1.
 
+
+Notes on attrs
+--------------
+
+IOData uses the `attrs`_ library, not to be confused with the `attr`_ library,
+for classes representing data loaded from files: ``IOData``, ``MolecularBasis``,
+``Shell``, ``MolecularOrbitals`` and ``Cube``. This enables basic attribute
+validation, which eliminates potentially silly bugs. The following two tricks
+might be convenient with working with these classes:
+
+- The data can be turned into plain Python data types with the ``attr.asdict``
+  function. Make sure you add the ``retain_collection_types=True`` option, to
+  avoid the following issue: https://github.com/python-attrs/attrs/issues/646
+  For example.
+
+  .. code-block:: python
+
+      from iodata import load_one
+      import attr
+      iodata = load_one("example.xyz")
+      fields = attr.asdict(iodata, retain_collection_types=True)
+
+- A shallow copy with a few modified attributes can be created with the evolve
+  method, which is a wrapper for ``attr.evolve``:
+
+  .. code-block:: python
+
+      from iodata import load_one
+      import attr
+      iodata1 = load_one("example.xyz")
+      iodata2 = iodata1.evolve(title="another title")
+
+
 .. _Bash: https://en.wikipedia.org/wiki/Bash_(Unix_shell)
 .. _Python: https://en.wikipedia.org/wiki/Python_(programming_language)
 .. _type hinting: https://docs.python.org/3/library/typing.html
 .. _PEP 0563: https://www.python.org/dev/peps/pep-0563/
+.. _attrs: https://www.attrs.org/en/stable/
+.. _attr: https://github.com/denis-ryzhkov/attr

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -332,8 +332,11 @@ Notes on attrs
 IOData uses the `attrs`_ library, not to be confused with the `attr`_ library,
 for classes representing data loaded from files: ``IOData``, ``MolecularBasis``,
 ``Shell``, ``MolecularOrbitals`` and ``Cube``. This enables basic attribute
-validation, which eliminates potentially silly bugs. The following two tricks
-might be convenient with working with these classes:
+validation, which eliminates potentially silly bugs.
+(See ``iodata/attrutils.py`` and the usage of ``validate_shape`` in all those
+classes.)
+
+The following two tricks might be convenient with working with these classes:
 
 - The data can be turned into plain Python data types with the ``attr.asdict``
   function. Make sure you add the ``retain_collection_types=True`` option, to
@@ -347,15 +350,46 @@ might be convenient with working with these classes:
       iodata = load_one("example.xyz")
       fields = attr.asdict(iodata, retain_collection_types=True)
 
-- A shallow copy with a few modified attributes can be created with the evolve
-  method, which is a wrapper for ``attr.evolve``:
+  A similar ``astuple`` function works as you would expect.
+
+- A `shallow copy`_ with a few modified attributes can be created with the
+  evolve method, which is a wrapper for ``attr.evolve``:
 
   .. code-block:: python
 
       from iodata import load_one
       import attr
       iodata1 = load_one("example.xyz")
-      iodata2 = iodata1.evolve(title="another title")
+      iodata2 = attr.evolve(iodata1, title="another title")
+
+  The usage of evolve becomes mandatory when you want to change two or more
+  attributes whose shape need to be consistent. For example, the following
+  would fail:
+
+  .. code-block:: python
+
+      from iodata import IOData
+      iodata = IOData(atnums=[7, 7], atcoords=[[0, 0, 0], [2, 0, 0]])
+      # The next line will fail because the size of atnums and atcoords
+      # becomes inconsistent.
+      iodata.atnums = [8, 8, 8]
+      iodata.atcoords = [[0, 0, 0], [2, 0, 1], [4, 0, 0]]
+
+  The following code, which has the same intent, does work:
+
+  .. code-block:: python
+
+      from iodata import IOData
+      import attr
+      iodata1 = IOData(atnums=[7, 7], atcoords=[[0, 0, 0], [2, 0, 0]])
+      iodata2 = attr.evolve(
+          iodata1,
+          atnums=[8, 8, 8],
+          atcoords=[[0, 0, 0], [2, 0, 1], [4, 0, 0]],
+      )
+
+   For brevity, lists (of lists) were used in these examples. These are always
+   converted to arrays by the constructor or when assigning them to attributes.
 
 
 .. _Bash: https://en.wikipedia.org/wiki/Bash_(Unix_shell)
@@ -364,3 +398,4 @@ might be convenient with working with these classes:
 .. _PEP 0563: https://www.python.org/dev/peps/pep-0563/
 .. _attrs: https://www.attrs.org/en/stable/
 .. _attr: https://github.com/denis-ryzhkov/attr
+.. _shallow copy: https://docs.python.org/3/library/copy.html?highlight=shallow

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -29,7 +29,7 @@ IOData has the following dependencies:
 
 - numpy >= 1.0: https://numpy.org/
 - scipy: https://scipy.org/
-- attrs >= 19.1.0: https://www.attrs.org/en/stable/index.html
+- attrs >= 20.1.0: https://www.attrs.org/en/stable/index.html
 - importlib_resources [only for Python 3.6]: https://gitlab.com/python-devs/importlib_resources
 
 You only need to install these dependencies manually when installing IOData from

--- a/iodata/attrutils.py
+++ b/iodata/attrutils.py
@@ -1,0 +1,129 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Utilities for building attr classes."""
+
+
+import numpy as np
+
+
+__all__ = ["convert_array_to", "validate_shape"]
+
+
+def convert_array_to(dtype):
+    """Return a function to convert arrays to the given type."""
+    def converter(array):
+        if array is None:
+            return None
+        return np.array(array, copy=False, dtype=dtype)
+    return converter
+
+
+# pylint: disable=too-many-branches
+def validate_shape(*shape_requirements: tuple):
+    """Return a validator for the shape of an array or the length of an iterable.
+
+    Parameters
+    ----------
+    shape_requirements
+        Specifications for the required shape. Every item of the tuple describes
+        the required size of the corresponding axis of an array. Also the
+        number of items should match the dimensionality of the array. When the
+        validator is used for general iterables, this tuple should contain just
+        one element. Possible values for each item are explained in the "Notes"
+        section below.
+
+    Returns
+    -------
+    validator
+        A validator function for the attr library.
+
+    Notes
+    -----
+    Every element of ``shape_requirements`` defines the expected size of an
+    array along the corresponding axis. An item in this tuple at position (or
+    index) ``i`` can be one of the following:
+
+    1. An integer, which is taken as the expected size along axis ``i``.
+    2. None. In this case, the size of the array along axis ``i`` is not
+       checked.
+    3. A string, which should be the name of another integer attribute with
+       the expected size along axis ``i``. The other attribute is always an
+       attribute of the same object as the attribute being checked.
+    4. A 2-tuple containing a name and an integer. In this case, the name refers
+       to another attribute which is an array or an iterable. When the integer
+       is 0, just the length of the other attribute is used. When the integer is
+       non-zero, the other attribute must be an array and the integer selects an
+       axis. The size of the other array along the selected axis is then used as
+       the expected size of the array being checked along axis ``i``.
+
+    """
+    def validator(obj, attribute, value):
+        # Build the expected shape, with the rules from the docstring.
+        expected_shape = []
+        for item in shape_requirements:
+            if isinstance(item, int) or item is None:
+                expected_shape.append(item)
+            elif isinstance(item, str):
+                expected_shape.append(getattr(obj, item))
+            elif isinstance(item, tuple) and len(item) == 2:
+                other_name, other_axis = item
+                other = getattr(obj, other_name)
+                if other is None:
+                    raise TypeError(
+                        "Other attribute '{}' is not set.".format(other_name)
+                    )
+                if other_axis == 0:
+                    expected_shape.append(len(other))
+                else:
+                    if other_axis >= other.ndim or other_axis < 0:
+                        raise TypeError(
+                            "Cannot get length along axis "
+                            "{} of attribute {} with ndim {}.".format(
+                                other_axis, other_name, other.ndim
+                            )
+                        )
+                    expected_shape.append(other.shape[other_axis])
+            else:
+                raise ValueError(f"Cannot interpret item in shape_requirements: {item}")
+        expected_shape = tuple(expected_shape)
+        # Get the actual shape
+        if isinstance(value, np.ndarray):
+            observed_shape = value.shape
+        else:
+            observed_shape = (len(value),)
+        # Compare
+        match = True
+        if len(expected_shape) != len(observed_shape):
+            match = False
+        if match:
+            for es, os in zip(expected_shape, observed_shape):
+                if es is None:
+                    continue
+                if es != os:
+                    match = False
+                    break
+        # Raise TypeError if needed.
+        if not match:
+            raise TypeError(
+                "Expecting shape {} for attribute {}, got {}".format(
+                    expected_shape, attribute.name, observed_shape
+                )
+            )
+
+    return validator

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -140,10 +140,6 @@ class Shell:
         """Number of contractions. This is usually 1; e.g., it would be 2 for an SP shell."""
         return len(self.angmoms)
 
-    def evolve(self, **changes):
-        """Create a copy with update attributes given in ``changes``."""
-        return attr.evolve(self, **changes)
-
 
 @attr.s(auto_attribs=True, slots=True)
 class MolecularBasis:
@@ -203,10 +199,6 @@ class MolecularBasis:
         """Number of basis functions."""
         return sum(shell.nbasis for shell in self.shells)
 
-    def evolve(self, **changes):
-        """Create a copy with update attributes given in ``changes``."""
-        return attr.evolve(self, **changes)
-
     def get_segmented(self):
         """Unroll generalized contractions."""
         shells = []
@@ -215,7 +207,7 @@ class MolecularBasis:
                 shells.append(Shell(shell.icenter, [angmom], [kind],
                                     shell.exponents, coeffs.reshape(-1, 1)))
         # pylint: disable=no-member
-        return self.evolve(shells=shells)
+        return attr.evolve(self, shells=shells)
 
 
 def convert_convention_shell(conv1: List[str], conv2: List[str], reverse=False) \

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -85,7 +85,8 @@ def angmom_its(angmom: Union[int, List[int]]) -> Union[str, List[str]]:
     return ANGMOM_CHARS[angmom]
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True, slots=True,
+        on_setattr=[attr.setters.validate, attr.setters.convert])
 class Shell:
     """A shell in a molecular basis representing (generalized) contractions with the same exponents.
 
@@ -141,7 +142,8 @@ class Shell:
         return len(self.angmoms)
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True, slots=True,
+        on_setattr=[attr.setters.validate, attr.setters.convert])
 class MolecularBasis:
     """A complete molecular orbital or density basis set.
 

--- a/iodata/formats/chgcar.py
+++ b/iodata/formats/chgcar.py
@@ -134,7 +134,7 @@ def _load_vasp_grid(lit: LineIterator) -> dict:
                 cube_data[i0, i1, i2] = float(words.pop(0))
 
     cube = Cube(origin=np.zeros(3), axes=cellvecs / shape.reshape(-1, 1),
-                shape=shape, data=cube_data)
+                data=cube_data)
 
     return {
         'title': title,

--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -151,7 +151,7 @@ def _read_cp2k_uncontracted_obasis(lit: LineIterator) -> MolecularBasis:
             # read the exponent
             exponent = float(words[-1])
             exponents.append(exponent)
-            coeffs.append([1.0 / _get_cp2k_norm_corrections(angmom, exponent)])
+            coeffs.append(1.0 / _get_cp2k_norm_corrections(angmom, exponent))
             line = next(lit)
         # Build the shell
         kind = 'c' if angmom < 2 else 'p'

--- a/iodata/formats/cube.py
+++ b/iodata/formats/cube.py
@@ -136,6 +136,7 @@ def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     title, atcoords, atnums, cellvecs, cube, atcorenums = _read_cube_header(lit)
     _read_cube_data(lit, cube)
+    del cube["shape"]
     return {
         'title': title,
         'atcoords': atcoords,

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -502,7 +502,7 @@ def _fix_obasis_normalize_contractions(obasis: MolecularBasis) -> MolecularBasis
     fixed_shells = []
     for shell in obasis.shells:
         shell_obasis = MolecularBasis(
-            [shell._replace(icenter=0)],
+            [shell.evolve(icenter=0)],
             obasis.conventions,
             obasis.primitive_normalization
         )

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -29,6 +29,7 @@ errors are corrected when loading them with IOData.
 from typing import Tuple, Union, TextIO
 import copy
 
+import attr
 import numpy as np
 
 from ..basis import (angmom_its, angmom_sti, MolecularBasis, Shell,
@@ -502,7 +503,7 @@ def _fix_obasis_normalize_contractions(obasis: MolecularBasis) -> MolecularBasis
     fixed_shells = []
     for shell in obasis.shells:
         shell_obasis = MolecularBasis(
-            [shell.evolve(icenter=0)],
+            [attr.evolve(shell, icenter=0)],
             obasis.conventions,
             obasis.primitive_normalization
         )

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -32,7 +32,8 @@ __all__ = ['IOData']
 
 
 # pylint: disable=too-many-instance-attributes
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True, slots=True,
+        on_setattr=[attr.setters.validate, attr.setters.convert])
 class IOData:
     """A container class for data loaded from (or to be written to) a file.
 

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -22,40 +22,13 @@
 import attr
 import numpy as np
 
+from .attrutils import convert_array_to, validate_shape
 from .basis import MolecularBasis
 from .orbitals import MolecularOrbitals
 from .utils import Cube
 
 
 __all__ = ['IOData']
-
-
-def convert_array_to(dtype):
-    """Return a function to convert arrays to the given type."""
-    def converter(array):
-        if array is None:
-            return None
-        return np.array(array, copy=False, dtype=dtype)
-    return converter
-
-
-def validate_shape(*shape):
-    """Return a function to validate the shape of an array."""
-    def validator(obj, attrname, value):
-        if value is None:
-            return
-        myshape = tuple([obj.natom if size == 'natom' else size for size in shape])
-        if len(myshape) != len(value.shape):
-            raise TypeError('Expect ndim {} for attribute {}, got {}'.format(
-                len(myshape), attrname, len(value.shape)))
-        for axis, size in enumerate(myshape):
-            if size is None:
-                continue
-            if size != value.shape[axis]:
-                raise TypeError(
-                    'Expect size {} for axis {} of attribute {}, got {}'.format(
-                        size, axis, attrname, value.shape[axis]))
-    return validator
 
 
 # pylint: disable=too-many-instance-attributes
@@ -199,40 +172,40 @@ class IOData:
     atcharges: dict = {}
     atcoords: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape('natom', 3))
+        validator=attr.validators.optional(validate_shape('natom', 3)))
     _atcorenums: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape('natom'))
+        validator=attr.validators.optional(validate_shape('natom')))
     atffparams: dict = {}
     atfrozen: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(bool),
-        validator=validate_shape('natom'))
+        validator=attr.validators.optional(validate_shape('natom')))
     atgradient: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape('natom', 3))
+        validator=attr.validators.optional(validate_shape('natom', 3)))
     athessian: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape(None, None))
+        validator=attr.validators.optional(validate_shape(None, None)))
     atmasses: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape('natom'))
+        validator=attr.validators.optional(validate_shape('natom')))
     atnums: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(int),
-        validator=validate_shape('natom'))
+        validator=attr.validators.optional(validate_shape('natom')))
     basisdef: str = None
     bonds: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(int),
-        validator=validate_shape(None, 3))
+        validator=attr.validators.optional(validate_shape(None, 3)))
     cellvecs: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape(None, 3))
+        validator=attr.validators.optional(validate_shape(None, 3)))
     _charge: float = None
     core_energy: float = None
     cube: Cube = None
     energy: float = None
     extcharges: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
-        validator=validate_shape(None, 4))
+        validator=attr.validators.optional(validate_shape(None, 4)))
     extra: dict = {}
     g_rot: float = None
     lot: str = None

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -19,15 +19,17 @@
 """Data structure for molecular orbitals."""
 
 
-from typing import NamedTuple
-
+import attr
 import numpy as np
+
+from .attrutils import validate_shape
 
 
 __all__ = ['MolecularOrbitals']
 
 
-class MolecularOrbitals(NamedTuple):
+@attr.s(auto_attribs=True, slots=True)
+class MolecularOrbitals:
     """Class of Orthonormal Molecular Orbitals.
 
     Attributes
@@ -64,10 +66,13 @@ class MolecularOrbitals(NamedTuple):
     kind: str
     norba: int
     norbb: int
-    occs: np.ndarray
-    coeffs: np.ndarray
-    energies: np.ndarray
-    irreps: np.ndarray
+    occs: np.ndarray = attr.ib(
+        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
+    coeffs: np.ndarray = attr.ib(validator=validate_shape(None, None))
+    energies: np.ndarray = attr.ib(
+        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
+    irreps: np.ndarray = attr.ib(
+        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
 
     @property
     def nelec(self) -> float:
@@ -172,5 +177,6 @@ class MolecularOrbitals(NamedTuple):
             return self.energies[self.norba:]
         raise NotImplementedError
 
-
-MolecularOrbitals.__defaults__ = (None,)
+    def evolve(self, **changes):
+        """Create a copy with update attributes given in ``changes``."""
+        return attr.evolve(self, **changes)

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -176,7 +176,3 @@ class MolecularOrbitals:
         if self.kind == 'unrestricted':
             return self.energies[self.norba:]
         raise NotImplementedError
-
-    def evolve(self, **changes):
-        """Create a copy with update attributes given in ``changes``."""
-        return attr.evolve(self, **changes)

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -28,7 +28,8 @@ from .attrutils import validate_shape
 __all__ = ['MolecularOrbitals']
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True, slots=True,
+        on_setattr=[attr.setters.validate, attr.setters.convert])
 class MolecularOrbitals:
     """Class of Orthonormal Molecular Orbitals.
 

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -18,6 +18,7 @@
 # --
 """Module for computing overlap of atomic orbital basis functions."""
 
+import attr
 import numpy as np
 from scipy.special import binom, factorial2
 
@@ -193,7 +194,7 @@ def _compute_cart_shell_normalizations(shell: 'Shell') -> np.ndarray:
         shell is pure.
 
     """
-    shell = shell.evolve(kinds=['c'] * shell.ncon)
+    shell = attr.evolve(shell, kinds=['c'] * shell.ncon)
     result = []
     for angmom in shell.angmoms:
         for exponent in shell.exponents:

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -193,7 +193,7 @@ def _compute_cart_shell_normalizations(shell: 'Shell') -> np.ndarray:
         shell is pure.
 
     """
-    shell = shell._replace(kinds=['c'] * shell.ncon)
+    shell = shell.evolve(kinds=['c'] * shell.ncon)
     result = []
     for angmom in shell.angmoms:
         for exponent in shell.exponents:

--- a/iodata/test/test_attrutils.py
+++ b/iodata/test/test_attrutils.py
@@ -1,0 +1,204 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+"""Unit tests for iodata.attrutils."""
+
+
+import attr
+import numpy as np
+from numpy.testing import assert_allclose
+import pytest
+
+from ..attrutils import convert_array_to, validate_shape
+
+
+@attr.s(slots=True)
+class FooBar:
+    """Just a silly class for testing convert_array_to."""
+
+    spam: np.ndarray = attr.ib(converter=convert_array_to(float))
+
+
+def test_convert_array_to_init():
+    fb = FooBar(spam=None)
+    assert fb.spam is None
+    spam1 = np.array([1.0, 3.0, -1.0])
+    fb = FooBar(spam1)
+    assert fb.spam is spam1
+    spam2 = np.array([3, 7, -2])
+    fb = FooBar(spam2)
+    assert fb.spam is not spam2
+    assert_allclose(fb.spam, spam2)
+
+
+# converter is not called when assigning!
+# See https://github.com/python-attrs/attrs/issues/645
+@pytest.mark.skip
+def test_convert_array_to_assign():
+    fb = FooBar(spam=None)
+    assert fb.spam is None
+    spam1 = np.array([1.0, 3.0, -1.0])
+    fb.spam = spam1
+    assert fb.spam is spam1
+    spam2 = np.array([3, 7, -2])
+    fb.spam = spam2
+    assert fb.spam is not spam2
+    assert_allclose(fb.spam, spam2)
+    fb.spam = None
+    assert fb.spam is None
+
+
+@attr.s(slots=True, frozen=True)
+class Spam:
+    """Just a silly class for testing validate_shape."""
+
+    egg0: np.ndarray = attr.ib(validator=validate_shape(1, None, "negg"))
+    egg1: np.ndarray = attr.ib(validator=validate_shape("negg", ("egg2", 1)))
+    egg2: np.ndarray = attr.ib(validator=validate_shape(2, ("egg1", 1)))
+    egg3: np.ndarray = attr.ib(validator=validate_shape(("leg", 0)))
+    negg: int = attr.ib(converter=int)
+    leg: str = attr.ib(validator=validate_shape(("egg3", 0)))
+
+
+def test_validate_shape_init():
+    # Construct a Spam instance with valid arguments. This should just work
+    spam = Spam(
+        np.zeros((1, 7, 4)), np.zeros((4, 3)), np.zeros((2, 3)), np.zeros(5), 4, "abcde"
+    )
+    # Double check
+    attr.validate(spam)
+    # Call constructor with invalid arguments
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7, 4)),
+            np.zeros((4, 3)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            4,
+            "abcde",
+        )
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7)),
+            np.zeros((4, 3)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            4,
+            "abcde",
+        )
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7, 4)),
+            np.zeros((1, 3)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            4,
+            "abcde",
+        )
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7, 4)),
+            np.zeros((4, 9)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            4,
+            "abcde",
+        )
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7, 4)),
+            np.zeros((4, 3)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            15,
+            "abcde",
+        )
+    with pytest.raises(TypeError):
+        _ = Spam(
+            np.zeros((2, 7, 4)),
+            np.zeros((4, 3)),
+            np.zeros((2, 3)),
+            np.zeros(5),
+            4,
+            "abcd",
+        )
+
+
+# validator is not called when assigning.
+# See https://github.com/python-attrs/attrs/issues/645
+@pytest.mark.skip
+def test_validate_shape_assign():
+    # Construct a Spam instance with valid arguments. This should just work
+    spam = Spam(
+        np.zeros((1, 7, 4)), np.zeros((4, 3)), np.zeros((2, 3)), np.zeros(5), 4, "abcde"
+    )
+    # Double check
+    attr.validate(spam)
+    # assign invalid attributes
+    with pytest.raises(TypeError):
+        spam.egg0 = np.zeros((2, 7, 4))
+    with pytest.raises(TypeError):
+        spam.egg0 = np.zeros((2, 7))
+    with pytest.raises(TypeError):
+        spam.egg1 = np.zeros((1, 3))
+    with pytest.raises(TypeError):
+        spam.egg1 = np.zeros((4, 9))
+    with pytest.raises(TypeError):
+        spam.negg = 15
+    with pytest.raises(TypeError):
+        spam.leg = "abcd"
+
+
+@attr.s(slots=True)
+class NoName0:
+    """Test exception in validate_shape: unsupported item in shape_requirements."""
+
+    xxx: str = attr.ib(validator=validate_shape(["asdfsa", 3]))
+
+
+@attr.s(slots=True)
+class NoName1:
+    """Test exception in validate_shape: unsupported item in shape_requirements."""
+
+    xxx: str = attr.ib(validator=validate_shape(("asdfsa",)))
+
+
+@attr.s(slots=True)
+class NoName2:
+    """Test exception in validate_shape: other doest not exist."""
+
+    xxx: str = attr.ib(validator=validate_shape("other"))
+
+
+@attr.s(slots=True)
+class NoName3:
+    """Test exception in validate_shape: other is not an array."""
+
+    xxx: str = attr.ib(validator=validate_shape(("other", 1)))
+    other = attr.ib()
+
+
+def test_validate_shape_exceptions():
+    with pytest.raises(ValueError):
+        _ = NoName0("aaa")
+    with pytest.raises(ValueError):
+        _ = NoName1("aaa")
+    with pytest.raises(AttributeError):
+        _ = NoName2("aaa")
+    with pytest.raises(TypeError):
+        _ = NoName3("aaa", None)

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -54,6 +54,6 @@ def test_load_chgcar_water():
     assert_allclose(mol.atcoords[1], coords, atol=1.e-7)
     assert_allclose(volume(mol.cellvecs), 15 ** 3, atol=1.e-4)
     assert_equal(len(mol.cube.shape), 3)
-    assert_equal(mol.cube.shape, 3)
+    assert_equal(mol.cube.shape, (3, 3, 3))
     assert_allclose(mol.cube.axes, mol.cellvecs / 3, atol=1.e-10)
     assert abs(mol.cube.origin).max() < 1e-10

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -38,7 +38,7 @@ def test_load_aelta():
     assert_equal(mol.natom, 72)
     assert_allclose(mol.atcoords[5, 0], 27.275511, atol=1.e-5)
     assert_allclose(mol.atcoords[-2, 2], 26.460812, atol=1.e-5)
-    assert_equal(mol.cube.shape, 12)
+    assert_equal(mol.cube.shape, (12, 12, 12))
     my_cellvecs = np.array([[1.8626, 0.1, 0.0],
                             [0.0, 1.8626, 0.0],
                             [0.0, 0.0, 1.8626]], dtype=np.float) * 12

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -453,7 +453,7 @@ def test_load_dump_consistency(tmpdir, fn, match):
     mol1.obasis = mol1.obasis.get_segmented()
     # - Set default irreps in mol1, if not present.
     if mol1.mo.irreps is None:
-        mol1.mo = mol1.mo._replace(irreps=['1a'] * mol1.mo.norb)
+        mol1.mo = mol1.mo.evolve(irreps=['1a'] * mol1.mo.norb)
     # - Remove the one_rdms from mol1.
     mol1.one_rdms = {}
     compare_mols(mol1, mol2)

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -21,6 +21,7 @@
 
 import os
 
+import attr
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
@@ -453,7 +454,7 @@ def test_load_dump_consistency(tmpdir, fn, match):
     mol1.obasis = mol1.obasis.get_segmented()
     # - Set default irreps in mol1, if not present.
     if mol1.mo.irreps is None:
-        mol1.mo = mol1.mo.evolve(irreps=['1a'] * mol1.mo.norb)
+        mol1.mo = attr.evolve(mol1.mo, irreps=['1a'] * mol1.mo.norb)
     # - Remove the one_rdms from mol1.
     mol1.one_rdms = {}
     compare_mols(mol1, mol2)

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -18,6 +18,7 @@
 # --
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
+import attr
 import numpy as np
 from numpy.testing import assert_allclose
 from pytest import raises
@@ -75,7 +76,7 @@ def test_load_fchk_o2_cc_pvtz_cart_num():
         ref = np.load(str(fn_npy))
     with path('iodata.test.data', 'o2_cc_pvtz_cart.fchk') as fn_fchk:
         data = load_one(fn_fchk)
-    obasis = data.obasis.evolve(conventions=OVERLAP_CONVENTIONS)
+    obasis = attr.evolve(data.obasis, conventions=OVERLAP_CONVENTIONS)
     assert_allclose(ref, compute_overlap(obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -75,7 +75,7 @@ def test_load_fchk_o2_cc_pvtz_cart_num():
         ref = np.load(str(fn_npy))
     with path('iodata.test.data', 'o2_cc_pvtz_cart.fchk') as fn_fchk:
         data = load_one(fn_fchk)
-    obasis = data.obasis._replace(conventions=OVERLAP_CONVENTIONS)
+    obasis = data.obasis.evolve(conventions=OVERLAP_CONVENTIONS)
     assert_allclose(ref, compute_overlap(obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -145,10 +145,6 @@ class Cube:
         """Shape of the rectangular grid."""  # noqa: D401
         return self.data.shape
 
-    def evolve(self, **changes):
-        """Create a copy with update attributes given in ``changes``."""
-        return attr.evolve(self, **changes)
-
 
 def set_four_index_element(four_index_object: np.ndarray, i: int, j: int, k: int, l: int,
                            value: float):

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -19,12 +19,15 @@
 """Utility functions module."""
 
 
-from typing import Tuple, NamedTuple
+from typing import Tuple
 import warnings
 
+import attr
 import numpy as np
 import scipy.constants as spc
 from scipy.linalg import eigh
+
+from .attrutils import validate_shape
 
 
 __all__ = ['LineIterator', 'Cube', 'set_four_index_element', 'volume',
@@ -116,7 +119,8 @@ class LineIterator:
         self.lineno -= 1
 
 
-class Cube(NamedTuple):
+@attr.s(auto_attribs=True, slots=True)
+class Cube:
     """The volumetric data from a cube (or similar) file.
 
     Attributes
@@ -127,17 +131,23 @@ class Cube(NamedTuple):
         A (3, 3) array where each row represents the spacing between two
         neighboring grid points along the first, second and third axis,
         respectively.
-    shape
-        A three-tuple with the number of points along each axis, respectively.
     data
         A (K, L, M) array of data on a uniform grid
 
     """
 
-    origin: np.ndarray
-    axes: np.ndarray
-    shape: np.ndarray
-    data: np.ndarray
+    origin: np.ndarray = attr.ib(validator=validate_shape(3))
+    axes: np.ndarray = attr.ib(validator=validate_shape(3, 3))
+    data: np.ndarray = attr.ib(validator=validate_shape(None, None, None))
+
+    @property
+    def shape(self):
+        """Shape of the rectangular grid."""  # noqa: D401
+        return self.data.shape
+
+    def evolve(self, **changes):
+        """Create a copy with update attributes given in ``changes``."""
+        return attr.evolve(self, **changes)
 
 
 def set_four_index_element(four_index_object: np.ndarray, i: int, j: int, k: int, l: int,

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -119,7 +119,8 @@ class LineIterator:
         self.lineno -= 1
 
 
-@attr.s(auto_attribs=True, slots=True)
+@attr.s(auto_attribs=True, slots=True,
+        on_setattr=[attr.setters.validate, attr.setters.convert])
 class Cube:
     """The volumetric data from a cube (or similar) file.
 

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,6 @@ setup(
         'Intended Audience :: Science/Research',
     ],
     setup_requires=['numpy>=1.0'],
-    install_requires=['numpy>=1.0', 'scipy', 'attrs>=19.1.0',
+    install_requires=['numpy>=1.0', 'scipy', 'attrs>=20.1.0',
                       'importlib_resources; python_version < "3.7"'],
 )

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -20,7 +20,7 @@ requirements:
   run:
     - python
     - scipy
-    - attrs >=19.1.0
+    - attrs >=20.1.0
     - importlib_resources  # [py<37]
 
 test:


### PR DESCRIPTION
Fixes #201 amongst other things:
- Improved attribute validation, both in constructor and upon attribute assignment (requires latest attrs version).
- `attrutil` module to facilitate writing validators.
- Fixed bug in CP2K loader.
- Document attr behavior in `CONTRIBUTING.rst`
- Few other fixes needed to satisfy validators.