### PR TITLE
Add 'atffparams' as guaranteed attribute from PDB

### DIFF
--- a/iodata/formats/pdb.py
+++ b/iodata/formats/pdb.py
@@ -41,7 +41,7 @@ __all__ = []
 PATTERNS = ['*.pdb']
 
 
-@document_load_one("PDB", ['atcoords', 'atnums', 'extra'], ['title'])
+@document_load_one("PDB", ['atcoords', 'atnums', 'atffparams', 'extra'], ['title'])
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     nums = []


### PR DESCRIPTION
Small fix: The 'atffparams' wasn't added as a guaranteed returned value of `load_one` in PDB, so I just added it.