### PR TITLE
Enable coverage upload to codecov in Roberto

### DIFF
--- a/.roberto.yaml
+++ b/.roberto.yaml
@@ -10,6 +10,7 @@ project:
         - build-py-inplace
         - cardboardlint-dynamic
         - pytest
+        - upload-codecov
         - build-sphinx-doc
         - build-py-source
         - build-conda


### PR DESCRIPTION
I'm not sure why this was not enabled yet. It is helpful for reviewing.