### PR TITLE
user-set threshold

### DIFF
--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -74,11 +74,18 @@ CONVENTIONS = {
 }
 
 
-@document_load_one("Molden", ['atcoords', 'atnums', 'atcorenums', 'mo', 'obasis'], ['title'])
-def load_one(lit: LineIterator, threshold: float = 1e-4) -> dict:
+@document_load_one(
+    "Molden",
+    ['atcoords', 'atnums', 'atcorenums', 'mo', 'obasis'],
+    ['title'],
+    {"norm_threshold": "When the normalization of one of the orbitals exceeds "
+                       "norm_threshold, a correction is attempted or an error "
+                       "is raised when no suitable correction can be found."}
+)
+def load_one(lit: LineIterator, norm_threshold: float = 1e-4) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     result = _load_low(lit)
-    _fix_molden_from_buggy_codes(result, lit, threshold)
+    _fix_molden_from_buggy_codes(result, lit, norm_threshold)
     return result
 
 
@@ -326,7 +333,7 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
 
 def _is_normalized_properly(obasis: MolecularBasis, atcoords: np.ndarray,
                             orb_alpha: np.ndarray, orb_beta: np.ndarray,
-                            threshold: float) -> bool:
+                            norm_threshold: float = 1e-4) -> bool:
     """Test the normalization of the occupied and virtual orbitals.
 
     Parameters
@@ -339,8 +346,8 @@ def _is_normalized_properly(obasis: MolecularBasis, atcoords: np.ndarray,
         The alpha orbitals coefficients
     orb_beta
         The beta orbitals (may be None).
-    threshold
-        When the maximal error on the norm is large than the threshold,
+    norm_threshold
+        When the error on one of the orbitals norm exceeds norm_threshold,
         the function returns False. True is returned otherwise.
 
     """
@@ -374,7 +381,7 @@ def _is_normalized_properly(obasis: MolecularBasis, atcoords: np.ndarray,
             error_max = max(error_max, abs(norm - 1))
 
     # final judgement
-    return error_max <= threshold
+    return error_max <= norm_threshold
 
 
 def _fix_obasis_orca(obasis: MolecularBasis) -> MolecularBasis:
@@ -582,7 +589,7 @@ def _fix_mo_coeffs_cfour(obasis: MolecularBasis) -> Union[MolecularBasis, None]:
     return None
 
 
-def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: float):
+def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, norm_threshold: float = 1e-4):
     """Detect errors in the data loaded from a molden or mkl file and correct.
 
     This function can recognize erroneous files created by PSI4, ORCA and
@@ -594,6 +601,11 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
         A dictionary with the data loaded in the ``load_molden`` function.
     lit
         The line iterator to read the data from, used for warnings.
+    norm_threshold
+        When the error on one of the orbitals norm exceeds norm_threshold,
+        the (corrected) data loaded from the Molden file is considered to be
+        incorrect, in which case other corrections are tested or an exception
+        is raised when no more corrections can be applied.
 
     """
     # pylint: disable=too-many-return-statements
@@ -609,13 +621,13 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
     else:
         raise ValueError('Molecular orbital kind={0} not recognized'.format(result['mo'].kind))
 
-    if _is_normalized_properly(obasis, atcoords, coeffsa, coeffsb, threshold):
+    if _is_normalized_properly(obasis, atcoords, coeffsa, coeffsb, norm_threshold):
         # The file is good. No need to change obasis.
         return
 
     # --- ORCA
     orca_obasis = _fix_obasis_orca(obasis)
-    if _is_normalized_properly(orca_obasis, atcoords, coeffsa, coeffsb, threshold):
+    if _is_normalized_properly(orca_obasis, atcoords, coeffsa, coeffsb, norm_threshold):
         lit.warn('Corrected for typical ORCA errors in Molden/MKL file.')
         result['obasis'] = orca_obasis
         return
@@ -623,7 +635,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
     # --- PSI4 < 1.0
     psi4_obasis = _fix_obasis_psi4(obasis)
     if psi4_obasis is not None and \
-       _is_normalized_properly(psi4_obasis, atcoords, coeffsa, coeffsb, threshold):
+       _is_normalized_properly(psi4_obasis, atcoords, coeffsa, coeffsb, norm_threshold):
         lit.warn('Corrected for PSI4 < 1.0 errors in Molden/MKL file.')
         result['obasis'] = psi4_obasis
         return
@@ -631,7 +643,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
     # -- Turbomole
     turbom_obasis = _fix_obasis_turbomole(obasis)
     if turbom_obasis is not None and \
-       _is_normalized_properly(turbom_obasis, atcoords, coeffsa, coeffsb, threshold):
+       _is_normalized_properly(turbom_obasis, atcoords, coeffsa, coeffsb, norm_threshold):
         lit.warn('Corrected for Turbomole errors in Molden/MKL file.')
         result['obasis'] = turbom_obasis
         return
@@ -647,7 +659,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
         if _is_normalized_properly(obasis,
                                    atcoords,
                                    coeffsa_cfour,
-                                   coeffsb_cfour, threshold):
+                                   coeffsb_cfour, norm_threshold):
             lit.warn('Corrected for CFOUR 2.1 errors in Molden/MKL file.')
             result['obasis'] = obasis
             if result['mo'].kind == 'restricted':
@@ -659,7 +671,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
 
     # --- Renormalized contractions
     normed_obasis = _fix_obasis_normalize_contractions(obasis)
-    if _is_normalized_properly(normed_obasis, atcoords, coeffsa, coeffsb, threshold):
+    if _is_normalized_properly(normed_obasis, atcoords, coeffsa, coeffsb, norm_threshold):
         lit.warn('Corrected for unnormalized contractions in Molden/MKL file.')
         result['obasis'] = normed_obasis
         return
@@ -672,7 +684,8 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: flo
             coeffsb_psi4 = None
         else:
             coeffsb_psi4 = coeffsb / psi4_coeff_correction[:, np.newaxis]
-        if _is_normalized_properly(normed_obasis, atcoords, coeffsa_psi4, coeffsb_psi4, threshold):
+        if _is_normalized_properly(normed_obasis, atcoords, coeffsa_psi4,
+                                   coeffsb_psi4, norm_threshold):
             lit.warn('Corrected for PSI4 <= 1.3.2 errors in Molden/MKL file.')
             result['obasis'] = normed_obasis
             if result['mo'].kind == 'restricted':

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -75,10 +75,10 @@ CONVENTIONS = {
 
 
 @document_load_one("Molden", ['atcoords', 'atnums', 'atcorenums', 'mo', 'obasis'], ['title'])
-def load_one(lit: LineIterator) -> dict:
+def load_one(lit: LineIterator, threshold: float = 1e-4) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     result = _load_low(lit)
-    _fix_molden_from_buggy_codes(result, lit)
+    _fix_molden_from_buggy_codes(result, lit, threshold)
     return result
 
 
@@ -326,7 +326,7 @@ def _load_helper_coeffs(lit: LineIterator) -> Tuple:
 
 def _is_normalized_properly(obasis: MolecularBasis, atcoords: np.ndarray,
                             orb_alpha: np.ndarray, orb_beta: np.ndarray,
-                            threshold: float = 1e-4) -> bool:
+                            threshold: float) -> bool:
     """Test the normalization of the occupied and virtual orbitals.
 
     Parameters
@@ -582,7 +582,7 @@ def _fix_mo_coeffs_cfour(obasis: MolecularBasis) -> Union[MolecularBasis, None]:
     return None
 
 
-def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
+def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator, threshold: float):
     """Detect errors in the data loaded from a molden or mkl file and correct.
 
     This function can recognize erroneous files created by PSI4, ORCA and
@@ -609,13 +609,13 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
     else:
         raise ValueError('Molecular orbital kind={0} not recognized'.format(result['mo'].kind))
 
-    if _is_normalized_properly(obasis, atcoords, coeffsa, coeffsb):
+    if _is_normalized_properly(obasis, atcoords, coeffsa, coeffsb, threshold):
         # The file is good. No need to change obasis.
         return
 
     # --- ORCA
     orca_obasis = _fix_obasis_orca(obasis)
-    if _is_normalized_properly(orca_obasis, atcoords, coeffsa, coeffsb):
+    if _is_normalized_properly(orca_obasis, atcoords, coeffsa, coeffsb, threshold):
         lit.warn('Corrected for typical ORCA errors in Molden/MKL file.')
         result['obasis'] = orca_obasis
         return
@@ -623,7 +623,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
     # --- PSI4 < 1.0
     psi4_obasis = _fix_obasis_psi4(obasis)
     if psi4_obasis is not None and \
-       _is_normalized_properly(psi4_obasis, atcoords, coeffsa, coeffsb):
+       _is_normalized_properly(psi4_obasis, atcoords, coeffsa, coeffsb, threshold):
         lit.warn('Corrected for PSI4 < 1.0 errors in Molden/MKL file.')
         result['obasis'] = psi4_obasis
         return
@@ -631,7 +631,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
     # -- Turbomole
     turbom_obasis = _fix_obasis_turbomole(obasis)
     if turbom_obasis is not None and \
-       _is_normalized_properly(turbom_obasis, atcoords, coeffsa, coeffsb):
+       _is_normalized_properly(turbom_obasis, atcoords, coeffsa, coeffsb, threshold):
         lit.warn('Corrected for Turbomole errors in Molden/MKL file.')
         result['obasis'] = turbom_obasis
         return
@@ -647,7 +647,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
         if _is_normalized_properly(obasis,
                                    atcoords,
                                    coeffsa_cfour,
-                                   coeffsb_cfour):
+                                   coeffsb_cfour, threshold):
             lit.warn('Corrected for CFOUR 2.1 errors in Molden/MKL file.')
             result['obasis'] = obasis
             if result['mo'].kind == 'restricted':
@@ -659,7 +659,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
 
     # --- Renormalized contractions
     normed_obasis = _fix_obasis_normalize_contractions(obasis)
-    if _is_normalized_properly(normed_obasis, atcoords, coeffsa, coeffsb):
+    if _is_normalized_properly(normed_obasis, atcoords, coeffsa, coeffsb, threshold):
         lit.warn('Corrected for unnormalized contractions in Molden/MKL file.')
         result['obasis'] = normed_obasis
         return
@@ -672,7 +672,7 @@ def _fix_molden_from_buggy_codes(result: dict, lit: LineIterator):
             coeffsb_psi4 = None
         else:
             coeffsb_psi4 = coeffsb / psi4_coeff_correction[:, np.newaxis]
-        if _is_normalized_properly(normed_obasis, atcoords, coeffsa_psi4, coeffsb_psi4):
+        if _is_normalized_properly(normed_obasis, atcoords, coeffsa_psi4, coeffsb_psi4, threshold):
             lit.warn('Corrected for PSI4 <= 1.3.2 errors in Molden/MKL file.')
             result['obasis'] = normed_obasis
             if result['mo'].kind == 'restricted':

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -161,8 +161,14 @@ def _load_helper_occ(lit: LineIterator) -> np.ndarray:
 
 
 # pylint: disable=too-many-branches,too-many-statements
-@document_load_one("Molekel", ['atcoords', 'atnums', 'mo', 'obasis'], ['atcharges'])
-def load_one(lit: LineIterator) -> dict:
+@document_load_one(
+    "Molekel",
+    ['atcoords', 'atnums', 'mo', 'obasis'], ['atcharges'],
+    {"norm_threshold": "When the normalization of one of the orbitals exceeds "
+                       "norm_threshold, a correction is attempted or an error "
+                       "is raised when no suitable correction can be found."}
+)
+def load_one(lit: LineIterator, norm_threshold: float = 1e-4) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     charge = None
     atnums = None
@@ -249,7 +255,7 @@ def load_one(lit: LineIterator) -> dict:
         'mo': mo,
         'atcharges': atcharges,
     }
-    _fix_molden_from_buggy_codes(result, lit)
+    _fix_molden_from_buggy_codes(result, lit, norm_threshold)
     return result
 
 

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -20,6 +20,8 @@
 """Test iodata.formats.molden module."""
 
 import os
+import warnings
+
 import attr
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -66,6 +68,14 @@ def test_load_molden_li2_orca():
     charges = compute_mulliken_charges(mol)
     expected_charges = np.array([0.5, 0.5])
     assert_allclose(charges, expected_charges, atol=1.e-5)
+
+
+def test_load_molden_li2_orca_huge_threshold():
+    with as_file(files("iodata.test.data").joinpath("li2.molden.input")) as fn_molden:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # The threshold is set very high, which skip a correction for ORCA.
+            mol = load_one(str(fn_molden), norm_threshold=1e4)
 
 
 def test_load_molden_h2o_orca():

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -75,7 +75,7 @@ def test_load_molden_li2_orca_huge_threshold():
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             # The threshold is set very high, which skip a correction for ORCA.
-            mol = load_one(str(fn_molden), norm_threshold=1e4)
+            load_one(str(fn_molden), norm_threshold=1e4)
 
 
 def test_load_molden_h2o_orca():

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -165,4 +165,4 @@ def test_load_mkl_h2_huge_threshold():
         with warnings.catch_warnings():
             warnings.simplefilter("error")
             # The threshold is set very high, which skip a correction for ORCA.
-            mol = load_one(str(fn_molekel), norm_threshold=1e4)
+            load_one(str(fn_molekel), norm_threshold=1e4)

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -20,6 +20,7 @@
 """Test iodata.formats.molekel module."""
 
 import os
+import warnings
 
 from numpy.testing import assert_equal, assert_allclose
 
@@ -29,6 +30,11 @@ from ..basis import convert_conventions
 from ..api import load_one, dump_one
 from ..overlap import compute_overlap
 from ..utils import angstrom
+
+try:
+    from importlib_resources import as_file, files
+except ImportError:
+    from importlib.resources import as_file, files
 
 
 def compare_mols_diff_formats(mol1, mol2):
@@ -152,3 +158,11 @@ def test_load_mkl_h2():
     # check mo normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffs, olp)
+
+
+def test_load_mkl_h2_huge_threshold():
+    with as_file(files("iodata.test.data").joinpath("h2_sto3g.mkl")) as fn_molekel:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            # The threshold is set very high, which skip a correction for ORCA.
+            mol = load_one(str(fn_molekel), norm_threshold=1e4)


### PR DESCRIPTION
Introduces the option to allow the user to set the threshold for normalization if desired. If no threshold is provided, the default as previously defined is used.

A note: The threshold argument was an option for the `_is_normalized_properly` did have a threshold argument, but wasn't easily accessible by the user it seemed. 