### PR TITLE
Fix missing `M END` tag for SDF format, close #266

### DIFF
--- a/iodata/formats/sdf.py
+++ b/iodata/formats/sdf.py
@@ -120,6 +120,7 @@ def dump_one(f: TextIO, data: IOData):
             print('{:3d}{:3d}{:3d}  0  0  0  0'.format(
                 iatom + 1, jatom + 1, bondtype
             ), file=f)
+    print('M  END', file=f)
     print('$$$$', file=f)
 
 


### PR DESCRIPTION
Because we are missing **M END** tag when dumping a molecule, the dumped molecule can not be recognized by molecular packages, such as `OpenBabel` or `RDKit`. This PR fixes this problem and should close #266.