### PR TITLE
Avoid 'is False'

### DIFF
--- a/iodata/formats/mol2.py
+++ b/iodata/formats/mol2.py
@@ -75,7 +75,7 @@ def load_one(lit: LineIterator) -> dict:
             if words[0] == "@<TRIPOS>BOND":
                 bonds = _load_helper_bonds(lit, nbonds)
                 result['bonds'] = bonds
-    if molecule_found is False:
+    if not molecule_found:
         raise lit.error("Molecule could not be read")
     return result
 


### PR DESCRIPTION
The old code goes against PEP8. See https://www.python.org/dev/peps/pep-0008/ (Look for `Don't compare boolean values to True or False`) A similar issue in `pdb.py` is being fixed in PR #250.