### PR TITLE
Handle warnings in unit tests

### DIFF
--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -23,8 +23,6 @@ This format is used by two programs:
 `Orca <https://sites.google.com/site/orcainputlibrary/>`_.
 """
 
-import warnings
-
 from typing import Tuple, List, TextIO
 
 import numpy as np
@@ -280,15 +278,11 @@ def dump_one(f: TextIO, data: IOData):
 
     # CHARGES
     if 'mulliken' in data.atcharges:
-        charges = data.atcharges['mulliken']
-    else:
-        charges = {}
-        warnings.warn('Skip writing Mulliken charges, because they are not stored in IOData.')
-    f.write('$CHARGES\n')
-    for charge in charges:
-        f.write('  {: ,.6f}\n'.format(charge))
-    f.write('$END\n')
-    f.write('\n')
+        f.write('$CHARGES\n')
+        for charge in data.atcharges['mulliken']:
+            f.write('  {: ,.6f}\n'.format(charge))
+        f.write('$END\n')
+        f.write('\n')
 
     # BASIS
     f.write('$BASIS\n')

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -169,7 +169,7 @@ def check_orthonormal(mo_coeffs, ao_overlap, atol=1e-5):
                     rtol=0., atol=atol, err_msg=message)
 
 
-def load_one_warning(filename: str, fmt: str = None, match: str = "", **kwargs):
+def load_one_warning(filename: str, fmt: str = None, match: str = None, **kwargs):
     """Call load_one, catching expected FileFormatWarning.
 
     Parameters
@@ -192,7 +192,7 @@ def load_one_warning(filename: str, fmt: str = None, match: str = "", **kwargs):
 
     """
     with path('iodata.test.data', filename) as fn:
-        if match == "":
+        if match == None:
             return load_one(str(fn), fmt, **kwargs)
         with pytest.warns(FileFormatWarning, match=match):
             return load_one(str(fn), fmt, **kwargs)

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -192,7 +192,7 @@ def load_one_warning(filename: str, fmt: str = None, match: str = None, **kwargs
 
     """
     with path('iodata.test.data', filename) as fn:
-        if match == None:
+        if match is None:
             return load_one(str(fn), fmt, **kwargs)
         with pytest.warns(FileFormatWarning, match=match):
             return load_one(str(fn), fmt, **kwargs)

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -517,8 +517,20 @@ def test_load_nbasis_indep(tmpdir):
     assert mol2.mo.coeffs.shape == (38, 37)
 
 
-def check_load_dump_consistency(tmpdir, fn, match=""):
-    """Check if dumping and loading an FCHK file results in the same data."""
+def check_load_dump_consistency(tmpdir: str, fn: str, match: str = None):
+    """Check if dumping and loading an FCHK file results in the same data.
+
+    Parameters
+    ----------
+    tmpdir
+        The temporary directory to dump and load the file.
+    fn
+        The filename to load.
+    match
+        When given, loading the file is expected to raise a warning whose
+        message string contains match.
+
+    """
     mol1 = load_one_warning(fn, match=match)
     fn_tmp = os.path.join(tmpdir, 'foo.bar')
     dump_one(mol1, fn_tmp, fmt='fchk')

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -29,9 +29,9 @@ import pytest
 
 from ..api import load_one, load_many, dump_one
 from ..overlap import compute_overlap
-from ..utils import check_dm, FileFormatWarning
+from ..utils import check_dm
 
-from .common import check_orthonormal, compare_mols
+from .common import check_orthonormal, compare_mols, load_one_warning
 from .test_molekel import compare_mols_diff_formats
 
 try:
@@ -517,14 +517,9 @@ def test_load_nbasis_indep(tmpdir):
     assert mol2.mo.coeffs.shape == (38, 37)
 
 
-def check_load_dump_consistency(tmpdir, fn, match=None):
+def check_load_dump_consistency(tmpdir, fn, match=""):
     """Check if dumping and loading an FCHK file results in the same data."""
-    with path('iodata.test.data', fn) as file_name:
-        if match is None:
-            mol1 = load_one(str(file_name))
-        else:
-            with pytest.warns(FileFormatWarning, match=match):
-                mol1 = load_one(str(file_name))
+    mol1 = load_one_warning(fn, match=match)
     fn_tmp = os.path.join(tmpdir, 'foo.bar')
     dump_one(mol1, fn_tmp, fmt='fchk')
     mol2 = load_one(fn_tmp, fmt='fchk')

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -51,7 +51,7 @@ def compare_mols_diff_formats(mol1, mol2):
     assert_allclose(charges1, charges2, rtol=0.0, atol=1.0e-6)
 
 
-def check_load_dump_consistency(fn: str, tmpdir: str, match: str = ""):
+def check_load_dump_consistency(fn: str, tmpdir: str, match: str = None):
     """Check if data is preserved after dumping and loading a Molekel file.
 
     Parameters

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -22,18 +22,13 @@
 import os
 
 from numpy.testing import assert_equal, assert_allclose
-import pytest
 
-from .common import check_orthonormal, compare_mols, compute_mulliken_charges
+from .common import (check_orthonormal, compare_mols, compute_mulliken_charges,
+                     load_one_warning)
 from ..basis import convert_conventions
 from ..api import load_one, dump_one
 from ..overlap import compute_overlap
-from ..utils import angstrom, FileFormatWarning
-
-try:
-    from importlib_resources import path
-except ImportError:
-    from importlib.resources import path
+from ..utils import angstrom
 
 
 def compare_mols_diff_formats(mol1, mol2):
@@ -56,19 +51,21 @@ def compare_mols_diff_formats(mol1, mol2):
     assert_allclose(charges1, charges2, rtol=0.0, atol=1.0e-6)
 
 
-def check_load_dump_consistency(fn, tmpdir):
+def check_load_dump_consistency(fn: str, tmpdir: str, match: str = ""):
     """Check if data is preserved after dumping and loading a Molekel file.
 
     Parameters
     ----------
-    fn : str
+    fn
         The Molekel filename to load
-    tmpdir : str
+    tmpdir
         The temporary directory to dump and load the file.
+    match
+        When given, loading the file is expected to raise a warning whose
+        message string contains match.
 
     """
-    with path('iodata.test.data', fn) as file_name:
-        mol1 = load_one(str(file_name))
+    mol1 = load_one_warning(fn, match=match)
     fn_tmp = os.path.join(tmpdir, 'foo.bar')
     dump_one(mol1, fn_tmp, fmt='molekel')
     mol2 = load_one(fn_tmp, fmt='molekel')
@@ -82,28 +79,19 @@ def check_load_dump_consistency(fn, tmpdir):
 
 
 def test_load_dump_consistency_h2(tmpdir):
-    with pytest.warns(FileFormatWarning) as record:
-        check_load_dump_consistency('h2_sto3g.mkl', tmpdir)
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    check_load_dump_consistency('h2_sto3g.mkl', tmpdir, match="ORCA")
 
 
 def test_load_dump_consistency_ethanol(tmpdir):
-    with pytest.warns(FileFormatWarning) as record:
-        check_load_dump_consistency('ethanol.mkl', tmpdir)
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    check_load_dump_consistency('ethanol.mkl', tmpdir, match="ORCA")
 
 
 def test_load_dump_consistency_li2(tmpdir):
-    with pytest.warns(FileFormatWarning) as record:
-        check_load_dump_consistency('li2.mkl', tmpdir)
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    check_load_dump_consistency('li2.mkl', tmpdir, match="ORCA")
 
 
 def test_load_molden_dump_molekel_li2(tmpdir):
-    check_load_dump_consistency('li2.molden.input', tmpdir)
+    check_load_dump_consistency('li2.molden.input', tmpdir, match="ORCA")
 
 
 def test_load_fchk_dump_molekel_li2(tmpdir):
@@ -111,11 +99,7 @@ def test_load_fchk_dump_molekel_li2(tmpdir):
 
 
 def test_load_mkl_ethanol():
-    with path('iodata.test.data', 'ethanol.mkl') as fn_mkl:
-        with pytest.warns(FileFormatWarning) as record:
-            mol = load_one(str(fn_mkl))
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    mol = load_one_warning("ethanol.mkl", match="ORCA")
 
     # Direct checks with mkl file
     assert_equal(mol.atnums.shape, (9,))
@@ -152,11 +136,7 @@ def test_load_mkl_ethanol():
 
 
 def test_load_mkl_li2():
-    with path('iodata.test.data', 'li2.mkl') as fn_mkl:
-        with pytest.warns(FileFormatWarning) as record:
-            mol = load_one(str(fn_mkl))
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    mol = load_one_warning("li2.mkl", match="ORCA")
     assert_equal(mol.atcharges['mulliken'].shape, (2,))
     assert_allclose(mol.atcharges['mulliken'], [0.5, 0.5])
     # check mo normalization
@@ -166,11 +146,7 @@ def test_load_mkl_li2():
 
 
 def test_load_mkl_h2():
-    with path('iodata.test.data', 'h2_sto3g.mkl') as fn_mkl:
-        with pytest.warns(FileFormatWarning) as record:
-            mol = load_one(str(fn_mkl))
-    assert len(record) == 1
-    assert "ORCA" in record[0].message.args[0]
+    mol = load_one_warning("h2_sto3g.mkl", match="ORCA")
     assert_equal(mol.atcharges['mulliken'].shape, (2,))
     assert_allclose(mol.atcharges['mulliken'], [0, 0])
     # check mo normalization

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -29,7 +29,8 @@ from ..formats.wfx import load_data_wfx, parse_wfx
 from ..overlap import compute_overlap
 from ..utils import LineIterator
 
-from .common import check_orthonormal, truncated_file, compare_mols, compute_mulliken_charges
+from .common import (check_orthonormal, truncated_file, compare_mols,
+                     compute_mulliken_charges, load_one_warning)
 
 try:
     from importlib_resources import path
@@ -86,23 +87,26 @@ def test_load_dump_consistency_lih_cation_rohf(tmpdir):
     check_load_dump_consistency('lih_cation_rohf.wfx', tmpdir)
 
 
-def compare_mulliken_charges(fname, tmpdir, rtol=1.0e-7, atol=0.0):
+def compare_mulliken_charges(
+        fname: str, tmpdir: str, rtol: float = 1.0e-7, atol: float = 0.0,
+        match: str = ""):
     """Check if charges are computed correctly after dumping and loading WFX file format.
 
     Parameters
     ----------
-    fname : str
+    fname
         The filename to be load.
-    tmpdir : str
+    tmpdir
         The temporary directory to dump and load the file.
-    rtole : float, optional
-        Relative tolerance when comparing charges.
-    atol : float, optional
-        Absolute tolerance when comparing charges.
-
+    rtole
+        Relative tolerance when comparing charges. (optional)
+    atol
+        Absolute tolerance when comparing charges. (optional)
+    match
+        When given, loading the file is expected to raise a warning whose
+        message string contains match.
     """
-    with path('iodata.test.data', fname) as file_name:
-        mol1 = load_one(str(file_name))
+    mol1 = load_one_warning(fname, match=match)
     # dump WFX and check that file exists
     fn_tmp = os.path.join(tmpdir, f"{fname}.wfx")
     dump_one(mol1, fn_tmp)
@@ -166,7 +170,7 @@ def test_dump_one_from_wfn_lif(tmpdir):
 
 
 def test_dump_one_from_molden_h2o(tmpdir):
-    compare_mulliken_charges('h2o.molden.input', tmpdir)
+    compare_mulliken_charges('h2o.molden.input', tmpdir, match="ORCA")
 
 
 def test_dump_one_from_molden_he2(tmpdir):
@@ -174,21 +178,22 @@ def test_dump_one_from_molden_he2(tmpdir):
 
 
 def test_dump_one_from_molden_neon(tmpdir):
-    compare_mulliken_charges('neon_turbomole_def2-qzvp.molden', tmpdir, atol=1.0e-10)
+    compare_mulliken_charges(
+        'neon_turbomole_def2-qzvp.molden', tmpdir, atol=1.0e-10, match="Turbomole")
 
 
 def test_dump_one_from_molden_nh3(tmpdir):
     compare_mulliken_charges('nh3_molden_cart.molden', tmpdir)
     compare_mulliken_charges('nh3_molpro2012.molden', tmpdir)
-    compare_mulliken_charges('nh3_turbomole.molden', tmpdir)
+    compare_mulliken_charges('nh3_turbomole.molden', tmpdir, match="Turbomole")
 
 
 def test_dump_one_from_mkl_methanol(tmpdir):
-    compare_mulliken_charges('ethanol.mkl', tmpdir)
+    compare_mulliken_charges('ethanol.mkl', tmpdir, match="ORCA")
 
 
 def test_dump_one_from_mkl_h2(tmpdir):
-    compare_mulliken_charges('h2_sto3g.mkl', tmpdir)
+    compare_mulliken_charges('h2_sto3g.mkl', tmpdir, match="ORCA")
 
 
 # add this test when pure to Cartesian basis set conversion is supported

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -89,7 +89,7 @@ def test_load_dump_consistency_lih_cation_rohf(tmpdir):
 
 def compare_mulliken_charges(
         fname: str, tmpdir: str, rtol: float = 1.0e-7, atol: float = 0.0,
-        match: str = ""):
+        match: str = None):
     """Check if charges are computed correctly after dumping and loading WFX file format.
 
     Parameters
@@ -98,13 +98,14 @@ def compare_mulliken_charges(
         The filename to be load.
     tmpdir
         The temporary directory to dump and load the file.
-    rtole
+    rtol
         Relative tolerance when comparing charges. (optional)
     atol
         Absolute tolerance when comparing charges. (optional)
     match
         When given, loading the file is expected to raise a warning whose
         message string contains match.
+
     """
     mol1 = load_one_warning(fname, match=match)
     # dump WFX and check that file exists


### PR DESCRIPTION
Several unit tests were generating warnings that were uncatched. I have also removed one warning from `molekel.py`, because it was raised in a fairly harmless scenario. I've also changed the code a bit: the entire charge section is omitted when there are no charges to be written.