### PR TITLE
Deal with pylint issues

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -126,7 +126,8 @@ disable=
     unsubscriptable-object,
     no-member,
     too-many-lines,
-    unspecified-encoding
+    unspecified-encoding,
+    bad-option-value
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/.roberto.yaml
+++ b/.roberto.yaml
@@ -1,7 +1,11 @@
 absolute: true  # Force absolute comparison for cardboardlint
 project:
   name: iodata
-  requirements: [[sympy, sympy]]
+  requirements: [
+    [sympy, sympy],
+    # pylint 2.11.* seems to have bugs which break the CI.
+    ["pylint <2.11.0", "pylint<2.11.0"]
+  ]
   packages:
     - dist_name: qc-iodata
       tools:


### PR DESCRIPTION
Pylint 2.11.x seems to fail for some reason. This is a temporary workaround. This is a preparation before fixing #282. Will be merged as soon as it passes.