### PR TITLE
Add exception for new pylint check

### DIFF
--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -72,7 +72,7 @@ class LineIterator:
 
         """
         self.filename = filename
-        self.f = open(filename)
+        self.f = open(filename)  # pylint: disable=consider-using-with
         self.lineno = 0
         self.stack = []
 


### PR DESCRIPTION
Tests on the master branch fail because of a Pylint upgrade. I'll merge this (trivial) fix when tests have passed.