### PR TITLE
Add contents table for supported file type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ iodata/overlap_accel.c
 doc/_build
 doc/pyapi
 doc/formats.rst
+doc/formats_tab.inc
 
 # Distribution / packaging
 .Python

--- a/doc/_static/css/override.css
+++ b/doc/_static/css/override.css
@@ -39,5 +39,5 @@ table.docutils tbody tr.row-odd td {
 }
 
 div.wy-table-responsive {
-    max-height: 600px;
+    max-height: 90vh;
 }

--- a/doc/_static/css/override.css
+++ b/doc/_static/css/override.css
@@ -1,0 +1,48 @@
+/** css/override.css **/
+
+
+/* This line is theme specific - it includes the base theme CSS */
+@import 'theme.css';       /* for the Read the Docs theme */
+
+table.docutils {
+    border-collapse: separate !important;
+}
+
+th.head {
+    position: sticky;
+    top: 0px;
+    z-index: 2;
+    background-color: white;
+    border-bottom-color: black !important;
+}
+
+th.head:nth-child(1) {
+    position: sticky;
+    top: 0px;
+    left: 0px;
+    z-index: 3;
+    background-color: white;
+    border-right-color: black !important;
+}
+
+td:nth-child(1) {
+    position: sticky;
+    left: 0px;
+    z-index: 1;
+    border-right-color: black !important;
+    border-right-width: 1px;
+    border-right-style: solid;
+}
+
+table.docutils tbody tr.row-odd td {
+    background-color: rgb(252, 252, 252);
+}
+
+div.wy-table-responsive {
+    max-height: 600px;
+}
+
+/*
+td {z-index: 0}*/
+
+

--- a/doc/_static/css/override.css
+++ b/doc/_static/css/override.css
@@ -41,8 +41,3 @@ table.docutils tbody tr.row-odd td {
 div.wy-table-responsive {
     max-height: 600px;
 }
-
-/*
-td {z-index: 0}*/
-
-

--- a/doc/acknowledgments.rst
+++ b/doc/acknowledgments.rst
@@ -1,0 +1,32 @@
+..
+    : IODATA is an input and output module for quantum chemistry.
+    :
+    : Copyright (C) 2011-2019 The IODATA Development Team
+    :
+    : This file is part of IODATA.
+    :
+    : IODATA is free software; you can redistribute it and/or
+    : modify it under the terms of the GNU General Public License
+    : as published by the Free Software Foundation; either version 3
+    : of the License, or (at your option) any later version.
+    :
+    : IODATA is distributed in the hope that it will be useful,
+    : but WITHOUT ANY WARRANTY; without even the implied warranty of
+    : MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    : GNU General Public License for more details.
+    :
+    : You should have received a copy of the GNU General Public License
+    : along with this program; if not, see <http://www.gnu.org/licenses/>
+    :
+    : --
+
+Acknowledgments
+===============
+
+This software was developed using funding from a variety of international
+sources including, but not limited to: Canarie, Canada Research Chairs,
+Compute Canada, European Union's Horizon 2020 Marie Sklodowska-Curie Actions (Individual
+Fellowship No 800130), Foundation of Scientific Research--Flanders (FWO), McMaster
+University, Queen's University, Natural Sciences and Engineering Research Council of
+Canada (NSERC), National Fund for Scientific and Technological Development of
+Chile (FONDECYT), Research Board of Ghent University (BOF), and Compute Canada.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -134,6 +134,7 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
+html_style = 'css/override.css'
 
 
 # -- Options for HTMLHelp output ------------------------------------------

--- a/doc/gen_docs.sh
+++ b/doc/gen_docs.sh
@@ -3,3 +3,4 @@
 SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,inherited-members sphinx-apidoc -o pyapi/ ../iodata/ ../iodata/test/test_*.py ../iodata/test/cached --separate
 
 ./gen_formats.py > formats.rst
+./gen_formats_tab.py

--- a/doc/gen_docs.sh
+++ b/doc/gen_docs.sh
@@ -3,4 +3,4 @@
 SPHINX_APIDOC_OPTIONS=members,undoc-members,show-inheritance,inherited-members sphinx-apidoc -o pyapi/ ../iodata/ ../iodata/test/test_*.py ../iodata/test/cached --separate
 
 ./gen_formats.py > formats.rst
-./gen_formats_tab.py
+./gen_formats_tab.py > formats_tab.inc

--- a/doc/gen_formats.py
+++ b/doc/gen_formats.py
@@ -61,8 +61,10 @@ def main():
                 break
         if skip:
             continue
-
         lines = module.__doc__.split('\n')
+        # add labels for cross-referencing format (e.g. in formats table)
+        print(f".. _format_{modname}:")
+        print()
         _print_section('{} (``{}``)'.format(lines[0][:-1], modname), "=")
         print()
         for line in lines[2:]:

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+# pylint: disable=unused-argument,redefined-builtin
+"""Generate formats.rst."""
+from collections import defaultdict
+import inspect
+import importlib
+
+import iodata
+
+
+__all__ = (write_rst_table, generate_table_rst)
+
+
+def _generate_all_format_parser():
+    """Parse supported functionality from each module.
+
+    Returns
+    -------
+    tuple(dict, dict)
+        dict{format_name: index}
+        dict{proper_name: formats_name_supported}
+    """
+    # inspect iodata format module
+    # obtaining a list of tuble [(module_name: str, module_object: obj)]
+    format_modules = inspect.getmembers(iodata.formats, inspect.ismodule)
+
+    fmt_names = {}  # storing supported format name and index(position) in table
+    prop_with_mods = defaultdict(list)  # storing methods with format supporting it.
+    for fmt_name, _ in format_modules:
+        # inspect(import) target module
+        fmt_module = importlib.import_module("iodata.formats." + fmt_name)
+        # add new format name to fmt_names
+        if fmt_name not in fmt_names:
+            fmt_names[fmt_name] = len(fmt_names) + 1
+        # obtaining supported properties
+        fields = fmt_module.load_one.guaranteed
+        for i in fields:
+            # add format to its supported property list
+            prop_with_mods[i].append(fmt_name)
+    return fmt_names, prop_with_mods
+
+
+def generate_table_rst():
+    """Construct table contents.
+
+    Returns
+    -------
+    list[list[]]
+        table with rows of each property and columns of each format
+    """
+    table = []
+    methods_names, prop_with_mods = _generate_all_format_parser()
+    # construct header
+    header = ["Properties"] + list(methods_names.keys())
+    table.append(header)
+    for prop in sorted(prop_with_mods.keys()):
+        # construct each row contents
+        row = [prop] + ["--"] * len(methods_names)
+        for method in prop_with_mods[prop]:
+            row[methods_names[method]] = u"\u2713"
+        table.append(row)
+    return table
+
+
+def write_rst_table(f, table, nhead=1):
+    """Write an RST table to file f.
+
+    Parameters
+    ----------
+    f : file object
+        A writable file object
+    table : list[list[]]
+        A list of rows. Each row must be a list of cells containing strings
+    nhead : int, optional
+        The number of header rows
+    """
+
+    def format_cell(cell):
+        if cell is None or len(cell.strip()) == 0:
+            return "\\ "
+        return str(cell)
+
+    # Determine the width of each column
+    widths = {}
+    for row in table:
+        for icell, cell in enumerate(row):
+            widths[icell] = max(widths.get(icell, 2), len(format_cell(cell)))
+
+    def format_row(cells, margin):
+        return " ".join(
+            margin + format_cell(cell).rjust(widths[icell]) + margin
+            for icell, cell in enumerate(cells)
+        )
+
+    # construct the column markers
+    markers = format_row(["=" * widths[icell] for icell in range(len(widths))], "=")
+
+    # top markers
+    print(markers, file=f)
+
+    # heading rows (if any)
+    for irow in range(nhead):
+        print(format_row(table[irow], " "), file=f)
+    if nhead > 0:
+        print(markers, file=f)
+
+    # table body
+    for irow in range(nhead, len(table)):
+        print(format_row(table[irow], " "), file=f)
+
+    # bottom markers
+    print(markers, file=f)
+
+
+content_table = generate_table_rst()
+with open("format_tab.inc", "w") as inc_file:
+    write_rst_table(
+        inc_file, content_table,
+    )

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -56,10 +56,9 @@ def _generate_all_format_parser():
         if fmt_name not in fmt_names:
             fmt_names[fmt_name] = len(fmt_names) + 1
         # obtaining supported properties
-        fields = fmt_module.load_one.guaranteed
-        for i in fields:
+        for attribute in fmt_module.load_one.guaranteed:
             # add format to its supported property list
-            prop_guaranteed[i].append(fmt_name)
+            prop_guaranteed[attribute].append(fmt_name)
         for attribute in fmt_module.load_one.ifpresent:
             prop_ifpresent[attribute].append(fmt_name)
     return fmt_names, prop_guaranteed, prop_ifpresent

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -85,8 +85,8 @@ def generate_table_rst():
     # order columns based on number of guaranteed and ifpresent entries for each format
     cols = []
     for fmt_names in fmt_names:
-        count = sum([1 for value in prop_guaranteed.values() if fmt_names in value])
-        count += sum([1 for value in prop_ifpresent.values() if fmt_names in value])
+        count = sum((fmt_names in value) for value in prop_guaranteed.values())
+        count += sum((fmt_names in value) for value in prop_ifpresent.values())
         cols.append((count, fmt_names))
     cols = [item[1] for item in sorted(cols)[::-1]]
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -84,7 +84,7 @@ def generate_table_rst():
 
     # order columns based on number of guaranteed and ifpresent entries for each format
     cols = []
-    for fmt in methods_names.keys():
+    for fmt in methods_names:
         count = sum([1 for value in prop_with_mods.values() if fmt in value])
         count += sum([1 for value in prop_ifpresent.values() if fmt in value])
         cols.append((count, fmt))

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -96,9 +96,20 @@ def generate_table_rst():
     # construct header with cross-referencing columns
     header = ["Properties"] + [f':ref:`{col} <format_{col}>`' for col in cols]
     table.append(header)
+    # attributes of IOData that have property type are going to be marked as always present,
+    # because they are derived from other attributes. However, this is not true for 'fcidump'
+    # and 'gaussianlog' formats (because they do not load information which is used to derive
+    # these property attributes), so we manually exclude these at the moment.
+    temp_index = [cols.index(fmt) for fmt in ['fcidump', 'gaussianlog']]
     for prop in rows:
-        # construct each row contents
-        row = [prop] + ["--"] * len(cols)
+        # construct default row entries
+        row = ["--"] * len(cols)
+        # set property attributes as always present expect for 'fcidump' & 'gaussianlog'
+        if isinstance(getattr(iodata.IOData, prop), property):
+            row = [item if index in temp_index else u"\u2713" for index, item in enumerate(row)]
+        # add attribute name as the first item on the row
+        row.insert(0, prop)
+        # check whether attribute is guaranteed or ifpresent for a format
         for fmt in prop_guaranteed[prop]:
             row[cols.index(fmt) + 1] = u"\u2713"
         for fmt in prop_ifpresent[prop]:

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -26,9 +26,6 @@ import importlib
 import iodata
 
 
-__all__ = (write_rst_table, generate_table_rst)
-
-
 def _generate_all_format_parser():
     """Parse supported functionality from each module.
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -19,11 +19,15 @@
 # --
 # pylint: disable=unused-argument,redefined-builtin
 """Generate formats.rst."""
+
 from collections import defaultdict
 import inspect
 import importlib
 
 import iodata
+
+
+__all__ = []
 
 
 def _generate_all_format_parser():

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -168,8 +168,9 @@ def write_rst_table(f, table, nhead=1):
     print(markers, file=f)
 
 
-content_table = generate_table_rst()
-with open("formats_tab.inc", "w") as inc_file:
-    write_rst_table(
-        inc_file, content_table,
-    )
+if __name__ == "__main__":
+    content_table = generate_table_rst()
+    with open("formats_tab.inc", "w") as inc_file:
+        write_rst_table(
+            inc_file, content_table,
+        )

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -72,16 +72,28 @@ def generate_table_rst():
     """
     table = []
     methods_names, prop_with_mods, prop_ifpresent = _generate_all_format_parser()
+    # order rows based on number of formats having that attribute
+    rows = [(len(v + prop_ifpresent.get(k, [])), k) for k, v in prop_with_mods.items()]
+    # add properties that only exist in prop_ifpresent
+    rows.extend([(len(v), k) for k, v in prop_ifpresent.items() if k not in prop_with_mods.keys()])
+    rows = [item[1] for item in sorted(rows)[::-1]]
+    # order columns based on number of guaranteed and ifpresent entries for each format
+    cols = []
+    for fmt in methods_names.keys():
+        count = sum([1 for value in prop_with_mods.values() if fmt in value])
+        count += sum([1 for value in prop_ifpresent.values() if fmt in value])
+        cols.append((count, fmt))
+    cols = [item[1] for item in sorted(cols)[::-1]]
     # construct header
-    header = ["Properties"] + list(methods_names.keys())
+    header = ["Properties"] + cols
     table.append(header)
-    for prop in sorted(prop_with_mods.keys()):
+    for prop in rows:
         # construct each row contents
-        row = [prop] + ["--"] * len(methods_names)
-        for method in prop_with_mods[prop]:
-            row[methods_names[method]] = u"\u2713"
-        for method in prop_ifpresent[prop]:
-            row[methods_names[method]] = 'm'
+        row = [prop] + ["--"] * len(cols)
+        for fmt in prop_with_mods[prop]:
+            row[cols.index(fmt) + 1] = u"\u2713"
+        for fmt in prop_ifpresent[prop]:
+            row[cols.index(fmt) + 1] = 'm'
         table.append(row)
     return table
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -86,8 +86,7 @@ def generate_table_rst():
     cols = [item[1] for item in sorted(cols)[::-1]]
 
     # construct header with cross-referencing columns
-    header = ["Properties"] + [f':ref:`{col} <format_{col}>`' for col in cols]
-    table.append(header)
+    table = [["Properties"] + [f':ref:`{col} <format_{col}>`' for col in cols]]
     # attributes of IOData that have property type are going to be marked as always present,
     # because they are derived from other attributes. However, this is not true for 'fcidump'
     # and 'gaussianlog' formats (because they do not load information which is used to derive

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -41,6 +41,7 @@ def _generate_all_format_parser():
 
     fmt_names = {}  # storing supported format name and index(position) in table
     prop_with_mods = defaultdict(list)  # storing methods with format supporting it.
+    prop_ifpresent = defaultdict(list)
     for fmt_name, _ in format_modules:
         # inspect(import) target module
         fmt_module = importlib.import_module("iodata.formats." + fmt_name)
@@ -52,7 +53,9 @@ def _generate_all_format_parser():
         for i in fields:
             # add format to its supported property list
             prop_with_mods[i].append(fmt_name)
-    return fmt_names, prop_with_mods
+        for attribute in fmt_module.load_one.ifpresent:
+            prop_ifpresent[attribute].append(fmt_name)
+    return fmt_names, prop_with_mods, prop_ifpresent
 
 
 def generate_table_rst():
@@ -64,7 +67,7 @@ def generate_table_rst():
         table with rows of each property and columns of each format
     """
     table = []
-    methods_names, prop_with_mods = _generate_all_format_parser()
+    methods_names, prop_with_mods, prop_ifpresent = _generate_all_format_parser()
     # construct header
     header = ["Properties"] + list(methods_names.keys())
     table.append(header)
@@ -73,6 +76,8 @@ def generate_table_rst():
         row = [prop] + ["--"] * len(methods_names)
         for method in prop_with_mods[prop]:
             row[methods_names[method]] = u"\u2713"
+        for method in prop_ifpresent[prop]:
+            row[methods_names[method]] = 'm'
         table.append(row)
     return table
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -119,7 +119,7 @@ def generate_table_rst():
     for attr_name in rows:
         # If an attribute is a property, we mark it as "d" for "derived from
         # other attributes if possible".
-        row = [attr_name]
+        row = [f":py:attr:`{attr_name} <iodata.iodata.IOData.{attr_name}>`"]
         if isinstance(getattr(iodata.IOData, attr_name), property):
             row[0] += " *(d)*"
         # Loop over formats and set flags

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -73,14 +73,9 @@ def generate_table_rst():
     table = []
     fmt_names, prop_guaranteed, prop_ifpresent = _generate_all_format_parser()
 
-    # order rows based on number of formats having that attribute
-    rows = [(len(v + prop_ifpresent.get(k, [])), k) for k, v in prop_guaranteed.items()]
-    # add properties that only exist in prop_ifpresent
-    rows.extend([(len(v), k) for k, v in prop_ifpresent.items() if k not in prop_guaranteed.keys()])
-    rows = [item[1] for item in sorted(rows)[::-1]]
-    # add properties that exist in IOData attribute list, but not load by any of current formats
-    extra = [item for item in dir(iodata.IOData) if not item.startswith('_') and item not in rows]
-    rows.extend(extra)
+    # Sort rows by number of times the attribute is used in decreasing order.
+    rows = [name for name in dir(iodata.IOData) if not name.startswith('_')]
+    rows.sort(key=(lambda name: len(prop_ifpresent[name]) + len(prop_guaranteed[name])), reverse=True)
 
     # order columns based on number of guaranteed and ifpresent entries for each format
     cols = []

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -49,9 +49,7 @@ def _generate_all_format_parser():
     # store guaranteed and ifpresent attributes & corresponding formats
     prop_guaranteed = defaultdict(list)
     prop_ifpresent = defaultdict(list)
-    for fmt_name, _ in format_modules:
-        # inspect(import) target module
-        fmt_module = importlib.import_module("iodata.formats." + fmt_name)
+    for fmt_name, fmt_module in format_modules:
         # add new format name to fmt_names
         if fmt_name not in fmt_names:
             fmt_names[fmt_name] = len(fmt_names) + 1

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -94,7 +94,7 @@ def generate_table_rst():
     temp_index = [cols.index(fmt_names) for fmt_names in ['fcidump', 'gaussianlog']]
     for prop in rows:
         # construct default row entries
-        row = ["--"] * len(cols)
+        row = ["."] * len(cols)
         # set property attributes as always present expect for 'fcidump' & 'gaussianlog'
         if isinstance(getattr(iodata.IOData, prop), property):
             row = [item if index in temp_index else u"\u2713" for index, item in enumerate(row)]

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -90,17 +90,14 @@ def generate_table_rst():
 
     # construct header with cross-referencing columns
     table = [["Properties"] + [f':ref:`{col} <format_{col}>`' for col in cols]]
-    # attributes of IOData that have property type are going to be marked as always present,
-    # because they are derived from other attributes. However, this is not true for 'fcidump'
-    # and 'gaussianlog' formats (because they do not load information which is used to derive
-    # these property attributes), so we manually exclude these at the moment.
-    temp_index = [cols.index(fmt_names) for fmt_names in ['fcidump', 'gaussianlog']]
     for attr_name in rows:
-        # construct default row entries
-        row = ["."] * len(cols)
-        # set property attributes as always present expect for 'fcidump' & 'gaussianlog'
+        # If an attribute is a property, we mark it as "d" for "derived from
+        # other attributes if possible".
         if isinstance(getattr(iodata.IOData, attr_name), property):
-            row = [item if index in temp_index else u"\u2713" for index, item in enumerate(row)]
+            row =  ["d"] * len(cols)
+        else:
+            # construct default row entries
+            row = ["."] * len(cols)
         # add attribute name as the first item on the row
         row.insert(0, attr_name)
         # check whether attribute is guaranteed or ifpresent for a format

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -107,7 +107,7 @@ def generate_table_rst():
     header = ["Attribute"]
     for fmt_name in cols:
         col_name = f':ref:`{fmt_name} <format_{fmt_name}>`'
-        col_name += " {}{}".format(
+        col_name += ": {}{}".format(
             "L" if fmt_name in has_load else "",
             "D" if fmt_name in has_dump else ""
         )

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -23,7 +23,6 @@
 
 from collections import defaultdict
 import inspect
-import importlib
 
 import iodata
 
@@ -85,8 +84,8 @@ def generate_table_rst():
         table with rows of each property and columns of each format
 
     """
-    table = []
-    fmt_names, has_load, guaranteed, ifpresent, has_dump, required, optional = _generate_all_format_parser()
+    fmt_names, has_load, guaranteed, ifpresent, has_dump, required, optional = \
+        _generate_all_format_parser()
 
     # Sort rows by number of times the attribute is used in decreasing order.
     rows = []
@@ -100,13 +99,13 @@ def generate_table_rst():
     # Order columns based on number of guaranteed and ifpresent entries for each format.
     # Also keep track of which format has a load_one and dump_one function.
     cols = []
-    for fmt_names in fmt_names:
-        count = sum((fmt_names in value) for value in guaranteed.values())
-        count += sum((fmt_names in value) for value in ifpresent.values())
-        cols.append((count, fmt_names))
+    for fmt_name in fmt_names:
+        count = sum((fmt_name in value) for value in guaranteed.values())
+        count += sum((fmt_name in value) for value in ifpresent.values())
+        cols.append((count, fmt_name))
     cols = [fmt_name[1] for fmt_name in sorted(cols, reverse=True)]
 
-    # construct header with cross-referencing columns
+    # Construct header with cross-referencing columns.
     header = ["Attribute"]
     for fmt_name in cols:
         col_name = f':ref:`{fmt_name} <format_{fmt_name}>`'

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -35,10 +35,12 @@ def _generate_all_format_parser():
 
     Returns
     -------
-    tuple(list, dict, dict)
+    tuple(list, set, dict, dict, set, dict, dict)
         list[fmt_name]
+        set{fmt_names_with_load_one}
         dict{attr_name: fmt_names_guaranteed}
         dict{attr_name: fmt_names_ifpresent}
+        set{fmt_names_with_dump_one}
         dict{attr_name: fmt_names_required}
         dict{attr_name: fmt_names_optional}
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -90,8 +90,8 @@ def generate_table_rst():
         cols.append((count, fmt))
     cols = [item[1] for item in sorted(cols)[::-1]]
 
-    # construct header
-    header = ["Properties"] + cols
+    # construct header with cross-referencing columns
+    header = ["Properties"] + [f':ref:`{col} <format_{col}>`' for col in cols]
     table.append(header)
     for prop in rows:
         # construct each row contents

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -88,13 +88,9 @@ def generate_table_rst():
         _generate_all_format_parser()
 
     # Sort rows by number of times the attribute is used in decreasing order.
-    rows = []
-    for attr_name in dir(iodata.IOData):
-        if not attr_name.startswith('_'):
-            count = len(ifpresent[attr_name]) + len(guaranteed[attr_name])
-            count += len(required[attr_name]) + len(required[attr_name])
-            rows.append((count, attr_name))
-    rows = [attr_name[1] for attr_name in sorted(rows, reverse=True)]
+    rows = sorted(
+        attr_name for attr_name in dir(iodata.IOData)
+        if not attr_name.startswith('_'))
 
     # Order columns based on number of guaranteed and ifpresent entries for each format.
     # Also keep track of which format has a load_one and dump_one function.

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -169,7 +169,7 @@ def write_rst_table(f, table, nhead=1):
 
 
 content_table = generate_table_rst()
-with open("format_tab.inc", "w") as inc_file:
+with open("formats_tab.inc", "w") as inc_file:
     write_rst_table(
         inc_file, content_table,
     )

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -72,11 +72,16 @@ def generate_table_rst():
     """
     table = []
     methods_names, prop_with_mods, prop_ifpresent = _generate_all_format_parser()
+
     # order rows based on number of formats having that attribute
     rows = [(len(v + prop_ifpresent.get(k, [])), k) for k, v in prop_with_mods.items()]
     # add properties that only exist in prop_ifpresent
     rows.extend([(len(v), k) for k, v in prop_ifpresent.items() if k not in prop_with_mods.keys()])
     rows = [item[1] for item in sorted(rows)[::-1]]
+    # add properties that exist in IOData attribute list, but not load by any of current formats
+    extra = [item for item in dir(iodata.IOData) if not item.startswith('_') and item not in rows]
+    rows.extend(extra)
+
     # order columns based on number of guaranteed and ifpresent entries for each format
     cols = []
     for fmt in methods_names.keys():
@@ -84,6 +89,7 @@ def generate_table_rst():
         count += sum([1 for value in prop_ifpresent.values() if fmt in value])
         cols.append((count, fmt))
     cols = [item[1] for item in sorted(cols)[::-1]]
+
     # construct header
     header = ["Properties"] + cols
     table.append(header)

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -54,11 +54,11 @@ def _generate_all_format_parser():
         if fmt_name not in fmt_names:
             fmt_names.append(fmt_name)
         # obtaining supported properties
-        for attribute in fmt_module.load_one.guaranteed:
+        for attrname in fmt_module.load_one.guaranteed:
             # add format to its supported property list
-            prop_guaranteed[attribute].append(fmt_name)
-        for attribute in fmt_module.load_one.ifpresent:
-            prop_ifpresent[attribute].append(fmt_name)
+            prop_guaranteed[attrname].append(fmt_name)
+        for attrname in fmt_module.load_one.ifpresent:
+            prop_ifpresent[attrname].append(fmt_name)
     return fmt_names, prop_guaranteed, prop_ifpresent
 
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -118,7 +118,7 @@ def generate_table_rst():
     return table
 
 
-def write_rst_table(f, table, nhead=1):
+def print_rst_table(table, nhead=1):
     """Write an RST table to file f.
 
     Parameters
@@ -152,25 +152,22 @@ def write_rst_table(f, table, nhead=1):
     markers = format_row(["=" * widths[icell] for icell in range(len(widths))], "=")
 
     # top markers
-    print(markers, file=f)
+    print(markers)
 
     # heading rows (if any)
     for irow in range(nhead):
-        print(format_row(table[irow], " "), file=f)
+        print(format_row(table[irow], " "))
     if nhead > 0:
-        print(markers, file=f)
+        print(markers)
 
     # table body
     for irow in range(nhead, len(table)):
-        print(format_row(table[irow], " "), file=f)
+        print(format_row(table[irow], " "))
 
     # bottom markers
-    print(markers, file=f)
+    print(markers)
 
 
 if __name__ == "__main__":
     content_table = generate_table_rst()
-    with open("formats_tab.inc", "w") as inc_file:
-        write_rst_table(
-            inc_file, content_table,
-        )
+    print_rst_table(content_table)

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -73,7 +73,7 @@ def generate_table_rst():
         table with rows of each property and columns of each format
     """
     table = []
-    methods_names, prop_guaranteed, prop_ifpresent = _generate_all_format_parser()
+    fmt_names, prop_guaranteed, prop_ifpresent = _generate_all_format_parser()
 
     # order rows based on number of formats having that attribute
     rows = [(len(v + prop_ifpresent.get(k, [])), k) for k, v in prop_guaranteed.items()]
@@ -86,10 +86,10 @@ def generate_table_rst():
 
     # order columns based on number of guaranteed and ifpresent entries for each format
     cols = []
-    for fmt in methods_names:
-        count = sum([1 for value in prop_guaranteed.values() if fmt in value])
-        count += sum([1 for value in prop_ifpresent.values() if fmt in value])
-        cols.append((count, fmt))
+    for fmt_names in fmt_names:
+        count = sum([1 for value in prop_guaranteed.values() if fmt_names in value])
+        count += sum([1 for value in prop_ifpresent.values() if fmt_names in value])
+        cols.append((count, fmt_names))
     cols = [item[1] for item in sorted(cols)[::-1]]
 
     # construct header with cross-referencing columns
@@ -99,7 +99,7 @@ def generate_table_rst():
     # because they are derived from other attributes. However, this is not true for 'fcidump'
     # and 'gaussianlog' formats (because they do not load information which is used to derive
     # these property attributes), so we manually exclude these at the moment.
-    temp_index = [cols.index(fmt) for fmt in ['fcidump', 'gaussianlog']]
+    temp_index = [cols.index(fmt_names) for fmt_names in ['fcidump', 'gaussianlog']]
     for prop in rows:
         # construct default row entries
         row = ["--"] * len(cols)
@@ -109,10 +109,10 @@ def generate_table_rst():
         # add attribute name as the first item on the row
         row.insert(0, prop)
         # check whether attribute is guaranteed or ifpresent for a format
-        for fmt in prop_guaranteed[prop]:
-            row[cols.index(fmt) + 1] = u"\u2713"
-        for fmt in prop_ifpresent[prop]:
-            row[cols.index(fmt) + 1] = 'm'
+        for fmt_names in prop_guaranteed[prop]:
+            row[cols.index(fmt_names) + 1] = u"\u2713"
+        for fmt_names in prop_ifpresent[prop]:
+            row[cols.index(fmt_names) + 1] = 'm'
         table.append(row)
     return table
 

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -36,9 +36,11 @@ def _generate_all_format_parser():
 
     Returns
     -------
-    tuple(dict, dict)
-        dict{format_name: index}
-        dict{proper_name: formats_name_supported}
+    tuple(list, dict, dict)
+        list[fmt_name]
+        dict{attr_name: fmt_names_guaranteed}
+        dict{attr_name: fmt_names_ifpresent}
+
     """
     # inspect iodata format module
     # obtain a list of tuple [(module_name: str, module_object: obj)]
@@ -69,6 +71,7 @@ def generate_table_rst():
     -------
     list[list[]]
         table with rows of each property and columns of each format
+
     """
     table = []
     fmt_names, prop_guaranteed, prop_ifpresent = _generate_all_format_parser()
@@ -110,16 +113,15 @@ def generate_table_rst():
 
 
 def print_rst_table(table, nhead=1):
-    """Write an RST table to file f.
+    """Print an RST table.
 
     Parameters
     ----------
-    f : file object
-        A writable file object
     table : list[list[]]
         A list of rows. Each row must be a list of cells containing strings
     nhead : int, optional
         The number of header rows
+
     """
 
     def format_cell(cell):

--- a/doc/gen_formats_tab.py
+++ b/doc/gen_formats_tab.py
@@ -45,14 +45,14 @@ def _generate_all_format_parser():
     format_modules = inspect.getmembers(iodata.formats, inspect.ismodule)
 
     # store supported format name and index (position) in table
-    fmt_names = {}
+    fmt_names = []
     # store guaranteed and ifpresent attributes & corresponding formats
     prop_guaranteed = defaultdict(list)
     prop_ifpresent = defaultdict(list)
     for fmt_name, fmt_module in format_modules:
         # add new format name to fmt_names
         if fmt_name not in fmt_names:
-            fmt_names[fmt_name] = len(fmt_names) + 1
+            fmt_names.append(fmt_name)
         # obtaining supported properties
         for attribute in fmt_module.load_one.guaranteed:
             # add format to its supported property list

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -45,6 +45,7 @@ User Documentation
 
    install
    getting_started
+   supported_format
    formats
    basis
    changelog

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -36,9 +36,22 @@ software packages.
 
 
 For the list of file formats that can be loaded or dumped by IOData, see
-:ref:`file_formats`. The table below summarize the file formats and features supported
-by IOData XXX. Scroll to the right to see all the formats, here letter "m" stands for
-"maybe" for the information that will loaded/dumped, if present.
+:ref:`file_formats`. The two tables below summarize the file formats and
+features supported by IOData:
+
+======= ==========
+Code    Definition
+======= ==========
+**L**   loading is supported
+**D**   dumping is supported
+*(d)*   attribute may be derived from other attributes
+R       attribute is always read
+r       attribute is read if present
+W       attribute is always written
+w       attribute is is written if present
+======= ==========
+
+Scroll to the right to see all the formats.
 
 .. include:: formats_tab.inc
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -40,7 +40,7 @@ For the list of file formats that can be loaded or dumped by IOData, see
 by IOData XXX. Scroll to the write to see all the formats, here letter "m" stands for
 "maybe" for the information that will loaded/dumped, if present.
 
-.. include:: format_tab.inc
+.. include:: formats_tab.inc
 
 
 User Documentation

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -51,8 +51,6 @@ W       attribute is always written
 w       attribute is is written if present
 ======= ==========
 
-Scroll to the right to see all the formats.
-
 .. include:: formats_tab.inc
 
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,7 +37,7 @@ software packages.
 
 For the list of file formats that can be loaded or dumped by IOData, see
 :ref:`file_formats`. The table below summarize the file formats and features supported
-by IOData XXX. Scroll to the write to see all the formats, here letter "m" stands for
+by IOData XXX. Scroll to the right to see all the formats, here letter "m" stands for
 "maybe" for the information that will loaded/dumped, if present.
 
 .. include:: formats_tab.inc

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -28,14 +28,20 @@
 Welcome to IOData's documentation!
 ==================================
 
-IOData is the HORTON3 module for reading and writing different quantum chemistry formats.
+IOData is a free and open-source Python library for parsing, storing, and
+converting various file formats commonly used by quantum chemistry,
+molecular dynamics, and plane-wave density-functional-theory software programs.
+It also supports a flexible framework for generating input files for various
+software packages.
 
-Currently we support the following formats to varying degrees: **XYZ, POSCAR,
-Cube, CHGCAR, LOCPOT, Fchk, Molden, MKL, WFN, FCIDUMP, CP2K ATOM output and
-Gaussian log**. See :ref:`file_formats` for details. IOData primarily focusses
-on correctly reading in wavefunctions from these file formats, where needed also
-correcting for common errors in the Molden and Molekel formats introduced by
-various programs (ORCA, TurboMole and pre-1.0 versions of PSI4).
+
+For the list of file formats that can be loaded or dumped by IOData, see
+:ref:`file_formats`. The table below summarize the file formats and features supported
+by IOData XXX. Scroll to the write to see all the formats, here letter "m" stands for
+"maybe" for the information that will loaded/dumped, if present.
+
+.. include:: format_tab.inc
+
 
 User Documentation
 ^^^^^^^^^^^^^^^^^^
@@ -45,7 +51,6 @@ User Documentation
 
    install
    getting_started
-   supported_format
    formats
    basis
    changelog

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -37,7 +37,7 @@ software packages.
 
 For the list of file formats that can be loaded or dumped by IOData, see
 :ref:`file_formats`. The two tables below summarize the file formats and
-features supported by IOData:
+features supported by IOData.
 
 ======= ==========
 Code    Definition

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -54,6 +54,7 @@ User Documentation
    formats
    basis
    changelog
+   acknowledgments
 
 Developer Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -70,18 +71,6 @@ API Reference
    :maxdepth: 2
 
    pyapi/modules
-
-
-Acknowledgments
-===============
-
-This software was developed using funding from a variety of international
-sources including, but not limited to: Canarie, the Canada Research Chairs,
-Compute Canada, the European Union's Horizon 2020 Marie Sklodowska-Curie Actions (Individual
-Fellowship No 800130), the Foundation of Scientific Research--Flanders (FWO), McMaster
-University, the National Fund for Scientific and Technological Development of
-Chile (FONDECYT), the Natural Sciences and Engineering Research Council of
-Canada (NSERC), the Research Board of Ghent University (BOF), and Sharcnet.
 
 
 Indices and tables

--- a/doc/supported_format.rst
+++ b/doc/supported_format.rst
@@ -1,0 +1,4 @@
+Overview of Versatility
+##################################
+
+.. include:: format_tab.inc

--- a/doc/supported_format.rst
+++ b/doc/supported_format.rst
@@ -1,4 +1,0 @@
-Overview of Versatility
-##################################
-
-.. include:: format_tab.inc

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -211,7 +211,7 @@ def parse_wfx(lit: LineIterator, required_tags: list = None) -> dict:
 
 
 @document_load_one("WFX", ['atcoords', 'atgradient', 'atnums', 'energy',
-                           'exrtra', 'mo', 'obasis', 'title'])
+                           'extra', 'mo', 'obasis', 'title'])
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     # get data contained in WFX file with the proper type & shape


### PR DESCRIPTION
Enhancement: Add `gen_formats_tab.py` to generate a rst-format
table file `format_tab.inc`. This file is then included in the
new added page `supported_format.rst`
1. Add format and properties supported table
2. Add a temperary page for exhibiting the table
3. Add the autogen script to gen_docs.sh