### PR TITLE
Fix new pylint issue: raise-missing-from

### DIFF
--- a/iodata/api.py
+++ b/iodata/api.py
@@ -106,7 +106,7 @@ def load_one(filename: str, fmt: str = None, **kwargs) -> IOData:
     try:
         return IOData(**format_module.load_one(lit, **kwargs))
     except StopIteration:
-        raise lit.error("File ended before all data was read.")
+        lit.error("File ended before all data was read.")
 
 
 def load_many(filename: str, fmt: str = None, **kwargs) -> Iterator[IOData]:

--- a/iodata/formats/sdf.py
+++ b/iodata/formats/sdf.py
@@ -62,7 +62,7 @@ def load_one(lit: LineIterator) -> dict:
         try:
             words = next(lit)
         except StopIteration:
-            raise lit.error("Molecule specification did not end properly with $$$$")
+            lit.error("Molecule specification did not end properly with $$$$")
         if words == "$$$$\n":
             break
     return {


### PR DESCRIPTION
@FarnazH With the latest Pylint upgrade, this is a new type of problem it can detect. The two lines were just minor mistakes, `raise` did not need to be present in front of the function call.