### PR TITLE
Fix UnicodeDecodeError when pip installing on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ def get_version_info():
 
 def get_readme():
     """Load README.rst for display on PyPI."""
-    with open('README.rst') as fhandle:
+    with open('README.rst', encoding="utf-8") as fhandle:
         return fhandle.read()
 
 


### PR DESCRIPTION
Change the encoding to fix the error below on Windows.
<img width="743" alt="235242135-bd31f4df-4873-4fdb-9032-9b41bf71cc37" src="https://user-images.githubusercontent.com/4535622/235244194-7071dde8-0feb-4303-aa61-6c3aeff3a555.png">
