### PR TITLE
Update README & Add License Shield

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,10 +51,9 @@ The following dependencies will be necessary for IOData to build properly,
 Installation
 ------------
 
-To install IOData using a conda environment:
-
-* Install miniconda: https://conda.io/miniconda.html
-* OR anaconda: https://www.anaconda.com/download
+To install IOData using conda package management system, install
+`miniconda <https://conda.io/miniconda.html>`__ or
+`anaconda <https://www.anaconda.com/download>`__ first, and then:
 
 .. code-block:: bash
 

--- a/README.rst
+++ b/README.rst
@@ -51,8 +51,6 @@ The following dependencies will be necessary for IOData to build properly,
 * SciPy >= 0.11.0: http://www.scipy.org/
 * NumPy >= 1.9.1: http://www.numpy.org/
 * pytest >= 4.2.0: https://docs.pytest.org/
-* Cython
-* gcc/clang
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -28,18 +28,13 @@ IOData
 |Codecov|
 |Version|
 |CondaVersion|
+|License|
 
 
 About
 -----
 IOData is a HORTON 3 module for input/output of quantum chemistry file formats. Documentation is
 here: https://iodata.readthedocs.io/en/latest/index.html
-
-
-License
--------
-
-IOData is distributed under GPL License version 3 (GPLv3).
 
 
 Dependencies
@@ -72,6 +67,7 @@ See https://iodata.readthedocs.io/en/latest/install.html for full details.
 .. |Travis| image:: https://travis-ci.org/theochem/iodata.svg?branch=master
     :target: https://travis-ci.org/theochem/iodata
 .. |Version| image:: https://img.shields.io/pypi/pyversions/iodata.svg
+.. |License| image:: https://img.shields.io/github/license/theochem/iodata
 .. |Pypi| image:: https://img.shields.io/pypi/v/iodata.svg
     :target: https://pypi.python.org/pypi/iodata/0.1.3
 .. |Codecov| image:: https://img.shields.io/codecov/c/github/theochem/iodata/master.svg


### PR DESCRIPTION
This PR:

1. Updates the dependencies in README
2. Add License shield and remove the License section of README (it makes it shorter & more informative)

I tried to update the python version shield, but I think that is tied to pypi (which based on its last release still supports python 2.7 & 3).