### PR TITLE
Fix "unsupported operand" issue when accessing IOData.charge

### DIFF
--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -248,6 +248,15 @@ class IOData:
     two_ints: dict = {}
     two_rdms: dict = {}
 
+    def __attrs_post_init__(self):
+        if self._charge is not None:
+            # Trigger charge setter to acchieve consistency in properties
+            # nelec, charge and atcorenums. This is needed because the
+            # attr constructor bypasses the setters. See
+            # https://www.attrs.org/en/stable/init.html#private-attributes
+            self.charge = self._charge
+
+
     # Public interfaces to private attributes
 
     @property

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -311,6 +311,8 @@ class IOData:
     @property
     def nelec(self) -> float:
         """Return the number of electrons."""
+        # When the molecular orbitals are present, they determine the number
+        # of electrons. Only when mo is absent, we use a stored value.
         if self.mo is not None:
             return self.mo.nelec
         return self._nelec
@@ -336,6 +338,8 @@ class IOData:
 
     @spinpol.setter
     def spinpol(self, spinpol: float):
+        # When the molecular orbitals are present, they determine the spin
+        # polarization. Only when mo is absent, we use a stored value.
         if self.mo is None:
             self._spinpol = spinpol
         else:

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -259,19 +259,22 @@ class IOData:
             # https://github.com/PyCQA/pylint/issues/1694
             # pylint: disable=no-member
             result = self.atnums.astype(float)
-            self._atcorenums = result
+            self.atcorenums = result
         return result
 
     @atcorenums.setter
     def atcorenums(self, atcorenums):
         self._atcorenums = atcorenums
+        if self._charge is not None:
+            self.nelec = self._atcorenums.sum() - self._charge
+            self._charge = None
 
     @property
     def charge(self) -> float:
         """Return the net charge of the system."""
-        if self.atcorenums is None:
-            return self._charge
-        return self.atcorenums.sum() - self.nelec
+        if self.atcorenums is not None and self.nelec is not None:
+            return self.atcorenums.sum() - self.nelec
+        return self._charge
 
     @charge.setter
     def charge(self, charge: float):
@@ -301,9 +304,9 @@ class IOData:
     @property
     def nelec(self) -> float:
         """Return the number of electrons."""
-        if self.mo is None:
-            return self._nelec
-        return self.mo.nelec
+        if self.mo is not None:
+            return self.mo.nelec
+        return self._nelec
 
     @nelec.setter
     def nelec(self, nelec: float):
@@ -320,9 +323,9 @@ class IOData:
         number in ]0, 2[ implies spin polarizaiton, which may not always be a
         valid assumption.
         """
-        if self.mo is None:
-            return self._spinpol
-        return self.mo.spinpol
+        if self.mo is not None:
+            return self.mo.spinpol
+        return self._spinpol
 
     @spinpol.setter
     def spinpol(self, spinpol: float):

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -264,18 +264,20 @@ class IOData:
     @atcorenums.setter
     def atcorenums(self, atcorenums):
         if atcorenums is None:
-            if self.nelec is not None:
+            if self.nelec is not None and self._atcorenums is not None:
                 # Set _charge because charge can no longer be derived from
                 # atcorenums and nelec.
                 self._charge = self._atcorenums.sum() - self.nelec
-        elif self._charge is not None:
-            # _charge is treated as the dependent one, while atcorenums and
-            # nelec are treated as independent.
-            if self._nelec is None:
-                # Switch to storing _nelec.
-                self._nelec = atcorenums.sum() - self._charge
-            self._charge = None
-        self._atcorenums = atcorenums
+            self._atcorenums = None
+        else:
+            if self._charge is not None:
+                # _charge is treated as the dependent one, while atcorenums and
+                # nelec are treated as independent.
+                if self._nelec is None:
+                    # Switch to storing _nelec.
+                    self._nelec = atcorenums.sum() - self._charge
+                self._charge = None
+            self._atcorenums = np.asarray(atcorenums, dtype=float)
 
     @property
     def charge(self) -> float:

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -249,13 +249,18 @@ class IOData:
     two_rdms: dict = {}
 
     def __attrs_post_init__(self):
+        # Trigger setter to acchieve consistency in properties
+        # atcorenums, nelec, charge, spinmult. This is needed because the
+        # attr constructor bypasses the setters. See
+        # https://www.attrs.org/en/stable/init.html#private-attributes
+        if self._atcorenums is not None:
+            self.atcorenums = self._atcorenums
         if self._charge is not None:
-            # Trigger charge setter to acchieve consistency in properties
-            # nelec, charge and atcorenums. This is needed because the
-            # attr constructor bypasses the setters. See
-            # https://www.attrs.org/en/stable/init.html#private-attributes
             self.charge = self._charge
-
+        if self._nelec is not None:
+            self.nelec = self._nelec
+        if self._spinpol is not None:
+            self.spinpol = self._spinpol
 
     # Public interfaces to private attributes
 

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -200,6 +200,69 @@ def test_charge_nelec7():
     assert mol.charge == 2
 
 
+def test_charge_nelec8():
+    mol = IOData()
+    mol.charge = 0.0
+    mol.atcorenums = None
+    assert mol.charge == 0.0
+    assert mol.atcorenums is None
+    assert mol.nelec is None
+
+
+# pylint: disable=protected-access
+def test_charge_nelec9():
+    mol = IOData()
+    mol.charge = 1.0
+    mol.atcorenums = np.array([8.0, 1.0, 1.0])
+    assert mol.charge == 1.0
+    assert mol._charge is None  # charge is derived
+    assert_equal(mol._atcorenums, np.array([8.0, 1.0, 1.0]))
+    assert mol.nelec == 9.0
+    mol.charge = None
+    assert mol.nelec is None
+
+
+# pylint: disable=protected-access
+def test_charge_nelec10():
+    mol = IOData()
+    mol.charge = 1.0
+    mol.atnums = np.array([8, 1, 1])
+    assert mol.charge == 1.0  # This triggers atcorenums to be initialized.
+    assert mol._charge is None
+    assert_equal(mol._atcorenums, np.array([8.0, 1.0, 1.0]))
+    assert mol.nelec == 9.0
+    mol.charge = None
+    assert mol.nelec is None
+
+
+def test_charge_nelec11():
+    mol = IOData()
+    mol.atnums = np.array([8, 1, 1])
+    mol.charge = 1.0
+    assert mol.nelec == 9.0
+    mol.charge = None
+    assert mol.nelec is None
+
+
+def test_charge_nelec12():
+    mol = IOData()
+    mol.atnums = np.array([8, 1, 1])
+    mol.nelec = 11.0
+    assert mol.charge == -1.0
+    mol.nelec = None
+    assert mol.charge is None
+
+
+def test_charge_nelec13():
+    mol = IOData()
+    mol.atcorenums = np.array([8, 1, 1])
+    mol.charge = 1.0
+    mol.atcorenums = None
+    assert mol.charge == 1.0
+    assert mol.nelec == 9.0
+    assert mol.atcorenums is None
+
+
 def test_undefined():
     # One a blank IOData object, accessing undefined charge and nelec should
     # return None.
@@ -215,6 +278,17 @@ def test_undefined():
     assert mol.nelec is None
 
 
+def test_spinpol1():
+    mol = IOData(spinpol=3)
+    assert mol.spinpol == 3
+
+
+def test_spinpol1():
+    mol = IOData()
+    mol.spinpol = 3
+    assert mol.spinpol == 3
+
+
 # pylint: disable=protected-access
 def test_derived1():
     # When loading a file with molecular orbitals, nelec, charge and spinpol are
@@ -227,6 +301,12 @@ def test_derived1():
     assert mol._nelec is None
     assert mol._charge is None
     assert mol._spinpol is None
+    with pytest.raises(TypeError):
+        mol.charge = 2
+    with pytest.raises(TypeError):
+        mol.nelec = 3
+    with pytest.raises(TypeError):
+        mol.spinpol = 1
 
 
 # pylint: disable=protected-access

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -16,7 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, see <http://www.gnu.org/licenses/>
 # --
-# pylint: disable=unsubscriptable-object,no-member
 """Test iodata.iodata module."""
 
 
@@ -96,8 +95,8 @@ def test_dm_ch3_rohf_g03():
     assert_allclose(np.einsum('ab,ba', olp, dm), 9, atol=1.e-6)
 
 
-# pylint: disable=protected-access
 def test_charge_nelec1():
+    # pylint: disable=protected-access
     # One a blank IOData object, charge and nelec can be set independently.
     mol = IOData()
     mol.nelec = 4
@@ -109,8 +108,8 @@ def test_charge_nelec1():
     assert mol._charge == -1
 
 
-# pylint: disable=protected-access
 def test_charge_nelec2():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atcorenums = np.array([6.0, 1.0, 1.0, 1.0, 1.0])
@@ -123,8 +122,8 @@ def test_charge_nelec2():
     assert mol._charge is None
 
 
-# pylint: disable=protected-access
 def test_charge_nelec3():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atnums = np.array([6, 1, 1, 1, 1])
@@ -141,8 +140,8 @@ def test_charge_nelec3():
     assert mol._charge is None
 
 
-# pylint: disable=protected-access
 def test_charge_nelec4():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atnums = np.array([6, 1, 1, 1, 1])
@@ -154,8 +153,8 @@ def test_charge_nelec4():
     assert mol.charge == 1
 
 
-# pylint: disable=protected-access
 def test_charge_nelec5():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.charge = 1
@@ -169,8 +168,8 @@ def test_charge_nelec5():
     assert mol.charge == 1
 
 
-# pylint: disable=protected-access
 def test_charge_nelec6():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.nelec = 8
@@ -184,8 +183,8 @@ def test_charge_nelec6():
     assert mol.charge == 2
 
 
-# pylint: disable=protected-access
 def test_charge_nelec7():
+    # pylint: disable=protected-access
     # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.nelec = 8
@@ -209,8 +208,8 @@ def test_charge_nelec8():
     assert mol.nelec is None
 
 
-# pylint: disable=protected-access
 def test_charge_nelec9():
+    # pylint: disable=protected-access
     mol = IOData()
     mol.charge = 1.0
     mol.atcorenums = np.array([8.0, 1.0, 1.0])
@@ -222,8 +221,8 @@ def test_charge_nelec9():
     assert mol.nelec is None
 
 
-# pylint: disable=protected-access
 def test_charge_nelec10():
+    # pylint: disable=protected-access
     mol = IOData()
     mol.charge = 1.0
     mol.atnums = np.array([8, 1, 1])
@@ -263,8 +262,8 @@ def test_charge_nelec13():
     assert mol.atcorenums is None
 
 
-# pylint: disable=protected-access
 def test_charge_nelec14():
+    # pylint: disable=protected-access
     mol = IOData()
     mol.nelec = 8
     mol.atcorenums = None
@@ -313,8 +312,8 @@ def test_spinpol2():
     assert mol.spinpol == 3
 
 
-# pylint: disable=protected-access
 def test_derived1():
+    # pylint: disable=protected-access
     # When loading a file with molecular orbitals, nelec, charge and spinpol are
     # derived from the mo object:
     with path('iodata.test.data', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
@@ -333,8 +332,8 @@ def test_derived1():
         mol.spinpol = 1
 
 
-# pylint: disable=protected-access
 def test_derived2():
+    # pylint: disable=protected-access
     mol = IOData(atnums=[1, 1, 8], charge=1)
     assert mol._charge is None
     assert mol._nelec == mol.atcorenums.sum() - 1

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -263,6 +263,7 @@ def test_charge_nelec13():
     assert mol.atcorenums is None
 
 
+# pylint: disable=protected-access
 def test_charge_nelec14():
     mol = IOData()
     mol.nelec = 8
@@ -335,17 +336,10 @@ def test_derived1():
 # pylint: disable=protected-access
 def test_derived2():
     mol = IOData(atnums=[1, 1, 8], charge=1)
-    # The following unit tests are confusing, so need a little explaining:
-    # Upon initialization, _charge is set when loaded from a file. See
-    # https://www.attrs.org/en/stable/init.html#private-attributes
-    # Our getters and setters may change this if needed to maintain consistency.
-    assert mol._nelec is None
-    assert mol._charge == 1.0
+    assert mol._charge is None
+    assert mol._nelec == mol.atcorenums.sum() - 1
     assert mol.charge == 1.0
     assert mol.nelec == mol.atcorenums.sum() - 1
-    assert mol._nelec == mol.atcorenums.sum() - 1
-    assert mol._charge is None
-    assert mol.charge == 1.0
 
 
 def test_natom():

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -111,7 +111,7 @@ def test_charge_nelec1():
 
 # pylint: disable=protected-access
 def test_charge_nelec2():
-    # When atcorenums is set, nelec and charge are coupled
+    # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atcorenums = np.array([6.0, 1.0, 1.0, 1.0, 1.0])
     mol.nelec = 10
@@ -125,7 +125,7 @@ def test_charge_nelec2():
 
 # pylint: disable=protected-access
 def test_charge_nelec3():
-    # When atnums is set, nelec and charge are coupled.
+    # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atnums = np.array([6, 1, 1, 1, 1])
     mol.nelec = 10
@@ -135,6 +135,7 @@ def test_charge_nelec3():
     # Changing charge should change nelec.
     mol.charge = 1
     assert mol.nelec == 9
+    assert mol.charge == 1
     # Only _nelec should be set.
     assert mol._nelec == 9
     assert mol._charge is None
@@ -142,14 +143,61 @@ def test_charge_nelec3():
 
 # pylint: disable=protected-access
 def test_charge_nelec4():
-    # When atnums is set, nelec and charge are coupled.
+    # When atcorenums is set, nelec and charge become coupled.
     mol = IOData()
     mol.atnums = np.array([6, 1, 1, 1, 1])
     mol.charge = 1
-    # _atcorenums and _nelec should be set, not _charge
+    # _atcorenums, _nelec and charge should be set, not _charge
     assert_equal(mol._atcorenums, np.array([6.0, 1.0, 1.0, 1.0, 1.0]))
     assert mol._nelec == 9
     assert mol._charge is None
+    assert mol.charge == 1
+
+
+# pylint: disable=protected-access
+def test_charge_nelec5():
+    # When atcorenums is set, nelec and charge become coupled.
+    mol = IOData()
+    mol.charge = 1
+    mol.atnums = np.array([6, 1, 1, 1, 1])
+    # Access atcorenums to trigger the setter
+    assert mol.atcorenums.sum() == 10
+    # _atcorenums, _nelec and charge should be set, not _charge
+    assert_equal(mol._atcorenums, np.array([6.0, 1.0, 1.0, 1.0, 1.0]))
+    assert mol._nelec == 9
+    assert mol._charge is None
+    assert mol.charge == 1
+
+
+# pylint: disable=protected-access
+def test_charge_nelec6():
+    # When atcorenums is set, nelec and charge become coupled.
+    mol = IOData()
+    mol.nelec = 8
+    mol.atnums = np.array([6, 1, 1, 1, 1])
+    # Access atcorenums to trigger the setter
+    assert mol.atcorenums.sum() == 10
+    # _atcorenums, _nelec and charge should be set, not _charge
+    assert_equal(mol._atcorenums, np.array([6.0, 1.0, 1.0, 1.0, 1.0]))
+    assert mol._nelec == 8
+    assert mol._charge is None
+    assert mol.charge == 2
+
+
+# pylint: disable=protected-access
+def test_charge_nelec7():
+    # When atcorenums is set, nelec and charge become coupled.
+    mol = IOData()
+    mol.nelec = 8
+    mol.charge = 1  # This will be discarded by setting _atcorenums.
+    mol.atnums = np.array([6, 1, 1, 1, 1])
+    # Access atcorenums to trigger the setter
+    assert mol.atcorenums.sum() == 10
+    # _atcorenums, _nelec and charge should be set, not _charge
+    assert_equal(mol._atcorenums, np.array([6.0, 1.0, 1.0, 1.0, 1.0]))
+    assert mol._nelec == 8
+    assert mol._charge is None
+    assert mol.charge == 2
 
 
 def test_undefined():

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -283,7 +283,7 @@ def test_spinpol1():
     assert mol.spinpol == 3
 
 
-def test_spinpol1():
+def test_spinpol2():
     mol = IOData()
     mol.spinpol = 3
     assert mol.spinpol == 3

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -263,6 +263,29 @@ def test_charge_nelec13():
     assert mol.atcorenums is None
 
 
+def test_charge_nelec14():
+    mol = IOData()
+    mol.nelec = 8
+    mol.atcorenums = None
+    mol.atcorenums = np.array([8, 1, 1])
+    assert mol.atcorenums.dtype == float
+    assert mol.charge == 2.0
+    assert mol._charge is None
+    mol.atcorenums = None
+    assert mol.nelec == 8
+    assert mol.charge == 2.0
+
+
+def test_charge_nelec15():
+    mol = IOData()
+    mol.nelec = 8
+    mol.atcorenums = np.array([8, 1, 1])
+    assert mol.charge == 2.0
+    mol.nelec = None
+    assert mol.nelec is None
+    assert mol.charge is None
+
+
 def test_undefined():
     # One a blank IOData object, accessing undefined charge and nelec should
     # return None.

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -42,9 +42,7 @@ def test_load_data_qchemlog_h2o():
     """Test load_qchemlog_low with water_hf_ccpvtz_freq_qchem.out."""
     data = helper_load_data_qchemlog_helper('water_hf_ccpvtz_freq_qchem.out')
     # check loaded data
-    assert data['charge'] == 0
     assert data['natom'] == 3
-    assert data['spin_multi'] == 1
     assert data['run_type'] == 'freq'
     assert data['lot'] == 'hf'
     assert data['obasis_name'] == 'cc-pvtz'
@@ -173,7 +171,6 @@ def test_load_one_qchemlog():
                          1.970000e-04, -1.093230e-02, -2.477343e-01, 1.178541e-01,
                          3.144706e-01]])
     assert_equal(mol.athessian, hessian)
-    assert mol.extra['spin_multi'] == 1
     assert mol.extra['nuclear_repulsion_energy'] == 9.19775748
     assert mol.extra['imaginary_freq'] == 0
     # unit conversion for entropy terms, used atomic units + Kalvin


### PR DESCRIPTION
This is the fix for the following type of error message:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/maarten/anaconda3/envs/iodata/lib/python3.8/site-packages/iodata/iodata.py", line 274, in charge
    return self.atcorenums.sum() - self.nelec
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType
```

This issue is hampering two PRs (#188 and #186), so I'm putting in a separate PR, which can be merged easily. 

(Related issues with nelec and spinpol are also fixed.)

