### PR TITLE
Temporarily change install instructions in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,28 +51,41 @@ Please use the following citation in any publication using IOData library:
 Installation
 ------------
 
-To install IOData using the conda package management system, install
-`miniconda <https://conda.io/miniconda.html>`__ or
-`anaconda <https://www.anaconda.com/download>`__ first, and then:
+..
+
+    : To install IOData using the conda package management system, install
+    : `miniconda <https://conda.io/miniconda.html>`__ or
+    : `anaconda <https://www.anaconda.com/download>`__ first, and then:
+    :
+    : .. code-block:: bash
+    :
+    :     # Create a horton3 conda environment. (optional, recommended)
+    :     conda create -n horton3
+    :     source activate horton3
+    :
+    :     # Install the stable release.
+    :     conda install -c theochem iodata
+    :
+    : To install IOData with pip, you may want to create a `virtual environment`_,
+    : and then:
+    :
+    : .. code-block:: bash
+    :
+    :     # Install the stable release.
+    :     pip install qc-iodata
+
+In anticipation of the 1.0 release of IOData, install the latest git revision
+as follows:
 
 .. code-block:: bash
 
-    # Create a horton3 conda environment. (optional, recommended)
-    conda create -n horton3
-    source activate horton3
+    python -m pip install git+https://github.com/theochem/iodata.git
 
-    # Install the stable release.
-    conda install -c theochem iodata
-
-To install IOData with pip, you may want to create a `virtual environment`_,
-and then:
-
-.. code-block:: bash
-
-    # Install the stable release.
-    pip install qc-iodata
+Add the ``--user`` argument if you are not working in a virtual or conda
+environment. Note that there may be API changes between subsequent revisions.
 
 See https://iodata.readthedocs.io/en/latest/install.html for full details.
+
 
 .. |GithubActions| image:: https://github.com/theochem/iodata/actions/workflows/ci.yml/badge.svg?branch=master
     :target: https://github.com/theochem/iodata/actions/workflows/ci.yml

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,6 @@ Installation
 ------------
 
 ..
-
     : To install IOData using the conda package management system, install
     : `miniconda <https://conda.io/miniconda.html>`__ or
     : `anaconda <https://www.anaconda.com/download>`__ first, and then:


### PR DESCRIPTION
I've commented out the install instructions for the stable release in replaced it by the install from git. This is a temporary change, until we have a first API-stable release.