### PR TITLE
Host docs on github

### DIFF
--- a/.roberto.yaml
+++ b/.roberto.yaml
@@ -12,6 +12,7 @@ project:
         - pytest
         - upload-codecov
         - build-sphinx-doc
+        - upload-docs-gh
         - build-py-source
         - build-conda
         - deploy-pypi


### PR DESCRIPTION
This change will cause the documentation on github.io to be rebuilt with every release. I've tested it manually without creating a real release. See https://theochem.github.io/iodata/