### PR TITLE
Molecular Basis

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -176,7 +176,7 @@ class Shell:
 
     @property
     def nprim(self) -> int:  # noqa: D401
-        """Number of primitive contracted shells, also known as the contraction length."""
+        """Number of primitive, also known as the contraction length."""
         return len(self.exponents)
 
     @property

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -38,11 +38,13 @@ ANGMOM_CHARS = 'spdfghiklmnoqrtuvwxyzabce'
 
 def _alsolist(f):
     """Wrap a function to accepts also list as first argument and then return list."""
+
     @wraps(f)
     def wrapper(firsts, *args, **kwargs):
         if isinstance(firsts, (Integral, str)):
             return f(firsts, *args, **kwargs)
         return [f(first, *args, **kwargs) for first in firsts]
+
     return wrapper
 
 
@@ -129,7 +131,7 @@ class Shell:
             C_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
             r^l P^m_l(\cos(\theta)) \cos(m \phi) & m \in \{1, \cdots, l\} \\
             S_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
-            r^l P^m_l(\cos(\theta)) \sin(m \phi) & m \in \{1, \cdots, l\}    \\
+            r^l P^m_l(\cos(\theta)) \sin(m \phi) & m \in \{1, \cdots, l\}\\
         \end{align*}
 
       where :math:`P_l^m` is the associated Legrende function and :math:`N(\alpha, l)` is the
@@ -138,7 +140,7 @@ class Shell:
     - Contraction of Primitive Gaussians is the linear combination of primitive Gaussian functions
       of the same shell-type l, meant as a basis function.  It has the form
 
-	  .. math:: P(\cdots) \sum^M_m c_m  N e^{-\alpha_m r_A^2},
+      .. math:: P(\cdots) \sum^M_m c_m N e^{-\alpha_m r_A^2},
 
       where N is the normalization constant and P is either the Cartesian polynomial for a fixed
       (i, j, k) or the real regular solid harmonic for a fixed (l, m).  The degree is the number
@@ -160,7 +162,7 @@ class Shell:
     coeffs: np.ndarray = attr.ib(validator=validate_shape(("exponents", 0), ("kinds", 0)))
 
     @property
-    def nbasis(self) -> int:   # noqa: D401
+    def nbasis(self) -> int:  # noqa: D401
         """Number of basis functions (e.g. 3 for a P shell and 4 for an SP shell)."""
         result = 0
         for angmom, kind in zip(self.angmoms, self.kinds):
@@ -173,16 +175,16 @@ class Shell:
         return result
 
     @property
-    def nprim(self) -> int:   # noqa: D401
+    def nprim(self) -> int:  # noqa: D401
         """Number of primitive contracted shells, also known as the contraction length."""
         return len(self.exponents)
 
     @property
-    def ncon(self) -> int:   # noqa: D401
+    def ncon(self) -> int:  # noqa: D401
         """Number of contractions with distinct angular momentum numbers.
 
-         This is usually 1; e.g., it would be 2 for an SP shell.
-         """
+        This is usually 1; e.g., it would be 2 for an SP shell.
+        """
         return len(self.angmoms)
 
 
@@ -265,7 +267,7 @@ class MolecularBasis:
     primitive_normalization: str
 
     @property
-    def nbasis(self) -> int:   # noqa: D401
+    def nbasis(self) -> int:  # noqa: D401
         """Number of basis functions."""
         return sum(shell.nbasis for shell in self.shells)
 
@@ -328,7 +330,7 @@ class MolecularBasis:
         convert_primitive_kind : Converts primitive shells with no averaging.
 
         """
-        if to != "c" and to != "p":
+        if to not in ("c", "p"):
             raise ValueError("The to string was not recognized: %s" % to)
 
         shells = []
@@ -358,7 +360,9 @@ class MolecularBasis:
                     coeffs_new.append(coeffs)
 
             shells.append(
-                Shell(shell.icenter, shell.angmoms, kind_new, shell.exponents, np.array(coeffs_new).T)
+                Shell(
+                    shell.icenter, shell.angmoms, kind_new, shell.exponents, np.array(coeffs_new).T
+                )
             )
         # pylint: disable=no-member
         return attr.evolve(self, shells=shells)
@@ -366,7 +370,7 @@ class MolecularBasis:
 
 def convert_primitive_kind(angmom: int, kind: str, coeffs: np.ndarray, to: str) -> np.ndarray:
     r"""
-    Converts coefficients in Cartesian to Pure or vice-versa of a Primitive shell.
+    Convert coefficients in Cartesian to Pure or vice-versa of a Primitive shell.
 
     Parameters
     ----------
@@ -407,9 +411,9 @@ def convert_primitive_kind(angmom: int, kind: str, coeffs: np.ndarray, to: str) 
     >> new_coeffs = convert_primitive_kind(1, "c", coeff, "p")
 
     """
-    if to != "c" and to != "p":
+    if to not in ("p", "c"):
         raise ValueError("The to string was not recognized: %s" % to)
-    if kind != "c" and kind != "p":
+    if kind not in ("p", "c"):
         raise ValueError("The kind string was not recognized: %s" % kind)
     if to != kind:
         if kind == "c":

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -176,7 +176,7 @@ class Shell:
 
     @property
     def nprim(self) -> int:  # noqa: D401
-        """Number of primitive, also known as the contraction length."""
+        """Number of primitives in the contracted shells, also known as the contraction length"""
         return len(self.exponents)
 
     @property

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -211,6 +211,24 @@ class MolecularBasis:
         # pylint: disable=no-member
         return attr.evolve(self, shells=shells)
 
+    def get_decontracted(self):
+        r"""
+        Get Decontracted Molecular Basis from a Molecular Basis.
+
+        Decontracted Molecular basis is a Molecular basis where each contracted shell is a
+        primitive contracted shell (ie contracted shell with only one exponent and one kind).
+
+        """
+        shells = []
+        for shell in self.shells:
+            for i, (angmom, kind) in enumerate(zip(shell.angmoms, shell.kinds)):
+                for exponent, coeff in zip(shell.exponents, shell.coeffs[:, i]):
+                    shells.append(
+                        Shell(shell.icenter, [angmom], [kind], np.array([exponent]),
+                              coeff.reshape(-1, 1))
+                    )
+        # pylint: disable=no-member
+        return self._replace(shells=shells)
 
 def convert_convention_shell(conv1: List[str], conv2: List[str], reverse=False) \
         -> Tuple[np.ndarray, np.ndarray]:

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -189,7 +189,7 @@ class Shell:
 @attr.s(auto_attribs=True, slots=True,
         on_setattr=[attr.setters.validate, attr.setters.convert])
 class MolecularBasis:
-    """A complete molecular orbital or density basis set.
+    """A complete molecular orbital or density basis set as a collection of contracted shells.
 
     Attributes
     ----------
@@ -234,6 +234,30 @@ class MolecularBasis:
         The normalization convention of primitives, which can be 'L2' (orbitals) or 'L1'
         (densities) normalized.
 
+    Methods
+    -------
+    get_segmented
+        Return molecular basis object that is segmented.
+    get_decontracted
+        Return molecular basis object that is decontracted.
+    convert_kind
+        Return molecular basis object whose kinds are the same type.
+
+    Notes
+    -----
+    - Primitive Contracted Shell with exponent :math:`\alpha`:
+      Set of all contractions in a contracted shell that have the exponent :math:`\alpha`.
+      Since there is a single exponent, then the degree of these contractions is one.
+
+    - Segmented Molecular Basis:
+      Molecular basis where each contracted shell has contractions that all correspond to the
+      same total angular momentum number.  There could only be the same shell-type inside a
+      contracted shell.  There could only be one kind of shell-type inside a contracted shell.
+
+    - Decontracted Molecular Basis:
+      Segmented molecular basis where each contracted shell is a primitive contracted shell with
+      its single exponent.
+
     """
 
     shells: List[Shell]
@@ -246,7 +270,11 @@ class MolecularBasis:
         return sum(shell.nbasis for shell in self.shells)
 
     def get_segmented(self):
-        """Unroll generalized contractions."""
+        """Convert Generalized Molecular Basis to Segmented Molecular Basis.
+
+        Segmented Molecular basis is a Molecular basis where all contracted shell in it share
+        a specific total angular momentum number.
+        """
         shells = []
         for shell in self.shells:
             for angmom, kind, coeffs in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
@@ -257,7 +285,7 @@ class MolecularBasis:
 
     def get_decontracted(self):
         r"""
-        Get Decontracted Molecular Basis from a Molecular Basis.
+        Convert to Decontracted Molecular Basis from a Molecular Basis.
 
         Decontracted Molecular basis is a Molecular basis where each contracted shell is a
         primitive contracted shell (ie contracted shell with only one exponent and one kind).
@@ -297,7 +325,7 @@ class MolecularBasis:
 
         See Also
         --------
-        convert_primitive_kind : Converts individual groups of primitive shells.
+        convert_primitive_kind : Converts primitive shells with no averaging.
 
         """
         if to != "c" and to != "p":

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -229,7 +229,7 @@ class MolecularBasis:
                               coeff.reshape(-1, 1))
                     )
         # pylint: disable=no-member
-        return self._replace(shells=shells)
+        return attr.evolve(self, shells=shells)
 
     def convert_kind(self, to: str):
         r"""
@@ -287,10 +287,10 @@ class MolecularBasis:
                     coeffs_new.append(coeffs)
 
             shells.append(
-                Shell(shell.icenter, angmom, kind_new, shell.exponents, np.array(coeffs_new).T)
+                Shell(shell.icenter, shell.angmoms, kind_new, shell.exponents, np.array(coeffs_new).T)
             )
         # pylint: disable=no-member
-        return self._replace(shells=shells)
+        return attr.evolve(self, shells=shells)
 
 
 def convert_primitive_kind(angmom: int, kind: str, coeffs: np.ndarray, to: str) -> np.ndarray:

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -116,42 +116,7 @@ class Shell:
 
     Notes
     -----
-    Following definitions assumes all functions are centered at A specified by attribute `icenter`.
-
-    - Cartesian Primitive Gaussian function for a given numbers (i, j, k) and exponent
-      :math:`\alpha`:
-
-      .. math:: N() x_A^i y_A^j z_A^k e^{-\alpha_i r^2}
-
-    - Pure Primitive Gaussian functions for a given integers (l, m) and exponent :math:`\alpha`:
-
-      .. math:: N(\alpha, l) P(r, \theta, \phi) e^{-\alpha_i r^2}
-         \begin{align*}
-            C_{0m}(r, \theta, \phi) &:= r^l P^0_{l}(\cos(\theta)) & m = 0\\
-            C_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
-            r^l P^m_l(\cos(\theta)) \cos(m \phi) & m \in \{1, \cdots, l\} \\
-            S_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
-            r^l P^m_l(\cos(\theta)) \sin(m \phi) & m \in \{1, \cdots, l\}\\
-        \end{align*}
-
-      where :math:`P_l^m` is the associated Legrende function and :math:`N(\alpha, l)` is the
-      normalization constant.
-
-    - Contraction of Primitive Gaussians is the linear combination of primitive Gaussian functions
-      of the same shell-type l, meant as a basis function.  It has the form
-
-      .. math:: P(\cdots) \sum^M_m c_m N e^{-\alpha_m r_A^2},
-
-      where N is the normalization constant and P is either the Cartesian polynomial for a fixed
-      (i, j, k) or the real regular solid harmonic for a fixed (l, m).  The degree is the number
-      of primitive used.
-
-    - Contracted Shell with exponents :math:`(\alpha_1, \cdots, \alpha_{M})` is the set of all
-      contractions whose primitives have the exponents
-      :math:`(\alpha_1, \cdots, \alpha_{M})` in that order.
-
-    - Primitive contracted shell with exponent :math:`\alpha` is the set of all contractions
-      in a contracted shell that have the exponent :math:`\alpha`.
+    Basis set conventions and terminology are documented in :ref:`basis_conventions`.
 
     """
 
@@ -247,18 +212,7 @@ class MolecularBasis:
 
     Notes
     -----
-    - Primitive Contracted Shell with exponent :math:`\alpha`:
-      Set of all contractions in a contracted shell that have the exponent :math:`\alpha`.
-      Since there is a single exponent, then the degree of these contractions is one.
-
-    - Segmented Molecular Basis:
-      Molecular basis where each contracted shell has contractions that all correspond to the
-      same total angular momentum number.  There could only be the same shell-type inside a
-      contracted shell.  There could only be one kind of shell-type inside a contracted shell.
-
-    - Decontracted Molecular Basis:
-      Segmented molecular basis where each contracted shell is a primitive contracted shell with
-      its single exponent.
+    Basis set conventions and terminology are documented in :ref:`basis_conventions`.
 
     """
 
@@ -272,11 +226,7 @@ class MolecularBasis:
         return sum(shell.nbasis for shell in self.shells)
 
     def get_segmented(self):
-        """Convert Generalized Molecular Basis to Segmented Molecular Basis.
-
-        Segmented Molecular basis is a Molecular basis where all contracted shell in it share
-        a specific total angular momentum number.
-        """
+        """Convert Generalized Molecular Basis to Segmented Molecular Basis."""
         shells = []
         for shell in self.shells:
             for angmom, kind, coeffs in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
@@ -286,13 +236,7 @@ class MolecularBasis:
         return attr.evolve(self, shells=shells)
 
     def get_decontracted(self):
-        r"""
-        Convert to Decontracted Molecular Basis from a Molecular Basis.
-
-        Decontracted Molecular basis is a Molecular basis where each contracted shell is a
-        primitive contracted shell (ie contracted shell with only one exponent and one kind).
-
-        """
+        r"""Convert to Decontracted Molecular Basis from a Molecular Basis."""
         shells = []
         for shell in self.shells:
             for i, (angmom, kind) in enumerate(zip(shell.angmoms, shell.kinds)):
@@ -327,7 +271,7 @@ class MolecularBasis:
 
         See Also
         --------
-        convert_primitive_kind : Converts primitive shells with no averaging.
+        convert_primitive_kind : Converts primitive shells without averaging.
 
         """
         if to not in ("c", "p"):

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -89,7 +89,7 @@ def angmom_its(angmom: Union[int, List[int]]) -> Union[str, List[str]]:
 @attr.s(auto_attribs=True, slots=True,
         on_setattr=[attr.setters.validate, attr.setters.convert])
 class Shell:
-    """A shell in a molecular basis representing (generalized) contractions with the same exponents.
+    """Contracted shell representing (generalized) contractions with the same exponents.
 
     Attributes
     ----------
@@ -103,13 +103,53 @@ class Shell:
         and 'p' for pure. Pure functions are only allowed for angmom>1.
         The length equals the number of contractions: len(angmoms)=ncon.
     exponents
-        The array containing the exponents of the primitives, with shape (nprim,).
+        The array containing the exponents of the primitives, with shape (nprim,),
+        where nprim is the number of primitive contracted shells.
     coeffs
         The array containing the coefficients of the normalized primitives in each contraction;
         shape = (nprim, ncon).
         These coefficients assume that the primitives are L2 (orbitals) or L1
         (densities) normalized, but contractions are not necessarily normalized.
         (This depends on the code which generated the contractions.)
+
+    Notes
+    -----
+    Following definitions assumes all functions are centered at A specified by attribute `icenter`.
+
+    - Cartesian Primitive Gaussian function for a given numbers (i, j, k) and exponent
+      :math:`\alpha`:
+
+      .. math:: N() x_A^i y_A^j z_A^k e^{-\alpha_i r^2}
+
+    - Pure Primitive Gaussian functions for a given integers (l, m) and exponent :math:`\alpha`:
+
+      .. math:: N(\alpha, l) P(r, \theta, \phi) e^{-\alpha_i r^2}
+         \begin{align*}
+            C_{0m}(r, \theta, \phi) &:= r^l P^0_{l}(\cos(\theta)) & m = 0\\
+            C_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
+            r^l P^m_l(\cos(\theta)) \cos(m \phi) & m \in \{1, \cdots, l\} \\
+            S_{lm}(r, \theta, \phi) &:= \sqrt{2} (-1)^m \sqrt{\frac{(l - m)!}{(l + m)!}}
+            r^l P^m_l(\cos(\theta)) \sin(m \phi) & m \in \{1, \cdots, l\}    \\
+        \end{align*}
+
+      where :math:`P_l^m` is the associated Legrende function and :math:`N(\alpha, l)` is the
+      normalization constant.
+
+    - Contraction of Primitive Gaussians is the linear combination of primitive Gaussian functions
+      of the same shell-type l, meant as a basis function.  It has the form
+
+	  .. math:: P(\cdots) \sum^M_m c_m  N e^{-\alpha_m r_A^2},
+
+      where N is the normalization constant and P is either the Cartesian polynomial for a fixed
+      (i, j, k) or the real regular solid harmonic for a fixed (l, m).  The degree is the number
+      of primitive used.
+
+    - Contracted Shell with exponents :math:`(\alpha_1, \cdots, \alpha_{M})` is the set of all
+      contractions whose primitives have the exponents
+      :math:`(\alpha_1, \cdots, \alpha_{M})` in that order.
+
+    - Primitive contracted shell with exponent :math:`\alpha` is the set of all contractions
+      in a contracted shell that have the exponent :math:`\alpha`.
 
     """
 
@@ -134,12 +174,15 @@ class Shell:
 
     @property
     def nprim(self) -> int:   # noqa: D401
-        """Number of primitives, also known as the contraction length."""
+        """Number of primitive contracted shells, also known as the contraction length."""
         return len(self.exponents)
 
     @property
     def ncon(self) -> int:   # noqa: D401
-        """Number of contractions. This is usually 1; e.g., it would be 2 for an SP shell."""
+        """Number of contractions with distinct angular momentum numbers.
+
+         This is usually 1; e.g., it would be 2 for an SP shell.
+         """
         return len(self.angmoms)
 
 

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -235,9 +235,6 @@ def convert_vector_basis(
     r"""
     Convert a vector from basis 1 of size M to another basis 2 of size N.
 
-    Basis vectors are defined to be linearly independent wrt to one another
-     and need not be orthogonal.
-
     Parameters
     ----------
     coeffs1:
@@ -262,14 +259,18 @@ def convert_vector_basis(
 
     Notes
     -----
+    - Basis vectors are defined to be linearly independent wrt to one another
+      and need not be orthogonal.
+
     - `basis2_overlap` is the matrix with (i, j)th entries
-    :math:`\braket{\psi_i, \psi_j}` where :math:`\psi_i` are in basis set 2.
+      :math:`\braket{\psi_i, \psi_j}` where :math:`\psi_i` are in basis set 2.
 
     - `basis21_overlap` is the matrix whose (i, j)th entries are
-    :math:`\braket{\psi_i, \phi_j}` where :math:`\phi_j` are in basis set 1 and
-    :math:`\psi_i` are in basis set 2.
+      :math:`\braket{\psi_i, \phi_j}` where :math:`\phi_j` are in basis set 1 and
+      :math:`\psi_i` are in basis set 2.
 
-    - If `basis2_overlap` is not full rank, then least-squared solution is solved instead.
+    - If `basis2_overlap` is not full rank, then least-squared solution is solved instead. This
+      is effectively solving :math:`||b - Ax||`.
 
     """
     if basis2_overlap.shape[0] != basis2_overlap.shape[1]:

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -228,6 +228,61 @@ def test_convert_convention_shell():
     assert_equal(vec2[permutation] * signs, vec1)
 
 
+def test_get_decontracted():
+    obasis = MolecularBasis(
+        [Shell(0, [0], ['c'], [0.01], np.array([[3.]])),
+         Shell(1, [0, 1], ['c', 'c'], [0.03, 0.04], np.array([[3., 4.], [1., 2.]])),
+         Shell(0, [2, 1, 2], ['p', 'c', 'c'], [0.05], np.array([[5., 5., 6.]]))],
+        {(0, 'c'): ['s'],
+         (1, 'c'): ['x', 'z', '-y'],
+         (2, 'p'): ['dc0', 'dc1', '-ds1', 'dc2', '-ds2']},
+        'L2'
+    )
+    obasis = obasis.get_decontracted()
+
+    ncontshells = 8  # Number of contracted shells now is equal to the number of primitives.
+    assert_equal(len(obasis.shells), ncontshells)
+    # Assert each shell has length one exponents
+    for i in range(0, ncontshells):
+        assert_equal(len(obasis.shells[0].exponents), 1)
+    # Assert they have the right exponents.
+    assert_equal(obasis.shells[0].exponents, 0.01)
+    assert_equal(obasis.shells[1].exponents, 0.03)
+    assert_equal(obasis.shells[2].exponents, 0.04)
+    assert_equal(obasis.shells[3].exponents, 0.03)
+    assert_equal(obasis.shells[4].exponents, 0.04)
+    assert_equal(obasis.shells[5].exponents, 0.05)
+    assert_equal(obasis.shells[6].exponents, 0.05)
+    assert_equal(obasis.shells[7].exponents, 0.05)
+    # Assert they have the right coefficients.
+    assert_equal(obasis.shells[0].coeffs, 3.)
+    assert_equal(obasis.shells[1].coeffs, np.array([[3.]]))
+    assert_equal(obasis.shells[2].coeffs, np.array([[1.]]))
+    assert_equal(obasis.shells[3].coeffs, np.array([[4.]]))
+    assert_equal(obasis.shells[4].coeffs, np.array([[2.]]))
+    assert_equal(obasis.shells[5].coeffs, np.array([[5.]]))
+    assert_equal(obasis.shells[6].coeffs, np.array([[5.]]))
+    assert_equal(obasis.shells[7].coeffs, np.array([[6.]]))
+    # Assert right centers
+    assert_equal(obasis.shells[0].icenter, 0)
+    assert_equal(obasis.shells[1].icenter, 1)
+    assert_equal(obasis.shells[2].icenter, 1)
+    assert_equal(obasis.shells[3].icenter, 1)
+    assert_equal(obasis.shells[4].icenter, 1)
+    assert_equal(obasis.shells[5].icenter, 0)
+    assert_equal(obasis.shells[6].icenter, 0)
+    assert_equal(obasis.shells[7].icenter, 0)
+    # Assert right kind
+    assert_equal(obasis.shells[0].kinds, ['c'])
+    assert_equal(obasis.shells[1].kinds, ['c'])
+    assert_equal(obasis.shells[2].kinds, ['c'])
+    assert_equal(obasis.shells[3].kinds, ['c'])
+    assert_equal(obasis.shells[4].kinds, ['c'])
+    assert_equal(obasis.shells[5].kinds, ['p'])
+    assert_equal(obasis.shells[6].kinds, ['c'])
+    assert_equal(obasis.shells[7].kinds, ['c'])
+
+
 def test_convert_convention_obasis():
     obasis = MolecularBasis(
         [Shell(0, [0], ['c'], np.zeros(3), np.zeros((3, 1))),

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -243,7 +243,7 @@ def test_get_decontracted():
     ncontshells = 8  # Number of contracted shells now is equal to the number of primitives.
     assert_equal(len(obasis.shells), ncontshells)
     # Assert each shell has length one exponents
-    for i in range(0, ncontshells):
+    for _ in range(0, ncontshells):
         assert_equal(len(obasis.shells[0].exponents), 1)
     # Assert they have the right exponents.
     assert_equal(obasis.shells[0].exponents, 0.01)
@@ -364,7 +364,7 @@ def test_convert_primitive_kind():
     # Test converting D-type from kind="p" to kind="c".
     coeff = np.array([1., 2., 3., 4., 5.])
     ccoeff = convert_primitive_kind(2, "p", coeff, "c")
-    desired = np.array([1.97606774,  5.,  2., -2.64273441,  3., 0.66666667])
+    desired = np.array([1.97606774, 5., 2., -2.64273441, 3., 0.66666667])
     assert_allclose(ccoeff, desired)
 
 

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -135,8 +135,7 @@ def test_converting_from_cartesian_to_pure():
     overlap_cp = tfs[2]
     coeff = np.array([1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
     coeff2 = convert_vector_basis(coeff, np.eye(5), overlap_cp)
-    desired = np.array([-0.5 - 0.5 * 4.0 + 6.0, 3.0, 5.0,
-                        0.86602540378 * 1.0 - 0.86602540378 * 4.0, 2.0])
+    desired = overlap_cp.dot(coeff)
     assert_allclose(coeff2, desired, rtol=1.e-5, atol=1.e-8)
 
 
@@ -151,13 +150,12 @@ def test_converting_from_pure_to_cartesian():
     overlap_cp = tfs[1]
     coeff = np.array([1., 2., 3.])
     coeff2 = convert_vector_basis(coeff, np.eye(3), overlap_cp.T)
-    desired = np.array([2., 3., 1.])
+    desired = np.linalg.lstsq(overlap_cp, coeff, rcond=None)[0]
     assert_allclose(coeff2, desired, rtol=1.e-5, atol=1.e-8)
 
     # Test converting D-type.
     overlap_cp = tfs[2]
-    coeff = np.array([1., 2., 3., 4., 5.])
-    coeff2 = convert_vector_basis(coeff, np.eye(6), overlap_cp.T)
-    desired = np.array([np.sqrt(3.0) * 4.0 / 2.0 - 0.5, 5.0, 2.0,
-                        -np.sqrt(3.0) * 4.0 / 2.0 - 0.5, 3.0, 1.0])
-    assert_allclose(coeff2, desired, rtol=1.e-5, atol=1.e-8)
+    pcoeff = np.array([1., 2., 3., 4., 5.])
+    ccoeff = convert_vector_basis(pcoeff, np.eye(6), np.linalg.pinv(overlap_cp))
+    desired =  np.linalg.lstsq(overlap_cp, pcoeff, rcond=None)[0]
+    assert_allclose(ccoeff, desired, rtol=1.e-5, atol=1.e-8)


### PR DESCRIPTION
This pull request is regarding issue (#146).

Added
---------
- Conversion to decontracted molecular basis (c97cad3)
- Ability to generally convert a vector between two basis sets, given that one knows the overlap matrices (6f3f76f)
- Method in `MolecularBasis` to convert all primitive shells in a contracted shell to a specific kind (either Cartesian or Pure) (345f190). 
    - Ran into the problem of iodata assuming all coefficients in a primitive shell are the same. However, conversion to a different            basis varys the coefficients across a primitive shell. This is fixed by averaging them.
- General function to convert a kind of a single primitive shell to Cartesian or pure (345f190) . 
- Update the code document with definitions, and equations (d956cfa, 8eb2ea7).