### PR TITLE
Add MO-basis RDMs fields

### DIFF
--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -164,8 +164,8 @@ def load_one(lit: LineIterator) -> dict:
     _load_dm('Spin SCF Density', fchk, one_rdms, 'scf_spin')
     # only one of the lots should be present, hence using the same key
     for lot in 'MP2', 'MP3', 'CC', 'CI':
-        _load_dm('Total {} Density'.format(lot), fchk, one_rdms, 'post_scf')
-        _load_dm('Spin {} Density'.format(lot), fchk, one_rdms, 'post_scf_spin')
+        _load_dm('Total {} Density'.format(lot), fchk, one_rdms, 'post_scf_ao')
+        _load_dm('Spin {} Density'.format(lot), fchk, one_rdms, 'post_scf_spin_ao')
     if one_rdms:
         result['one_rdms'] = one_rdms
 
@@ -617,9 +617,9 @@ def dump_one(f: TextIO, data: IOData):
             title = "Total SCF Density"
         elif key == "scf_spin":
             title = "Spin SCF Density"
-        elif key == "post_scf":
+        elif key == "post_scf_ao":
             title = "Total {0} Density".format(level)
-        elif key == "post_scf_spin":
+        elif key == "post_scf_spin_ao":
             title = "Spin {0} Density".format(level)
         else:
             title = "Total SCF Density"

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -129,20 +129,25 @@ class IOData:
         www.basissetexchange.org.
     one_ints
         Dictionary where keys are names and values are numpy arrays with
-        one-body operators, typically integrals of a one-body operator
-        with a pair of (Gaussian) basis functions. Names can start with ``olp``
+        one-body operators, typically integrals of a one-body operator with
+        a pair of (Gaussian) basis functions. Names can start with ``olp``
         (overlap), ``kin`` (kinetic energy), ``na`` (nuclear attraction),
-        ``core`` (core hamiltonian), etc. When relevant, these names must have a
-        suffix ``_ao`` or ``_mo`` to clarify in which basis the integrals are
-        computed. ``_ao`` is used to denote integrals in a non-orthogonal
-        (atomic orbital) basis. ``_mo`` is used to denote an orthogonal
-        (molecular orbital) basis. For the overlap integrals, this suffix can be
-        omitted because it is only useful to compute them in the atomic-orbital
-        basis.
+        ``core`` (core hamiltonian), etc., or ``one`` (general one-electron
+        integral). When relevant, these names must have a suffix ``_ao`` or
+        ``_mo`` to clarify in which basis the integrals are computed. ``_ao``
+        is used to denote integrals in a non-orthogonal (atomic orbital) basis.
+        ``_mo`` is used to denote an orthogonal (molecular orbital) basis. For
+        the overlap integrals, this suffix can be omitted because it is only
+        useful to compute them in the atomic-orbital basis.
     one_rdms
         Dictionary where keys are names and values are one-particle density
         matrices. Names can be ``scf``, ``post_scf``, ``scf_spin``,
-        ``post_scf_spin``. These matrices are always expressed in the AO basis.
+        ``post_scf_spin``. When relevant, these names must have a suffix
+        ``_ao`` or ``_mo`` to clarify in which basis the RDMs are computed.
+        ``_ao`` is used to denote a non-orthogonal (atomic orbital) basis.
+        ``_mo`` is used to denote an orthogonal (molecular orbital) basis.
+        For the SCF RDMs, this suffix can be omitted because it is only useful
+        to compute them in the atomic-orbital basis.
     run_type
         The type of calculation that lead to the results stored in IOData, which
         must be one of the following: 'energy', 'energy_force', 'opt', 'scan',
@@ -156,17 +161,18 @@ class IOData:
          A suitable name for the data.
     two_ints
         Dictionary where keys are names and values are numpy arrays with
-        two-body operators, typically integrals of two-body operator
-        with four of (Gaussian) basis functions. Names can start with ``er``
-        (electron repulsion) or ``two`` (general pairswise interaction). When
-        relevant, these names must have a suffix ``_ao`` or ``_mo`` to clarify
-        in which basis the integrals are computed, see one_ints for more
-        details. Array indexes are in physicist's notation.
+        two-body operators, typically integrals of two-body operator with four
+        of (Gaussian) basis functions. Names can start with ``er`` (electron
+        repulsion) or ``two`` (general pairswise interaction). When relevant,
+        these names must have a suffix ``_ao`` or ``_mo`` to clarify in which
+        basis the integrals are computed. See ``one_ints`` for more details.
+        Array indexes are in physicist's notation.
     two_rdms
         Dictionary where keys are names and values are two-particle density
-        matrices. Names can be ``post_scf`` or ``post_scf_spin``. These matrices
-        are always expressed in the AO basis. Array indexes are in physicist's
-        notation.
+        matrices. Names can be ``post_scf`` or ``post_scf_spin``. When relevant,
+        these names must have a suffix ``_ao`` or ``_mo`` to clarify in which
+        basis the RDMs are computed. See ``one_rdms`` for more details.
+        Array indexes are in physicist's notation.
 
     """
 

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -131,7 +131,7 @@ def compare_mols(mol1, mol2, atol=1.0e-8, rtol=0.0):
     cases = [
         ('one_ints', ['olp', 'kin_ao', 'na_ao']),
         ('two_ints', ['er_ao']),
-        ('one_rdms', ['scf', 'scf_spin', 'post_scf', 'post_scf_spin']),
+        ('one_rdms', ['scf', 'scf_spin', 'post_scf_ao', 'post_scf_spin_ao']),
     ]
     for attrname, keys in cases:
         d1 = getattr(mol1, attrname)

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -272,7 +272,7 @@ def check_load_azirine(key, numbers):
     """Perform some basic checks on a azirine fchk file."""
     mol = load_fchk_helper('2h-azirine-{}.fchk'.format(key))
     assert mol.obasis.nbasis == 33
-    dm = mol.one_rdms['post_scf']
+    dm = mol.one_rdms['post_scf_ao']
     assert_equal(dm[0, 0], numbers[0])
     assert_equal(dm[32, 32], numbers[1])
     olp = compute_overlap(mol.obasis, mol.atcoords)
@@ -299,7 +299,7 @@ def check_load_nitrogen(key, numbers, numbers_spin):
     """Perform some basic checks on a nitrogen fchk file."""
     mol = load_fchk_helper('nitrogen-{}.fchk'.format(key))
     assert mol.obasis.nbasis == 9
-    dm = mol.one_rdms['post_scf']
+    dm = mol.one_rdms['post_scf_ao']
     assert_equal(dm[0, 0], numbers[0])
     assert_equal(dm[8, 8], numbers[1])
     olp = compute_overlap(mol.obasis, mol.atcoords)
@@ -307,7 +307,7 @@ def check_load_nitrogen(key, numbers, numbers_spin):
     check_orthonormal(mol.mo.coeffsb, olp)
     check_dm(dm, olp, eps=1e-3, occ_max=2)
     assert_allclose(np.einsum('ab,ba', olp, dm), 7.0, atol=1.e-7, rtol=0)
-    dm_spin = mol.one_rdms['post_scf_spin']
+    dm_spin = mol.one_rdms['post_scf_spin_ao']
     assert_equal(dm_spin[0, 0], numbers_spin[0])
     assert_equal(dm_spin[8, 8], numbers_spin[1])
 
@@ -333,7 +333,7 @@ def check_normalization_dm_azirine(key):
     mol = load_fchk_helper('2h-azirine-{}.fchk'.format(key))
     olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
-    dm = mol.one_rdms['post_scf']
+    dm = mol.one_rdms['post_scf_ao']
     check_dm(dm, olp, eps=1e-2, occ_max=2)
     assert_allclose(np.einsum('ab,ba', olp, dm), 22.0, atol=1.e-8, rtol=0)
 


### PR DESCRIPTION
Hi, @PaulWAyers @FarnazH, this is my modification to allow IOData to handle MO-basis RDMs. Thoughts?
I will then add a wrapper to PyCI/PySCF and put it in IOData/Scripts, so that we can use IOData with PyCI to run HCI computations.