### PR TITLE
Prepare for 1.0.0a1 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -68,6 +68,7 @@ setup(
         'console_scripts': ['iodata-convert = iodata.__main__:main']
     },
     classifiers=[
+        'Development Status :: 3 - Alpha',
         'Environment :: Console',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
Classifiers are needed in setup.py to let PyPI know the kind of release. (This is needed to avoid that users accidentally update to unstable releases.)