### PR TITLE
Derive development classifier from git tag

### DIFF
--- a/iodata/__init__.py
+++ b/iodata/__init__.py
@@ -21,3 +21,9 @@
 
 from .iodata import IOData
 from .api import *
+
+
+try:
+    from .version import __version__
+except ImportError:
+    __version__ = "0.0.0.post0"

--- a/setup.py
+++ b/setup.py
@@ -30,15 +30,15 @@ import os
 from setuptools import setup
 
 
-def get_version():
-    """Read __version__ from version.py, with exec to avoid importing it."""
+def get_version_info():
+    """Read __version__ and classifier from version.py, using exec, not import."""
     try:
         with open(os.path.join('iodata', 'version.py'), 'r') as f:
             myglobals = {}
             exec(f.read(), myglobals)  # pylint: disable=exec-used
-        return myglobals['__version__']
+        return myglobals['__version__'], myglobals['DEV_CLASSIFIER']
     except IOError:
-        return "0.0.0.post0"
+        return "0.0.0.post0", "Development Status :: 2 - Pre-Alpha"
 
 
 def get_readme():
@@ -47,9 +47,11 @@ def get_readme():
         return fhandle.read()
 
 
+VERSION, DEV_CLASSIFIER = get_version_info()
+
 setup(
     name='iodata',
-    version=get_version(),
+    version=VERSION,
     description='Python Input and Output Library for Quantum Chemistry.',
     long_description=get_readme(),
     author='HORTON-ChemTools Dev Team',
@@ -62,7 +64,7 @@ setup(
         'console_scripts': ['iodata-convert = iodata.__main__:main']
     },
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        DEV_CLASSIFIER,
         'Environment :: Console',
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
         'Operating System :: POSIX :: Linux',


### PR DESCRIPTION
@FarnazH  This change will facilitate making releases. It takes away manual work that one would have to do normally when switching between release types (alpha, beta, stable). This works with the latest version of Roberto 1.11.0.