### PR TITLE
Disable caching on venv tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,10 +45,6 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
-      - uses: actions/cache@v2
-        with:
-          path: ~/.local/venvs
-          key: ${{ runner.os }}-Python-${{ matrix.python-version }}-venv
       - name: Install Pip and Roberto
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
The caching in Github Actions seems to break easily. (This is probably due to limited storage for the caches, not sure.) I'm keeping cache in place for the conda test on the master branch, but not for venv tests which run for each PR.

I'll merge this as soon as tests pass because this issue affects all other PRs.