### PR TITLE
Adding additional bond type support when reading MOL2 files

### DIFF
--- a/iodata/formats/mol2.py
+++ b/iodata/formats/mol2.py
@@ -39,11 +39,12 @@ __all__ = []
 
 PATTERNS = ['*.mol2']
 
+
 # mol2 bond types
 MOL2_BOND_TYPES = ["1", "2", "3", "am", "ar", "du", "un", "nc"]
-MOL2_BOND_CONVERSION = dict(zip(MOL2_BOND_TYPES, range(len(MOL2_BOND_TYPES))))
+MOL2_BOND_CONVERSION = dict(zip(MOL2_BOND_TYPES, range(1, len(MOL2_BOND_TYPES) + 1)))
 
-@document_load_one("MOL2", ['atcoords', 'atnums', 'atcharges', 'atffparams'], ['title'])
+
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     molecule_found = False


### PR DESCRIPTION
I noticed that the mol2 format reader only supports bond types 1, 2, 3 and am
However, there are a few more defined in the original specification. This PR will add the support for these to the code.

Similar to assigning "am" to 4 it will also just assign the other bond types to increasing integers.