### PR TITLE
Update matrix os & python-version of CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Fetch base branch (usually master)
+        shell: bash
         run: |
           if [[ -n "${GITHUB_HEAD_REF}" ]]; then
             git fetch origin ${GITHUB_BASE_REF} --depth=2
@@ -43,10 +44,12 @@ jobs:
           path: ~/.local/venvs
           key: ${{ runner.os }}-Python-${{ matrix.python-version }}-venv
       - name: Install Pip and Roberto
+        shell: bash
         run: |
           python -m pip install --upgrade pip
           python -m pip install roberto>=2.0.0
       - name: Test with Roberto
+        shell: bash
         run: |
           if [[ -n "${GITHUB_HEAD_REF}" ]]; then
             ROBERTO_GIT_MERGE_BRANCH=${GITHUB_SHA} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,15 +17,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            python-version: 3.7
-          - os: ubuntu-latest
-            python-version: 3.8
-          - os: ubuntu-latest
-            python-version: 3.9
-          - os: macos-latest
-            python-version: 3.7
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: [3.6, 3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
     env:
       # Tell Roberto to upload coverage results
       ROBERTO_UPLOAD_COVERAGE: 1
+      COMSPEC: bash
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
 
     runs-on: ${{ matrix.os }}
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,14 +17,24 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+          - os: ubuntu-latest
+            python-version: 3.8
+          - os: ubuntu-latest
+            python-version: 3.9
+          - os: macos-latest
+            python-version: 3.9
+          - os: windows-latest
+            python-version: 3.9
 
     runs-on: ${{ matrix.os }}
     env:
-      # Tell Roberto to upload coverage results
+      # Tell Roberto to upload coverage results.
       ROBERTO_UPLOAD_COVERAGE: 1
-      COMSPEC: bash
+      # Tell invoke to use Bash on Windows.
+      COMSPEC: 'C:\Program Files\Git\bin\bash.EXE'
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
The CI workflow's matrix is updated to test all various versions of Python for various operating systems (including windows).  Only a subset of these combinations was used before. Is this useful @tovrstra?

Now I see all the Window's tests failing. Does the `ci.yml` need to be updated?