### PR TITLE
Allow absence of orbital coefficients

### DIFF
--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -451,7 +451,7 @@ def load_one(lit: LineIterator) -> dict:
                        oe_alpha, coeffs_alpha, obasis, restricted)
         mo = MolecularOrbitals(
             'restricted', norb, norb, 2 * orb_alpha_occs, orb_alpha_coeffs,
-            orb_alpha_energies, None)
+            orb_alpha_energies)
     else:
         norb_alpha = _get_norb_nel(oe_alpha)[0]
         norb_beta = _get_norb_nel(oe_beta)[0]
@@ -472,7 +472,6 @@ def load_one(lit: LineIterator) -> dict:
             np.concatenate((orb_alpha_occs, orb_beta_occs), axis=0),
             np.concatenate((orb_alpha_coeffs, orb_beta_coeffs), axis=1),
             np.concatenate((orb_alpha_energies, orb_beta_energies), axis=0),
-            None,
         )
 
     result = {

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -191,7 +191,7 @@ def load_one(lit: LineIterator) -> dict:
         mo_occs = np.zeros(norba + norbb)
         mo_occs[:nalpha] = 1.0
         mo_occs[norba: norba + nbeta] = 1.0
-        mo = MolecularOrbitals('unrestricted', norba, norbb, mo_occs, mo_coeffs, mo_energies, None)
+        mo = MolecularOrbitals('unrestricted', norba, norbb, mo_occs, mo_coeffs, mo_energies)
     else:
         # restricted closed-shell and open-shell
         mo_occs = np.zeros(norba)
@@ -201,7 +201,7 @@ def load_one(lit: LineIterator) -> dict:
             # delete dm_full_scf because it is known to be buggy
             if 'scf' in result['one_rdms']:
                 result['one_rdms'].pop('scf')
-        mo = MolecularOrbitals('restricted', norba, norba, mo_occs, mo_coeffs, mo_energies, None)
+        mo = MolecularOrbitals('restricted', norba, norba, mo_occs, mo_coeffs, mo_energies)
     result['mo'] = mo
 
     # E) Load properties

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -58,25 +58,23 @@ def load_one(lit: LineIterator) -> dict:
     # restricted case
     if not data['unrestricted']:
         mo_energies = np.concatenate((data['mo_a_occ'], data['mo_a_vir']), axis=0)
-        mo_coeffs = np.full((data['nbasis'], data['norba']), np.nan)
-        mo_occs = np.zeros(mo_coeffs.shape[1])
+        mo_occs = np.zeros(data['norba'])
         mo_occs[:data['alpha_elec']] = 1.0
         mo_occs[:data['beta_elec']] += 1.0
         mo = MolecularOrbitals("restricted", data['norba'], data['norba'],
-                               mo_occs, mo_coeffs, mo_energies, None)
+                               occs=mo_occs, energies=mo_energies)
     # unrestricted case
     else:
         mo_energies = np.concatenate((data['mo_a_occ'], data['mo_a_vir'],
                                       data['mo_b_occ'], data['mo_b_vir']), axis=0)
-        mo_coeffs = np.full((data['nbasis'], data['norba'] + data['norbb']), np.nan)
-        mo_occs = np.zeros(mo_coeffs.shape[1])
+        mo_occs = np.zeros(data['norba'] + data['norbb'])
         # number of alpha & beta electrons and number of alpha molecular orbitals
         na, nb = data['alpha_elec'], data['beta_elec']
         na_mo = len(data['mo_a_occ']) + len(data['mo_a_vir'])
         mo_occs[:na] = 1.0
         mo_occs[na_mo: na_mo + nb] = 1.0
         mo = MolecularOrbitals("unrestricted", data['norba'], data['norbb'],
-                               mo_occs, mo_coeffs, mo_energies, None)
+                               occs=mo_occs, energies=mo_energies)
     result['mo'] = mo
 
     # moments

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -407,12 +407,12 @@ def load_one(lit: LineIterator) -> dict:
         # Restricted wavefunction.
         mo = MolecularOrbitals(
             'restricted', norb_a + norb_ab, norb_a + norb_ab,
-            mo_occs, mo_coeffs, mo_energies, None)
+            mo_occs, mo_coeffs, mo_energies)
     else:
         # Unrestricted wavefunction.
         mo = MolecularOrbitals(
             'unrestricted', norb_a, norb_b,
-            mo_occs, mo_coeffs, mo_energies, None)
+            mo_occs, mo_coeffs, mo_energies)
     return {
         'title': title,
         'atcoords': atcoords,

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -268,7 +268,7 @@ def load_one(lit: LineIterator) -> dict:
         # conventions for norba and norbb, see orbitals.py for details.
         mo = MolecularOrbitals(
             "restricted", norba, norba,  # This is not a typo!
-            data['mo_occs'], data['mo_coeffs'], data['mo_energies'], None)
+            data['mo_occs'], data['mo_coeffs'], data['mo_energies'])
 
     # unrestricted case with "Alpha" and "Beta" in mo_spins
     else:
@@ -284,7 +284,7 @@ def load_one(lit: LineIterator) -> dict:
         # conventions as WFX.
         mo = MolecularOrbitals(
             "unrestricted", norba, norbb,
-            data['mo_occs'], data['mo_coeffs'], data['mo_energies'], None)
+            data['mo_occs'], data['mo_coeffs'], data['mo_energies'])
 
     # prepare WFX-specific data for IOData
     extra_labels = ['keywords', 'model_name', 'num_perturbations', 'num_core_electrons',

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -127,7 +127,7 @@ class MolecularOrbitals:
         return self.coeffs.shape[0]
 
     @property
-    def norb(self):
+    def norb(self):  # pylint: disable=too-many-return-statements
         """Return the number of spatially distinct orbitals.
 
         Notes

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -93,10 +93,8 @@ class MolecularOrbitals:
 
     kind: str = attr.ib(
         validator=attr.validators.in_(["restricted", "unrestricted", "generalized"]))
-    norba: int = attr.ib(
-        default=None, validator=validate_norbab)
-    norbb: int = attr.ib(
-        default=None, validator=validate_norbab)
+    norba: int = attr.ib(validator=validate_norbab)
+    norbb: int = attr.ib(validator=validate_norbab)
     occs: np.ndarray = attr.ib(
         default=None, converter=convert_array_to(float),
         validator=attr.validators.optional(validate_shape("norb")))

--- a/iodata/orbitals.py
+++ b/iodata/orbitals.py
@@ -22,10 +22,37 @@
 import attr
 import numpy as np
 
-from .attrutils import validate_shape
+from .attrutils import convert_array_to, validate_shape
 
 
 __all__ = ['MolecularOrbitals']
+
+
+def validate_norbab(mo, attribute, value):
+    """Validate the norba or norbb value assigned to a MolecularOrbitals object.
+
+    Parameters
+    ----------
+    mo
+        The MolecularOrbitals instance.
+    attribute
+        Attribute instancce being changed.
+    value
+        The new value.
+
+    """
+    if mo.kind == "generalized":
+        if value is not None:
+            raise ValueError(
+                f"Attribute {attribute.name} must be None in case of generalized orbitals.")
+        return
+    if value is None:
+        raise ValueError(
+            f"Attribute {attribute.name} cannot be None in case of (un)restricted orbitals.")
+    if mo.kind == "restricted":
+        norb_other = mo.norbb if (attribute.name == "norba") else mo.norba
+        if value != norb_other:
+            raise ValueError("In case of restricted orbitals, norba must be equal to norbb.")
 
 
 @attr.s(auto_attribs=True, slots=True,
@@ -64,116 +91,162 @@ class MolecularOrbitals:
 
     """
 
-    kind: str
-    norba: int
-    norbb: int
+    kind: str = attr.ib(
+        validator=attr.validators.in_(["restricted", "unrestricted", "generalized"]))
+    norba: int = attr.ib(
+        default=None, validator=validate_norbab)
+    norbb: int = attr.ib(
+        default=None, validator=validate_norbab)
     occs: np.ndarray = attr.ib(
-        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
-    coeffs: np.ndarray = attr.ib(validator=validate_shape(None, None))
+        default=None, converter=convert_array_to(float),
+        validator=attr.validators.optional(validate_shape("norb")))
+    coeffs: np.ndarray = attr.ib(
+        default=None, converter=convert_array_to(float),
+        validator=attr.validators.optional(validate_shape(None, "norb")))
     energies: np.ndarray = attr.ib(
-        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
+        default=None, converter=convert_array_to(float),
+        validator=attr.validators.optional(validate_shape("norb")))
     irreps: np.ndarray = attr.ib(
-        validator=attr.validators.optional(validate_shape(("coeffs", 1))))
+        default=None,
+        validator=attr.validators.optional(validate_shape("norb")))
 
     @property
     def nelec(self) -> float:
         """Return the total number of electrons."""
+        if self.occs is None:
+            return None
         return self.occs.sum()
 
     @property
     def nbasis(self):
         """Return the number of spatial basis functions."""
+        if self.coeffs is None:
+            return None
         if self.kind == 'generalized':
             return self.coeffs.shape[0] // 2
         return self.coeffs.shape[0]
 
     @property
     def norb(self):
-        """Return the number of orbitals."""
-        return self.coeffs.shape[1]
+        """Return the number of spatially distinct orbitals.
+
+        Notes
+        -----
+        In case of restricted wavefunctions, this may be less than just the
+        sum of ``norba`` and ``norbb``, because alpha and beta orbitals share
+        the same spatical dependence.
+
+        """
+        if self.kind == "restricted":
+            return self.norba
+        if self.kind == "unrestricted":
+            return self.norba + self.norbb
+        if self.coeffs is not None:
+            return self.coeffs.shape[1]
+        if self.occs is not None:
+            return self.occs.shape[0]
+        if self.energies is not None:
+            return self.energies.shape[0]
+        if self.irreps is not None:
+            return len(self.irreps)
+        return None
 
     @property
     def spinpol(self) -> float:
         """Return the spin polarization of the Slater determinant."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.occs is None:
+            return None
         if self.kind == 'restricted':
             nbeta = np.clip(self.occs, 0, 1).sum()
             return abs(self.nelec - 2 * nbeta)
-        if self.kind == 'unrestricted':
-            return abs(self.occsa.sum() - self.occsb.sum())
-        raise NotImplementedError
+        return abs(self.occsa.sum() - self.occsb.sum())
 
     @property
     def occsa(self):
         """Return alpha occupation numbers."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.occs is None:
+            return None
         if self.kind == 'restricted':
             return np.clip(self.occs, 0, 1)
-        if self.kind == 'unrestricted':
-            return self.occs[:self.norba]
-        raise NotImplementedError
+        return self.occs[:self.norba]
 
     @property
     def occsb(self):
         """Return beta occupation numbers."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.occs is None:
+            return None
         if self.kind == 'restricted':
             return self.occs - np.clip(self.occs, 0, 1)
-        if self.kind == 'unrestricted':
-            return self.occs[self.norba:]
-        raise NotImplementedError
+        return self.occs[self.norba:]
 
     @property
     def coeffsa(self):
         """Return alpha orbital coefficients."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.coeffs is None:
+            return None
         if self.kind == 'restricted':
             return self.coeffs
-        if self.kind == 'unrestricted':
-            return self.coeffs[:, :self.norba]
-        raise NotImplementedError
+        return self.coeffs[:, :self.norba]
 
     @property
     def coeffsb(self):
         """Return beta orbital coefficients."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.coeffs is None:
+            return None
         if self.kind == 'restricted':
             return self.coeffs
-        if self.kind == 'unrestricted':
-            return self.coeffs[:, self.norba:]
-        raise NotImplementedError
-
-    @property
-    def irrepsa(self):
-        """Return alpha irreps."""
-        if self.irreps is None:
-            return None
-        if self.kind == 'restricted':
-            return self.irreps
-        if self.kind == 'unrestricted':
-            return self.irreps[:self.norba]
-        raise NotImplementedError
-
-    @property
-    def irrepsb(self):
-        """Return beta irreps."""
-        if self.irreps is None:
-            return None
-        if self.kind == 'restricted':
-            return self.irreps
-        if self.kind == 'unrestricted':
-            return self.irreps[self.norba:]
-        raise NotImplementedError
+        return self.coeffs[:, self.norba:]
 
     @property
     def energiesa(self):
         """Return alpha orbital energies."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.energies is None:
+            return None
         if self.kind == 'restricted':
             return self.energies
-        if self.kind == 'unrestricted':
-            return self.energies[:self.norba]
-        raise NotImplementedError
+        return self.energies[:self.norba]
 
     @property
     def energiesb(self):
         """Return beta orbital energies."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.energies is None:
+            return None
         if self.kind == 'restricted':
             return self.energies
-        if self.kind == 'unrestricted':
-            return self.energies[self.norba:]
-        raise NotImplementedError
+        return self.energies[self.norba:]
+
+    @property
+    def irrepsa(self):
+        """Return alpha irreps."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.irreps is None:
+            return None
+        if self.kind == 'restricted':
+            return self.irreps
+        return self.irreps[:self.norba]
+
+    @property
+    def irrepsb(self):
+        """Return beta irreps."""
+        if self.kind == "generalized":
+            raise NotImplementedError
+        if self.irreps is None:
+            return None
+        if self.kind == 'restricted':
+            return self.irreps
+        return self.irreps[self.norba:]

--- a/iodata/test/test_orbitals.py
+++ b/iodata/test/test_orbitals.py
@@ -1,0 +1,395 @@
+# IODATA is an input and output module for quantum chemistry.
+# Copyright (C) 2011-2019 The IODATA Development Team
+#
+# This file is part of IODATA.
+#
+# IODATA is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 3
+# of the License, or (at your option) any later version.
+#
+# IODATA is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, see <http://www.gnu.org/licenses/>
+# --
+# pylint: disable=pointless-statement
+"""Unit tests for iodata.orbitals."""
+
+
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+
+from ..orbitals import MolecularOrbitals
+
+
+def test_wrong_kind():
+    with pytest.raises(ValueError):
+        MolecularOrbitals("foo", 5, 5)
+
+
+def test_restricted_empty():
+    with pytest.raises(ValueError):
+        MolecularOrbitals("restricted", 3, None)
+    with pytest.raises(ValueError):
+        MolecularOrbitals("restricted", None, 5)
+    with pytest.raises(ValueError):
+        MolecularOrbitals("restricted", None, None)
+    with pytest.raises(ValueError):
+        MolecularOrbitals("restricted", 5, 3)
+    mo = MolecularOrbitals("restricted", 5, 5)
+    assert mo.norba == 5
+    assert mo.norbb == 5
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 5
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_restricted_occs():
+    occs = [2, 2, 0, 0, 0]
+    with pytest.raises(TypeError):
+        MolecularOrbitals("restricted", 3, 3, occs=occs)
+    mo = MolecularOrbitals("restricted", 5, 5, occs=occs)
+    assert mo.norba == 5
+    assert mo.norbb == 5
+    assert mo.nelec == 4
+    assert mo.nbasis is None
+    assert mo.norb == 5
+    assert mo.spinpol == 0
+    assert_equal(mo.occsa, [1, 1, 0, 0, 0])
+    assert_equal(mo.occsb, [1, 1, 0, 0, 0])
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_restricted_coeffs():
+    coeffs = np.random.uniform(-1, 1, (7, 5))
+    with pytest.raises(TypeError):
+        MolecularOrbitals("restricted", 3, 3, coeffs=coeffs)
+    mo = MolecularOrbitals("restricted", 5, 5, coeffs=coeffs)
+    assert mo.norba == 5
+    assert mo.norbb == 5
+    assert mo.nelec is None
+    assert mo.nbasis == 7
+    assert mo.norb == 5
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is coeffs
+    assert mo.coeffsb is coeffs
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_restricted_energies():
+    energies = np.random.uniform(-1, 1, 5)
+    with pytest.raises(TypeError):
+        MolecularOrbitals("restricted", 3, 3, energies=energies)
+    mo = MolecularOrbitals("restricted", 5, 5, energies=energies)
+    assert mo.norba == 5
+    assert mo.norbb == 5
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 5
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is energies
+    assert mo.energiesb is energies
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_restricted_irreps():
+    irreps = ["A", "A", "B", "A", "B"]
+    with pytest.raises(TypeError):
+        MolecularOrbitals("restricted", 3, 3, irreps=irreps)
+    mo = MolecularOrbitals("restricted", 5, 5, irreps=irreps)
+    assert mo.norba == 5
+    assert mo.norbb == 5
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 5
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is irreps
+    assert mo.irrepsb is irreps
+
+
+def test_unrestricted_empty():
+    with pytest.raises(ValueError):
+        MolecularOrbitals("unrestricted", 3, None)
+    with pytest.raises(ValueError):
+        MolecularOrbitals("unrestricted", None, 5)
+    with pytest.raises(ValueError):
+        MolecularOrbitals("unrestricted", None, None)
+    mo = MolecularOrbitals("unrestricted", 5, 3)
+    assert mo.norba == 5
+    assert mo.norbb == 3
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 8
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_unrestricted_occs():
+    occs = [1, 1, 0, 0, 0, 1, 0, 0]
+    with pytest.raises(TypeError):
+        MolecularOrbitals("unrestricted", 3, 2, occs=occs)
+    mo = MolecularOrbitals("unrestricted", 5, 3, occs=occs)
+    assert mo.norba == 5
+    assert mo.norbb == 3
+    assert mo.nelec == 3
+    assert mo.nbasis is None
+    assert mo.norb == 8
+    assert mo.spinpol == 1
+    assert_equal(mo.occsa, [1, 1, 0, 0, 0])
+    assert_equal(mo.occsb, [1, 0, 0])
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_unrestricted_coeffs():
+    coeffs = np.random.uniform(-1, 1, (7, 8))
+    with pytest.raises(TypeError):
+        MolecularOrbitals("unrestricted", 3, 2, coeffs=coeffs)
+    mo = MolecularOrbitals("unrestricted", 5, 3, coeffs=coeffs)
+    assert mo.norba == 5
+    assert mo.norbb == 3
+    assert mo.nelec is None
+    assert mo.nbasis == 7
+    assert mo.norb == 8
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert_equal(mo.coeffsa, coeffs[:, :5])
+    assert_equal(mo.coeffsb, coeffs[:, 5:])
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_unrestricted_energies():
+    energies = np.random.uniform(-1, 1, 8)
+    with pytest.raises(TypeError):
+        MolecularOrbitals("unrestricted", 3, 2, energies=energies)
+    mo = MolecularOrbitals("unrestricted", 5, 3, energies=energies)
+    assert mo.norba == 5
+    assert mo.norbb == 3
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 8
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert_equal(mo.energiesa, energies[:5])
+    assert_equal(mo.energiesb, energies[5:])
+    assert mo.irrepsa is None
+    assert mo.irrepsb is None
+
+
+def test_unrestricted_irreps():
+    irreps = ["A", "A", "B", "A", "B", "B", "B", "A"]
+    with pytest.raises(TypeError):
+        MolecularOrbitals("unrestricted", 3, 2, irreps=irreps)
+    mo = MolecularOrbitals("unrestricted", 5, 3, irreps=irreps)
+    assert mo.norba == 5
+    assert mo.norbb == 3
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 8
+    assert mo.spinpol is None
+    assert mo.occsa is None
+    assert mo.occsb is None
+    assert mo.coeffsa is None
+    assert mo.coeffsb is None
+    assert mo.energiesa is None
+    assert mo.energiesb is None
+    # irreps are lists, not arrays
+    assert mo.irrepsa == irreps[:5]
+    assert mo.irrepsb == irreps[5:]
+
+
+def test_generalized_empty():
+    with pytest.raises(ValueError):
+        mo = MolecularOrbitals("generalized", 5, 3)
+    with pytest.raises(ValueError):
+        mo = MolecularOrbitals("generalized", 5, None)
+    with pytest.raises(ValueError):
+        mo = MolecularOrbitals("generalized", None, 3)
+    mo = MolecularOrbitals("generalized", None, None)
+    assert mo.norba is None
+    assert mo.norbb is None
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb is None
+    with pytest.raises(NotImplementedError):
+        mo.spinpol
+    with pytest.raises(NotImplementedError):
+        mo.occsa
+    with pytest.raises(NotImplementedError):
+        mo.occsb
+    with pytest.raises(NotImplementedError):
+        mo.coeffsa
+    with pytest.raises(NotImplementedError):
+        mo.coeffsb
+    with pytest.raises(NotImplementedError):
+        mo.energiesa
+    with pytest.raises(NotImplementedError):
+        mo.energiesb
+    with pytest.raises(NotImplementedError):
+        mo.irrepsa
+    with pytest.raises(NotImplementedError):
+        mo.irrepsb
+
+
+def test_generalized_occs():
+    mo = MolecularOrbitals("generalized", None, None, occs=[1, 1, 1, 1, 1, 0, 0])
+    assert mo.norba is None
+    assert mo.norbb is None
+    assert mo.nelec == 5
+    assert mo.nbasis is None
+    assert mo.norb == 7
+    with pytest.raises(NotImplementedError):
+        mo.spinpol
+    with pytest.raises(NotImplementedError):
+        mo.occsa
+    with pytest.raises(NotImplementedError):
+        mo.occsb
+    with pytest.raises(NotImplementedError):
+        mo.coeffsa
+    with pytest.raises(NotImplementedError):
+        mo.coeffsb
+    with pytest.raises(NotImplementedError):
+        mo.energiesa
+    with pytest.raises(NotImplementedError):
+        mo.energiesb
+    with pytest.raises(NotImplementedError):
+        mo.irrepsa
+    with pytest.raises(NotImplementedError):
+        mo.irrepsb
+
+
+def test_generalized_coeffs():
+    coeffs = np.random.uniform(-1, 1, (10, 7))
+    mo = MolecularOrbitals("generalized", None, None, coeffs=coeffs)
+    assert mo.norba is None
+    assert mo.norbb is None
+    assert mo.nelec is None
+    assert mo.nbasis == 5  # 5 *spatial* basis functions!
+    assert mo.norb == 7
+    with pytest.raises(NotImplementedError):
+        mo.spinpol
+    with pytest.raises(NotImplementedError):
+        mo.occsa
+    with pytest.raises(NotImplementedError):
+        mo.occsb
+    with pytest.raises(NotImplementedError):
+        mo.coeffsa
+    with pytest.raises(NotImplementedError):
+        mo.coeffsb
+    with pytest.raises(NotImplementedError):
+        mo.energiesa
+    with pytest.raises(NotImplementedError):
+        mo.energiesb
+    with pytest.raises(NotImplementedError):
+        mo.irrepsa
+    with pytest.raises(NotImplementedError):
+        mo.irrepsb
+
+
+def test_generalized_energies():
+    energies = np.random.uniform(-1, 1, 7)
+    mo = MolecularOrbitals("generalized", None, None, energies=energies)
+    assert mo.norba is None
+    assert mo.norbb is None
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 7
+    with pytest.raises(NotImplementedError):
+        mo.spinpol
+    with pytest.raises(NotImplementedError):
+        mo.occsa
+    with pytest.raises(NotImplementedError):
+        mo.occsb
+    with pytest.raises(NotImplementedError):
+        mo.coeffsa
+    with pytest.raises(NotImplementedError):
+        mo.coeffsb
+    with pytest.raises(NotImplementedError):
+        mo.energiesa
+    with pytest.raises(NotImplementedError):
+        mo.energiesb
+    with pytest.raises(NotImplementedError):
+        mo.irrepsa
+    with pytest.raises(NotImplementedError):
+        mo.irrepsb
+
+
+def test_generalized_irreps():
+    irreps = ["A", "B", "A", "A", "B", "B", "B"]
+    mo = MolecularOrbitals("generalized", None, None, irreps=irreps)
+    assert mo.norba is None
+    assert mo.norbb is None
+    assert mo.nelec is None
+    assert mo.nbasis is None
+    assert mo.norb == 7
+    with pytest.raises(NotImplementedError):
+        mo.spinpol
+    with pytest.raises(NotImplementedError):
+        mo.occsa
+    with pytest.raises(NotImplementedError):
+        mo.occsb
+    with pytest.raises(NotImplementedError):
+        mo.coeffsa
+    with pytest.raises(NotImplementedError):
+        mo.coeffsb
+    with pytest.raises(NotImplementedError):
+        mo.energiesa
+    with pytest.raises(NotImplementedError):
+        mo.energiesb
+    with pytest.raises(NotImplementedError):
+        mo.irrepsa
+    with pytest.raises(NotImplementedError):
+        mo.irrepsb


### PR DESCRIPTION
Fixes #168 

This PR was initially intended to address a minor issue of the QChem log file loader, namely that it initialized an array full of `nan`s for the orbital coefficients, because the `MolecularOrbitals` class insisted on having this array. This PR fixes that limitation and allows `None` for the array of orbital coefficients. In addition, other attributes are also allowed to be None, without breaking functionality. There were no unit tests for the `MolecularOrbitals` class, so these are now included as well. The API remains fully backward compatible.