### PR TITLE
Use string `.format` method instead of `Template` module in `write_input`

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -174,7 +174,8 @@ The run types can be any of the following: ``energy``, ``energy_force``,
 keywords when the file is written.
 
 It is possible to define a custom input file template to allow for specialized
-commands. This is done by passing a template string using the optional ``template`` keyword:
+commands. This is done by passing a template string using the optional ``template`` keyword,
+placing each IOData attribute (or additional keyword, as shown below) in curly brackets:
 
 .. code-block:: python
 
@@ -188,12 +189,12 @@ commands. This is done by passing a template string using the optional ``templat
     %NProcShared=4
     %mem=16GB
     %chk=B3LYP_def2qzvp_H2O
-    #n ${lot}/${obasis_name} scf=(maxcycle=900,verytightlineq,xqc) integral=(grid=ultrafinegrid) pop=(cm5, hlygat, mbs, npa, esp)
+    #n {lot}/{obasis_name} scf=(maxcycle=900,verytightlineq,xqc) integral=(grid=ultrafinegrid) pop=(cm5, hlygat, mbs, npa, esp)
 
-    ${title}
+    {title}
 
-    ${charge} ${spinmult}
-    ${geometry}
+    {charge} {spinmult}
+    {geometry}
 
     """
     write_input(mol, "water.com", fmt="gaussian", template=custom_template)
@@ -210,13 +211,13 @@ object:
     mol.obasis_name = "Def2QZVP"
     mol.run_type = "opt"
     custom_template = """\
-    %chk=${chk_name}
-    #n ${lot}/${obasis_name} ${run_type}
+    %chk={chk_name}
+    #n {lot}/{obasis_name} {run_type}
 
-    ${title}
+    {title}
 
-    ${charge} ${spinmult}
-    ${geometry}
+    {charge} {spinmult}
+    {geometry}
 
     """
     # Custom keywords as arguments (best for few extra arguments)

--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -99,7 +99,7 @@ IOData can also be used to write different file formats:
     dump_one(mol, 'water.molden')
 
 
-One could als convert (and manipulate) an entire trajectory. The following
+One could also convert (and manipulate) an entire trajectory. The following
 example converts a geometry optimization trajectory from a Gaussian FCHK file
 to an XYZ file:
 
@@ -226,6 +226,20 @@ object:
     custom_keywords = {"chk_name": "B3LYP_def2qzvp_waters"}
     write_input(mol, "water.com", fmt="gaussian", template=custom_template, **custom_keywords)
 
+In some cases, it may be preferable to load the template from file, instead of
+defining it in the script:
+
+.. code-block:: python
+
+    from iodata import load_one, write_input
+
+    mol = load_one("water.pdb")
+    mol.lot = "B3LYP"
+    mol.obasis_name = "6-31g*"
+    mol.run_type = "opt"
+    write_input(mol, "water.com", fmt="gaussian", template=open("my_template.com", "r").read())
+
+
 Data storage
 ^^^^^^^^^^^^
 
@@ -248,8 +262,8 @@ Unit conversion
 ^^^^^^^^^^^^^^^
 
 IOData always represents all quantities in atomic units and unit conversion
-constants are defined in ``iodata.utils``. Conversion _to_ atomic units is done
-by _multiplication_ with a unit constant. This convention can be easily
+constants are defined in ``iodata.utils``. Conversion *to* atomic units is done
+by *multiplication* with a unit constant. This convention can be easily
 remembered with the following examples:
 
 - When you say "this bond length is 1.5 Å", the IOData equivalent is

--- a/iodata/inputs/gaussian.py
+++ b/iodata/inputs/gaussian.py
@@ -20,7 +20,6 @@
 
 
 from typing import TextIO
-from string import Template
 
 from .common import populate_fields
 
@@ -33,12 +32,12 @@ __all__ = []
 
 
 default_template = """\
-#n ${lot}/${obasis_name} ${run_type}
+#n {lot}/{obasis_name} {run_type}
 
-${title}
+{title}
 
-${charge} ${spinmult}
-${geometry}
+{charge} {spinmult}
+{geometry}
 
 """
 
@@ -66,4 +65,4 @@ def write_input(f: TextIO, data: IOData, template: str = None, **kwargs):
         template = default_template
     # populate files & write input
     fields.update(kwargs)
-    print(Template(template).substitute(fields), file=f)
+    print(template.format(**fields), file=f)

--- a/iodata/inputs/orca.py
+++ b/iodata/inputs/orca.py
@@ -20,7 +20,6 @@
 
 
 from typing import TextIO
-from string import Template
 
 from .common import populate_fields
 
@@ -32,10 +31,10 @@ __all__ = []
 
 
 default_template = """\
-! ${lot} ${obasis_name} ${run_type}
-# ${title}
-*xyz ${charge} ${spinmult}
-${geometry}
+! {lot} {obasis_name} {run_type}
+# {title}
+*xyz {charge} {spinmult}
+{geometry}
 *"""
 
 
@@ -65,4 +64,4 @@ def write_input(f: TextIO, data: IOData, template: str = None, **kwargs):
         template = default_template
     # populate files & write input
     fields.update(kwargs)
-    print(Template(template).substitute(fields), file=f)
+    print(template.format(**fields), file=f)

--- a/iodata/test/test_inputs.py
+++ b/iodata/test/test_inputs.py
@@ -63,18 +63,18 @@ def test_input_gaussian_from_xyz(tmpdir):
 %chk=gaussian.chk
 %mem=3500MB
 %nprocs=4
-#p ${lot}/${obasis_name} opt scf(tight,xqc,fermi) integral(grid=ultrafine) ${extra_cmd}
+#p {lot}/{obasis_name} opt scf(tight,xqc,fermi) integral(grid=ultrafine) {extra_cmd}
 
-${title} ${lot}/${obasis_name} opt-force
+{title} {lot}/{obasis_name} opt-force
 
 0 1
-${geometry}
+{geometry}
 
 --Link1--
 %chk=gaussian.chk
 %mem=3500MB
 %nprocs=4
-#p ${lot}/${obasis_name} force guess=read geom=allcheck integral(grid=ultrafine) output=wfn
+#p {lot}/{obasis_name} force guess=read geom=allcheck integral(grid=ultrafine) output=wfn
 
 gaussian.wfn
 
@@ -121,17 +121,17 @@ def test_input_orca_from_xyz(tmpdir):
     # write input in a temporary folder using the user-template
     fname = os.path.join(tmpdir, 'input_from_xyz.com')
     template = """\
-! ${lot} ${obasis_name} ${grid_stuff} KeepDens
-# ${title}
+! {lot} {obasis_name} {grid_stuff} KeepDens
+# {title}
 %output PrintLevel Mini Print[ P_Mulliken ] 1 Print[P_AtCharges_M] 1 end
 %pal nprocs 4 end
 %coords
     CTyp xyz
-    Charge ${charge}
-    Mult ${spinmult}
+    Charge {charge}
+    Mult {spinmult}
     Units Angs
     coords
-${geometry}
+{geometry}
     end
 end
 """


### PR DESCRIPTION
This replaces the Template module with the format string method, as discussed in #241. 

I felt that it would be easier to unpack the `fields` dict into the `format` method, so that the template looks like
`#n {lot}/{obasis_name} {run_type}` and not `#n {fields[lot]}/{fields[obasis_name]} {fields[run_type]}`. I don't think that will cause any problems. 

I also added another example in the docs, to show that it's possible to read a template from file, in case someone is hoping to do that.

Closes #241 