### PR TITLE
Rename pip package with qc prefix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,19 +33,9 @@ IOData
 
 About
 -----
-IOData is a HORTON 3 module for input/output of quantum chemistry file formats. Documentation is
-here: https://iodata.readthedocs.io/en/latest/index.html
 
-
-Dependencies
-------------
-
-The following dependencies will be necessary for IOData to build properly,
-
-* Python >= 3.6: http://www.python.org/
-* SciPy >= 0.11.0: http://www.scipy.org/
-* NumPy >= 1.9.1: http://www.numpy.org/
-* pytest >= 4.2.0: https://docs.pytest.org/
+IOData is a HORTON 3 module for input/output of quantum chemistry file formats.
+Documentation is here: https://iodata.readthedocs.io/en/latest/index.html
 
 
 Installation

--- a/README.rst
+++ b/README.rst
@@ -51,13 +51,11 @@ The following dependencies will be necessary for IOData to build properly,
 Installation
 ------------
 
-To install IOData using conda package management system, install
+To install IOData using the conda package management system, install
 `miniconda <https://conda.io/miniconda.html>`__ or
 `anaconda <https://www.anaconda.com/download>`__ first, and then:
 
 .. code-block:: bash
-
-    # Activate your main conda environment if needed.
 
     # Create a horton3 conda environment. (optional, recommended)
     conda create -n horton3

--- a/README.rst
+++ b/README.rst
@@ -57,9 +57,22 @@ To install IOData using conda package management system, install
 
 .. code-block:: bash
 
-    $ conda create -n iodata_env
-    $ source activate iodata_env
-    (iodata_env) $ conda install -c theochem iodata
+    # Activate your main conda environment if needed.
+
+    # Create a horton3 conda environment. (optional, recommended)
+    conda create -n horton3
+    source activate horton3
+
+    # Install the stable release.
+    conda install -c theochem iodata
+
+To install IOData with pip, you may want to create a `virtual environment`_,
+and then:
+
+.. code-block:: bash
+
+    # Install the stable release.
+    pip install qc-iodata
 
 See https://iodata.readthedocs.io/en/latest/install.html for full details.
 
@@ -75,3 +88,4 @@ See https://iodata.readthedocs.io/en/latest/install.html for full details.
     :target: https://anaconda.org/theochem/iodata
 .. |CondaVersion| image:: https://img.shields.io/conda/pn/theochem/iodata.svg
     :target: https://anaconda.org/theochem/iodata
+.. _virtual environment: https://docs.python.org/3/tutorial/venv.html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -33,7 +33,9 @@ To install IOData using conda package management system, install
 
 .. code-block:: bash
 
-    # Activate your main conda environment if needed.
+    # Activate your main conda environment if it is not loaded in your .bashrc.
+    # E.g. run the following if you have miniconda installed in e.g. ~/miniconda3
+    source ~/miniconda3/bin/activate
 
     # Create a horton3 conda environment. (optional, recommended)
     conda create -n horton3
@@ -43,21 +45,56 @@ To install IOData using conda package management system, install
     conda install -c theochem iodata
 
     # For developers:
+    # (Only do this if you understand the implications.)
     # Install the testing release. (beta)
     conda install -c theochem/label/test iodata
     # Install the development release. (alpha)
     conda install -c theochem/label/dev iodata
 
-To install IOData with pip, you may want to create a `virtual environment`_,
-and then:
 
-.. code-block:: bash
+There are two common methods to install IOData with pip:
 
-    # Install the stable release.
-    pip install qc-iodata
+1. By creating and installing in a `virtual environment`_:
 
-    # For developers, install a pre-release (alpha or beta)
-    pip install --pre qc-iodata
+   .. code-block:: bash
+
+       # Create a virtual environment in ~/horton3
+       # Feel free to change the path.
+       python3 -m venv ~/horton3
+
+       # Activate the virtual environemnt.
+       source ~/horton3/bin/activate
+
+       # Install the stable release in the venv horton3.
+       pip3 install qc-iodata
+
+       # For developers, install a pre-release (alpha or beta).
+       # (Only do this if you understand the implications.)
+       pip3 install --pre qc-iodata
+
+2. By installing into the user ``${HOME}`` directory, without creating a
+   virtual environment.
+
+   .. code-block:: bash
+
+       # Install the sable release in your home directory.
+       pip3 install qc-iodata --user
+
+       # For developers, install a pre-release (alpha or beta).
+       # (Only do this if you understand the implications.)
+       pip3 install --pre qc-iodata --user
+
+   This is by far the simplest method, ideal to get started, but you have only
+   one home directory. If the installation breaks due to some experimentation,
+   it is harder to make a clean start in comparison to the other options.
+
+In case the ``pip3`` executable is not found, it may be installed in a directory
+which is not included in your ${PATH} variable. This seems to be a common issue
+on macOS. A simple workaround is to replace ``pip3`` by ``python3 -m pip``.
+
+On up-to-date python installs, you may also use ``pip`` instead of ``pip3`` or
+``python`` instead of ``python3``. The ``3`` is only used to avoid potential
+confusion with Python 2.
 
 
 Testing

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,21 +27,37 @@ Installation
 Python 3 (>=3.6) must be installed. Other dependencies will be pulled in with
 the instructions below.
 
-IOData can be installed with conda:
+To install IOData using conda package management system, install
+`miniconda <https://conda.io/miniconda.html>`__ or
+`anaconda <https://www.anaconda.com/download>`__ first, and then:
 
 .. code-block:: bash
 
-    conda install theochem::iodata
+    # Activate your main conda environment if needed.
 
-It can also be installed with pip. One of the following is fine, whichever you
-prefer:
+    # Create a horton3 conda environment. (optional, recommended)
+    conda create -n horton3
+    source activate horton3
+
+    # Install the stable release.
+    conda install -c theochem iodata
+
+    # For developers:
+    # Install the testing release. (beta)
+    conda install -c theochem/label/test iodata
+    # Install the development release. (alpha)
+    conda install -c theochem/label/dev iodata
+
+To install IOData with pip, you may want to create a `virtual environment`_,
+and then:
 
 .. code-block:: bash
 
-    pip install iodata
-    pip install iodata --user
-    python3 -m pip install iodata
-    python3 -m pip install iodata --user
+    # Install the stable release.
+    pip install qc-iodata
+
+    # For developers, install a pre-release (alpha or beta)
+    pip install --pre qc-iodata
 
 
 Testing
@@ -52,4 +68,12 @@ them again on your own machine after installation:
 
 .. code-block:: bash
 
-    $ pytest --pyargs iodata
+    # Install pytest in conda ...
+    conda install pytest
+    # ... or with pip.
+    pip install pytest
+    # Then run the tests.
+    pytest --pyargs iodata
+
+
+.. _virtual environment: https://docs.python.org/3/tutorial/venv.html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,18 +24,21 @@
 Installation
 ============
 
-Python 3 (>=3.6) must be installed. The following dependencies will be installed
-automatically with the instructions below:
+Python 3 (>=3.6) must be installed before you can install IOData. In addition,
+IOData has the following dependencies:
 
 - numpy >= 1.0: https://numpy.org/
 - scipy: https://scipy.org/
 - attrs >= 19.1.0: https://www.attrs.org/en/stable/index.html
 - importlib_resources [only for Python 3.6]: https://gitlab.com/python-devs/importlib_resources
 
-IOData is available as a package on:
+You only need to install these dependencies manually when installing IOData from
+source. We recommend installing IOData as a Conda or PyPI package instead, which
+will automatically install the dependencies (other than Python itself). Package
+details can be found here:
 
-- Conda, see https://anaconda.org/theochem/iodata, and
-- PyPI, see https://pypi.org/project/qc-iodata.
+- https://anaconda.org/theochem/iodata (Conda package)
+- https://pypi.org/project/qc-iodata (PyPI package)
 
 To install IOData using the conda package management system, install
 `miniconda <https://conda.io/miniconda.html>`__ or
@@ -77,10 +80,12 @@ There are two common methods to install IOData with pip:
 
        # Install the stable release in the venv horton3.
        pip3 install qc-iodata
+       # alternative: python3 -m pip install qc-iodata
 
        # For developers, install a pre-release (alpha or beta).
        # (Only do this if you understand the implications.)
        pip3 install --pre qc-iodata
+       # alternative: python3 -m pip install --pre qc-iodata
 
 2. You can install into your ``${HOME}`` directory, without creating a virtual
    environment.
@@ -89,24 +94,26 @@ There are two common methods to install IOData with pip:
 
        # Install the sable release in your home directory.
        pip3 install qc-iodata --user
+       # alternative: python3 -m pip install qc-iodata --user
 
        # For developers, install a pre-release (alpha or beta).
        # (Only do this if you understand the implications.)
        pip3 install --pre qc-iodata --user
+       # alternative: python3 -m pip install --pre qc-iodata --user
 
    This is by far the simplest method, ideal to get started, but you have only
    one home directory. If the installation breaks due to some experimentation,
    it is harder to make a clean start in comparison to the other options.
 
-In case the ``pip3`` executable is not found, it may be installed in a directory
-which is not included in your ``${PATH}`` variable. This seems to be a common
-issue on macOS. A simple workaround is to replace ``pip3`` by
+In case the ``pip3`` executable is not found, pip may be installed in a
+directory which is not included in your ``${PATH}`` variable. This seems to be a
+common issue on macOS. A simple workaround is to replace ``pip3`` by
 ``python3 -m pip``.
 
-On up-to-date python installs, you may also use ``pip`` instead of ``pip3`` or
-``python`` instead of ``python3``. The ``3`` is only used to avoid potential
-confusion with Python 2. Note that the ``3`` is only present in names of
-executables, not names of Python modules.
+In case Python and your operating system are up to date, you may also use
+``pip`` instead of ``pip3`` or ``python`` instead of ``python3``. The ``3`` is
+only used to avoid potential confusion with Python 2. Note that the ``3`` is
+only present in names of executables, not names of Python modules.
 
 
 Testing
@@ -115,7 +122,7 @@ Testing
 The tests are automatically run when we build packages with conda, but you may
 try them again on your own machine after installation.
 
-Wtih Conda:
+With Conda:
 
 .. code-block:: bash
 
@@ -131,10 +138,14 @@ With Pip:
 
     # Install pytest in your conda env ...
     pip install pytest pytest-xdist
+    # .. and refresh the virtual environment.
+    # This is a venv quirk. Without it, pytest may not find IOData.
     deactivate && source ~/horton3/activate
-    # .. or in your home directory
+
+    # Alternatively, install pytest in your home directory.
     pip install pytest pytest-xdist --user
-    # Then run the tests.
+
+    # Finally, run the tests.
     pytest --pyargs iodata -n auto
 
 

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -100,17 +100,30 @@ confusion with Python 2.
 Testing
 -------
 
-The tests are automatically run when building with conda, but you may try
-them again on your own machine after installation:
+The tests are automatically run when we build packages with conda, but you may
+try them again on your own machine after installation:
 
-.. code-block:: bash
+For Conda users:
 
-    # Install pytest in conda ...
-    conda install pytest
-    # ... or with pip.
-    pip install pytest
-    # Then run the tests.
-    pytest --pyargs iodata
+  .. code-block:: bash
+
+      # Install pytest in your conda env.
+      conda install pytest pytest-xdist
+      # Then run the tests.
+      pytest --pyargs iodata
+
+
+For pip users:
+
+  .. code-block:: bash
+
+      # Install pytest in your conda env ...
+      pip install pytest pytest-xdist
+      deactivate && source ~/horton3/activate
+      # .. or in your home directory
+      pip install pytest pytest-xdist --user
+      # Then run the tests.
+      pytest --pyargs iodata
 
 
 .. _virtual environment: https://docs.python.org/3/tutorial/venv.html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -27,7 +27,7 @@ Installation
 Python 3 (>=3.6) must be installed. Other dependencies will be pulled in with
 the instructions below.
 
-To install IOData using conda package management system, install
+To install IOData using the conda package management system, install
 `miniconda <https://conda.io/miniconda.html>`__ or
 `anaconda <https://www.anaconda.com/download>`__ first, and then:
 
@@ -54,7 +54,7 @@ To install IOData using conda package management system, install
 
 There are two common methods to install IOData with pip:
 
-1. By creating and installing in a `virtual environment`_:
+1. You can work in a `virtual environment`_:
 
    .. code-block:: bash
 
@@ -72,8 +72,8 @@ There are two common methods to install IOData with pip:
        # (Only do this if you understand the implications.)
        pip3 install --pre qc-iodata
 
-2. By installing into the user ``${HOME}`` directory, without creating a
-   virtual environment.
+2. You can install into your ``${HOME}`` directory, without creating a virtual
+   environment.
 
    .. code-block:: bash
 
@@ -89,41 +89,43 @@ There are two common methods to install IOData with pip:
    it is harder to make a clean start in comparison to the other options.
 
 In case the ``pip3`` executable is not found, it may be installed in a directory
-which is not included in your ${PATH} variable. This seems to be a common issue
-on macOS. A simple workaround is to replace ``pip3`` by ``python3 -m pip``.
+which is not included in your ``${PATH}`` variable. This seems to be a common
+issue on macOS. A simple workaround is to replace ``pip3`` by
+``python3 -m pip``.
 
 On up-to-date python installs, you may also use ``pip`` instead of ``pip3`` or
 ``python`` instead of ``python3``. The ``3`` is only used to avoid potential
-confusion with Python 2.
+confusion with Python 2. Note that the ``3`` is only present in names of
+executables, not names of Python modules.
 
 
 Testing
 -------
 
 The tests are automatically run when we build packages with conda, but you may
-try them again on your own machine after installation:
+try them again on your own machine after installation.
 
-For Conda users:
+Wtih Conda:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-      # Install pytest in your conda env.
-      conda install pytest pytest-xdist
-      # Then run the tests.
-      pytest --pyargs iodata
+    # Install pytest in your conda env.
+    conda install pytest pytest-xdist
+    # Then run the tests.
+    pytest --pyargs iodata -n auto
 
 
-For pip users:
+With Pip:
 
-  .. code-block:: bash
+.. code-block:: bash
 
-      # Install pytest in your conda env ...
-      pip install pytest pytest-xdist
-      deactivate && source ~/horton3/activate
-      # .. or in your home directory
-      pip install pytest pytest-xdist --user
-      # Then run the tests.
-      pytest --pyargs iodata
+    # Install pytest in your conda env ...
+    pip install pytest pytest-xdist
+    deactivate && source ~/horton3/activate
+    # .. or in your home directory
+    pip install pytest pytest-xdist --user
+    # Then run the tests.
+    pytest --pyargs iodata -n auto
 
 
 .. _virtual environment: https://docs.python.org/3/tutorial/venv.html

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -24,8 +24,18 @@
 Installation
 ============
 
-Python 3 (>=3.6) must be installed. Other dependencies will be pulled in with
-the instructions below.
+Python 3 (>=3.6) must be installed. The following dependencies will be installed
+automatically with the instructions below:
+
+- numpy >= 1.0: https://numpy.org/
+- scipy: https://scipy.org/
+- attrs >= 19.1.0: https://www.attrs.org/en/stable/index.html
+- importlib_resources [only for Python 3.6]: https://gitlab.com/python-devs/importlib_resources
+
+IOData is available as a package on:
+
+- Conda, see https://anaconda.org/theochem/iodata, and
+- PyPI, see https://pypi.org/project/qc-iodata.
 
 To install IOData using the conda package management system, install
 `miniconda <https://conda.io/miniconda.html>`__ or

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -92,7 +92,7 @@ There are two common methods to install IOData with pip:
 
    .. code-block:: bash
 
-       # Install the sable release in your home directory.
+       # Install the stable release in your home directory.
        pip3 install qc-iodata --user
        # alternative: python3 -m pip install qc-iodata --user
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ def get_readme():
 VERSION, DEV_CLASSIFIER = get_version_info()
 
 setup(
-    name='iodata',
+    name='qc-iodata',
     version=VERSION,
     description='Python Input and Output Library for Quantum Chemistry.',
     long_description=get_readme(),


### PR DESCRIPTION
Fixes #185. (This is also to avoid name collisions on pypi.)