### PR TITLE
Revert "Pin xdist to working version"

### DIFF
--- a/.roberto.yaml
+++ b/.roberto.yaml
@@ -1,7 +1,7 @@
 abs: true  # Force absolute comparison for cardboardlint
 project:
   name: iodata
-  conda_requirements: [sympy, pytest-xdist<2.0.0]
+  conda_requirements: [sympy]
   packages:
     - conda_name: iodata
       tools:

--- a/tools/conda.recipe/meta.yaml
+++ b/tools/conda.recipe/meta.yaml
@@ -33,7 +33,7 @@ test:
   requires:
     - python
     - pytest
-    - pytest-xdist <2.0.0
+    - pytest-xdist
   imports:
     - iodata
   commands:


### PR DESCRIPTION
Reverts theochem/iodata#181.

The problem has already been solved externally, so pinning should not longer be needed.