### PR TITLE
Fix DeprecationWarning: path is deprecated.

### DIFF
--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -20,7 +20,6 @@
 
 import os
 from contextlib import contextmanager
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest
@@ -31,10 +30,9 @@ from ..basis import convert_conventions
 from ..utils import FileFormatWarning
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
-
+    from importlib.resources import as_file, files
 
 __all__ = ['compute_mulliken_charges', 'compute_1rdm',
            'compare_mols', 'check_orthonormal', 'load_one_warning']
@@ -191,7 +189,7 @@ def load_one_warning(filename: str, fmt: str = None, match: str = None, **kwargs
         The instance of IOData with data loaded from the input files.
 
     """
-    with path('iodata.test.data', filename) as fn:
+    with as_file(files("iodata.test.data").joinpath(filename)) as fn:
         if match is None:
             return load_one(str(fn), fmt, **kwargs)
         with pytest.warns(FileFormatWarning, match=match):

--- a/iodata/test/test_charmm.py
+++ b/iodata/test/test_charmm.py
@@ -26,14 +26,14 @@ from ..api import load_one
 from ..utils import angstrom, amu
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_crambin():
     # test CHARMM crd file of crambin
-    with path('iodata.test.data', 'crambin.crd') as fn_crd:
+    with as_file(files("iodata.test.data").joinpath("crambin.crd")) as fn_crd:
         mol = load_one(str(fn_crd))
     assert len(mol.title) == 125
     assert mol.atcoords.shape == (648, 3)

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -26,13 +26,13 @@ from ..api import load_one
 from ..utils import angstrom, volume
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_chgcar_oxygen():
-    with path('iodata.test.data', 'CHGCAR.oxygen') as fn:
+    with as_file(files("iodata.test.data").joinpath("CHGCAR.oxygen")) as fn:
         mol = load_one(str(fn))
     assert_equal(mol.atnums, 8)
     assert_allclose(volume(mol.cellvecs), (10 * angstrom) ** 3, atol=1.e-10)
@@ -46,7 +46,7 @@ def test_load_chgcar_oxygen():
 
 
 def test_load_chgcar_water():
-    with path('iodata.test.data', 'CHGCAR.water') as fn:
+    with as_file(files("iodata.test.data").joinpath("CHGCAR.water")) as fn:
         mol = load_one(str(fn))
     assert mol.title == 'unknown system'
     assert_equal(mol.atnums, [8, 1, 1])

--- a/iodata/test/test_cli.py
+++ b/iodata/test/test_cli.py
@@ -18,25 +18,23 @@
 # --
 """Unit tests for iodata.__main__."""
 
-
 import os
 import functools
 import subprocess
-
 from numpy.testing import assert_equal, assert_allclose
 
 from ..__main__ import convert
 from ..api import load_one, load_many
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def _check_convert_one(myconvert, tmpdir):
     outfn = os.path.join(tmpdir, 'tmp.xyz')
-    with path('iodata.test.data', 'hf_sto3g.fchk') as infn:
+    with as_file(files("iodata.test.data").joinpath("hf_sto3g.fchk")) as infn:
         myconvert(infn, outfn)
     iodata = load_one(outfn)
     assert iodata.natom == 2
@@ -71,7 +69,7 @@ def test_script_one_manfmt(tmpdir):
 
 def _check_convert_many(myconvert, tmpdir):
     outfn = os.path.join(tmpdir, 'tmp.xyz')
-    with path('iodata.test.data', 'peroxide_relaxed_scan.fchk') as infn:
+    with as_file(files("iodata.test.data").joinpath("peroxide_relaxed_scan.fchk")) as infn:
         myconvert(infn, outfn)
     trj = list(load_many(outfn))
     assert len(trj) == 13

--- a/iodata/test/test_cp2klog.py
+++ b/iodata/test/test_cp2klog.py
@@ -19,7 +19,6 @@
 """Test iodata.formats.cp2klog module."""
 
 import pytest
-
 from numpy.testing import assert_equal, assert_allclose
 
 from .common import truncated_file, check_orthonormal
@@ -28,13 +27,13 @@ from ..api import load_one
 from ..overlap import compute_overlap
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_atom_si_uks():
-    with path('iodata.test.data', 'atom_si.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("atom_si.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [14])
     assert_equal(mol.atcorenums, [4])
@@ -59,7 +58,7 @@ def test_atom_si_uks():
 
 
 def test_atom_o_rks():
-    with path('iodata.test.data', 'atom_om2.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("atom_om2.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [8])
     assert_equal(mol.atcorenums, [6])
@@ -80,7 +79,7 @@ def test_atom_o_rks():
 
 
 def test_carbon_gs_ae_contracted():
-    with path('iodata.test.data', 'carbon_gs_ae_contracted.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("carbon_gs_ae_contracted.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
@@ -97,7 +96,8 @@ def test_carbon_gs_ae_contracted():
 
 
 def test_carbon_gs_ae_uncontracted():
-    with path('iodata.test.data', 'carbon_gs_ae_uncontracted.cp2k.out') as fn_out:
+    source = files("iodata.test.data").joinpath("carbon_gs_ae_uncontracted.cp2k.out")
+    with as_file(source) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
@@ -114,7 +114,7 @@ def test_carbon_gs_ae_uncontracted():
 
 
 def test_carbon_gs_pp_contracted():
-    with path('iodata.test.data', 'carbon_gs_pp_contracted.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("carbon_gs_pp_contracted.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
@@ -131,7 +131,8 @@ def test_carbon_gs_pp_contracted():
 
 
 def test_carbon_gs_pp_uncontracted():
-    with path('iodata.test.data', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_out:
+    source = files("iodata.test.data").joinpath("carbon_gs_pp_uncontracted.cp2k.out")
+    with as_file(source) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
@@ -148,7 +149,7 @@ def test_carbon_gs_pp_uncontracted():
 
 
 def test_carbon_sc_ae_contracted():
-    with path('iodata.test.data', 'carbon_sc_ae_contracted.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("carbon_sc_ae_contracted.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
@@ -162,7 +163,8 @@ def test_carbon_sc_ae_contracted():
 
 
 def test_carbon_sc_ae_uncontracted():
-    with path('iodata.test.data', 'carbon_sc_ae_uncontracted.cp2k.out') as fn_out:
+    source = files("iodata.test.data").joinpath("carbon_sc_ae_uncontracted.cp2k.out")
+    with as_file(source) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [6])
@@ -176,7 +178,7 @@ def test_carbon_sc_ae_uncontracted():
 
 
 def test_carbon_sc_pp_contracted():
-    with path('iodata.test.data', 'carbon_sc_pp_contracted.cp2k.out') as fn_out:
+    with as_file(files("iodata.test.data").joinpath("carbon_sc_pp_contracted.cp2k.out")) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
@@ -190,7 +192,8 @@ def test_carbon_sc_pp_contracted():
 
 
 def test_carbon_sc_pp_uncontracted():
-    with path('iodata.test.data', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_out:
+    source = files("iodata.test.data").joinpath("carbon_sc_pp_uncontracted.cp2k.out")
+    with as_file(source) as fn_out:
         mol = load_one(str(fn_out))
     assert_equal(mol.atnums, [6])
     assert_equal(mol.atcorenums, [4])
@@ -204,7 +207,8 @@ def test_carbon_sc_pp_uncontracted():
 
 
 def test_errors(tmpdir):
-    with path('iodata.test.data', 'carbon_sc_pp_uncontracted.cp2k.out') as fn_test:
+    source = files("iodata.test.data").joinpath("carbon_sc_pp_uncontracted.cp2k.out")
+    with as_file(source) as fn_test:
         with truncated_file(fn_test, 0, 0, tmpdir) as fn:
             with pytest.raises(IOError):
                 load_one(fn)
@@ -217,7 +221,8 @@ def test_errors(tmpdir):
         with truncated_file(fn_test, 405, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 load_one(fn)
-    with path('iodata.test.data', 'carbon_gs_pp_uncontracted.cp2k.out') as fn_test:
+    source = files("iodata.test.data").joinpath("carbon_gs_pp_uncontracted.cp2k.out")
+    with as_file(source) as fn_test:
         with truncated_file(fn_test, 456, 10, tmpdir) as fn:
             with pytest.raises(IOError):
                 load_one(fn)

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -19,20 +19,19 @@
 # pylint: disable=unsubscriptable-object
 """Test iodata.formats.cube module."""
 
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one, dump_one
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_aelta():
-    with path('iodata.test.data', 'aelta.cube') as fn_cube:
+    with as_file(files("iodata.test.data").joinpath("aelta.cube")) as fn_cube:
         mol = load_one(str(fn_cube))
     assert mol.title == 'Some random cube for testing (sort of) useless data'
     assert_equal(mol.natom, 72)
@@ -59,7 +58,7 @@ def test_load_aelta():
 
 
 def test_load_dump_load_aelta(tmpdir):
-    with path('iodata.test.data', 'aelta.cube') as fn_cube1:
+    with as_file(files("iodata.test.data").joinpath("aelta.cube")) as fn_cube1:
         mol1 = load_one(str(fn_cube1))
 
     fn_cube2 = '%s/%s' % (tmpdir, 'aelta.cube')
@@ -98,7 +97,7 @@ def test_load_dump_load_aelta(tmpdir):
 
 def test_load_dump_h2o_5points(tmpdir):
     # load cube file
-    with path('iodata.test.data', 'cubegen_h2o_5points.cube') as fn_cube1:
+    with as_file(files("iodata.test.data").joinpath("cubegen_h2o_5points.cube")) as fn_cube1:
         mol1 = load_one(str(fn_cube1))
     # write cube file in a temporary directory
     fn_cube2 = tmpdir.join('iodata_h2o_5points.cube')
@@ -112,7 +111,7 @@ def test_load_dump_h2o_5points(tmpdir):
 
 def test_load_dump_ch4_6points(tmpdir):
     # load cube file
-    with path('iodata.test.data', 'cubegen_ch4_6points.cube') as fn_cube1:
+    with as_file(files("iodata.test.data").joinpath("cubegen_ch4_6points.cube")) as fn_cube1:
         mol1 = load_one(str(fn_cube1))
     # write cube file in a temporary directory
     fn_cube2 = tmpdir.join('iodata_ch4_6points.cube')
@@ -126,7 +125,7 @@ def test_load_dump_ch4_6points(tmpdir):
 
 def test_load_dump_nh3_7points(tmpdir):
     # load cube file
-    with path('iodata.test.data', 'cubegen_nh3_7points.cube') as fn_cube1:
+    with as_file(files("iodata.test.data").joinpath("cubegen_nh3_7points.cube")) as fn_cube1:
         mol1 = load_one(str(fn_cube1))
     # write cube file in a temporary directory
     fn_cube2 = tmpdir.join('iodata_nh3_7points.cube')

--- a/iodata/test/test_extxyz.py
+++ b/iodata/test/test_extxyz.py
@@ -23,14 +23,15 @@ from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one, load_many
 from ..utils import angstrom
+
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_fcc_extended():
-    with path('iodata.test.data', 'al_fcc.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("al_fcc.xyz")) as fn_xyz:
         mol = load_one(str(fn_xyz), fmt='extxyz')
     assert hasattr(mol, 'energy')
     assert isinstance(mol.energy, float)
@@ -51,7 +52,7 @@ def test_load_fcc_extended():
 
 
 def test_load_mgo():
-    with path('iodata.test.data', 'mgo.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("mgo.xyz")) as fn_xyz:
         mol = load_one(str(fn_xyz), fmt='extxyz')
     assert_equal(mol.atnums, [12] * 4 + [8] * 4)
     assert_equal(mol.atcoords[3], np.array([1, 1, 0]) * 2.10607000 * angstrom)
@@ -62,7 +63,7 @@ def test_load_mgo():
 
 
 def test_load_many_extended():
-    with path('iodata.test.data', 'water_extended_trajectory.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water_extended_trajectory.xyz")) as fn_xyz:
         mols = list(load_many(str(fn_xyz), fmt='extxyz'))
     assert len(mols) == 3
     assert 'some_label' in mols[0].extra

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -19,9 +19,7 @@
 # pylint: disable=unsubscriptable-object,no-member
 """Test iodata.formats.fchk module."""
 
-
 import os
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
@@ -35,20 +33,20 @@ from .common import check_orthonormal, compare_mols, load_one_warning, compute_1
 from .test_molekel import compare_mols_diff_formats
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_fchk_nonexistent():
     with pytest.raises(IOError):
-        with path('iodata.test.data', 'fubar_crap.fchk') as fn:
+        with as_file(files("iodata.test.data").joinpath("fubar_crap.fchk")) as fn:
             load_one(str(fn))
 
 
 def load_fchk_helper(fn_fchk):
     """Load a testing fchk file with iodata.iodata.load_one."""
-    with path('iodata.test.data', fn_fchk) as fn:
+    with as_file(files("iodata.test.data").joinpath(fn_fchk)) as fn:
         return load_one(fn)
 
 
@@ -389,7 +387,7 @@ def test_load_monosilicic_acid_hf_lan():
 
 def load_fchk_trj_helper(fn_fchk):
     """Load a trajectory from a testing fchk file with iodata.iodata.load_many."""
-    with path('iodata.test.data', fn_fchk) as fn:
+    with as_file(files("iodata.test.data").joinpath(fn_fchk)) as fn:
         return list(load_many(fn))
 
 
@@ -543,7 +541,7 @@ def test_load_nbasis_indep(tmpdir):
     mol1 = load_fchk_helper('li2_g09_nbasis_indep.fchk')
     assert mol1.mo.coeffs.shape == (38, 37)
     # Fake an old g03 fchk file by rewriting one line
-    with path('iodata.test.data', 'li2_g09_nbasis_indep.fchk') as fnin:
+    with as_file(files("iodata.test.data").joinpath("li2_g09_nbasis_indep.fchk")) as fnin:
         fnout = os.path.join(tmpdir, 'tmpg03.fchk')
         with open(fnin) as fin, open(fnout, "w") as fout:
             for line in fin:

--- a/iodata/test/test_fcidump.py
+++ b/iodata/test/test_fcidump.py
@@ -19,20 +19,19 @@
 """Test iodata.formats.fcidump module."""
 
 import os
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one, dump_one
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_fcidump_psi4_h2():
-    with path('iodata.test.data', 'FCIDUMP.psi4.h2') as fn:
+    with as_file(files("iodata.test.data").joinpath("FCIDUMP.psi4.h2")) as fn:
         mol = load_one(str(fn))
     assert_allclose(mol.core_energy, 0.7151043364864863E+00)
     assert_equal(mol.nelec, 2)
@@ -59,7 +58,7 @@ def test_load_fcidump_psi4_h2():
 
 
 def test_load_fcidump_molpro_h2():
-    with path('iodata.test.data', 'FCIDUMP.molpro.h2') as fn:
+    with as_file(files("iodata.test.data").joinpath("FCIDUMP.molpro.h2")) as fn:
         mol = load_one(str(fn))
     assert_allclose(mol.core_energy, 0.7151043364864863E+00)
     assert_equal(mol.nelec, 2)
@@ -87,13 +86,13 @@ def test_load_fcidump_molpro_h2():
 
 def test_dump_load_fcidimp_consistency_ao(tmpdir):
     # Setup IOData
-    with path('iodata.test.data', 'water.xyz') as fn:
+    with as_file(files("iodata.test.data").joinpath("water.xyz")) as fn:
         mol0 = load_one(str(fn))
     mol0.nelec = 10
     mol0.spinpol = 0
-    with path('iodata.test.data', 'psi4_h2_one.npy') as fn:
+    with as_file(files("iodata.test.data").joinpath("psi4_h2_one.npy")) as fn:
         mol0.one_ints = {'core_mo': np.load(str(fn))}
-    with path('iodata.test.data', 'psi4_h2_two.npy') as fn:
+    with as_file(files("iodata.test.data").joinpath("psi4_h2_two.npy")) as fn:
         mol0.two_ints = {'two_mo': np.load(str(fn))}
 
     # Dump to a file and load it again

--- a/iodata/test/test_gamess.py
+++ b/iodata/test/test_gamess.py
@@ -18,20 +18,19 @@
 # --
 """Test iodata.formats.gamess module."""
 
-
 from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one
 from ..utils import angstrom
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_one_gamess_punch():
-    with path('iodata.test.data', 'PCGamess_PUNCH.dat') as f:
+    with as_file(files("iodata.test.data").joinpath("PCGamess_PUNCH.dat")) as f:
         data = load_one(str(f))
     N = len(["CL", "H", "H", "H", "H", "F", "F", "F", "F", "H", "F"])
     assert data.title == "Simple example sample optimization with Hessian output for Toon"

--- a/iodata/test/test_gaussianinput.py
+++ b/iodata/test/test_gaussianinput.py
@@ -23,52 +23,53 @@ from numpy.testing import assert_equal, assert_allclose, assert_raises
 
 from ..api import load_one
 from ..utils import angstrom
+
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_water_com():
     # test .com with Link 0 section
-    with path('iodata.test.data', 'water.com') as fn_xyz:
-        mol = load_one(str(fn_xyz))
+    with as_file(files("iodata.test.data").joinpath("water.com")) as fn:
+        mol = load_one(str(fn))
     check_water(mol, 'water')
 
 
 def test_load_water_gjf():
     # test .com without Link 0 section
-    with path('iodata.test.data', 'water.gjf') as fn_xyz:
-        mol = load_one(str(fn_xyz))
+    with as_file(files("iodata.test.data").joinpath("water.gjf")) as fn:
+        mol = load_one(str(fn))
     check_water(mol, 'water')
 
 
 def test_load_multi_link():
     # test .com with multiple #link 0 contents
-    with path('iodata.test.data', 'water_multi_link.com') as fn_xyz:
-        mol = load_one(str(fn_xyz))
+    with as_file(files("iodata.test.data").joinpath("water_multi_link.com")) as fn:
+        mol = load_one(str(fn))
     check_water(mol, 'water')
 
 
 def test_load_multi_route():
     # test .com with multiple route contents
-    with path('iodata.test.data', 'water_multi_route.com') as fn_xyz:
-        mol = load_one(str(fn_xyz))
+    with as_file(files("iodata.test.data").joinpath("water_multi_route.com")) as fn:
+        mol = load_one(str(fn))
     check_water(mol, 'water')
 
 
 def test_load_multi_title():
     # test .com with multiple title and concatenate
-    with path('iodata.test.data', 'water_multi_title.com') as fn_xyz:
-        mol = load_one(str(fn_xyz))
+    with as_file(files("iodata.test.data").joinpath("water_multi_title.com")) as fn:
+        mol = load_one(str(fn))
     check_water(mol, 'water water')
 
 
 def test_load_error():
     # test error raises when loading .com with z-matrix
     with assert_raises(ValueError):
-        with path('iodata.test.data', 'water_z.com') as fn_xyz:
-            load_one(str(fn_xyz))
+        with as_file(files("iodata.test.data").joinpath("water_z.com")) as fn:
+            load_one(str(fn))
 
 
 def check_water(mol, title):

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -23,14 +23,14 @@ from numpy.testing import assert_equal, assert_allclose
 from ..api import load_one
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def load_log_helper(fn_log):
     """Load a testing Gaussian log file with iodata.load_one."""
-    with path('iodata.test.data', fn_log) as fn:
+    with as_file(files("iodata.test.data").joinpath(fn_log)) as fn:
         return load_one(fn)
 
 

--- a/iodata/test/test_gromacs.py
+++ b/iodata/test/test_gromacs.py
@@ -25,14 +25,14 @@ from ..api import load_one, load_many
 from ..utils import nanometer, picosecond
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_water():
     # test gro file of one water
-    with path('iodata.test.data', 'water.gro') as fn_gro:
+    with as_file(files("iodata.test.data").joinpath("water.gro")) as fn_gro:
         mol = load_one(str(fn_gro))
     check_water(mol)
 
@@ -52,7 +52,7 @@ def check_water(mol):
 
 
 def test_load_many():
-    with path('iodata.test.data', 'water2.gro') as fn_gro:
+    with as_file(files("iodata.test.data").joinpath("water2.gro")) as fn_gro:
         mols = list(load_many(str(fn_gro)))
     assert len(mols) == 2
     assert mols[0].extra['time'] == 0.0 * picosecond

--- a/iodata/test/test_inputs.py
+++ b/iodata/test/test_inputs.py
@@ -18,7 +18,6 @@
 # --
 """Test iodata.inputs module."""
 
-
 import os
 import numpy as np
 
@@ -27,9 +26,9 @@ from ..utils import angstrom
 from ..api import load_one, write_input
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def check_load_input_and_compare(fname: str, fname_expected: str):
@@ -52,7 +51,7 @@ def check_load_input_and_compare(fname: str, fname_expected: str):
 
 def test_input_gaussian_from_xyz(tmpdir):
     # load geometry from xyz file & add level of theory & basis set
-    with path('iodata.test.data', 'water_number.xyz') as fn:
+    with as_file(files("iodata.test.data").joinpath("water_number.xyz")) as fn:
         mol = load_one(fn)
     mol.nelec = 10
     mol.lot = 'ub3lyp'
@@ -82,7 +81,8 @@ gaussian.wfn
 """
     write_input(mol, fname, fmt='gaussian', template=template, extra_cmd="nosymmetry")
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_gaussian_h2o_opt_ub3lyp.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_gaussian_h2o_opt_ub3lyp.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)
 
 
@@ -95,25 +95,27 @@ def test_input_gaussian_from_iodata(tmpdir):
     fname = os.path.join(tmpdir, 'input_from_iodata.com')
     write_input(mol, fname, fmt='gaussian')
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_gaussian_hcl_anion_opt_hf.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_gaussian_hcl_anion_opt_hf.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)
 
 
 def test_input_gaussian_from_fchk(tmpdir):
     # load fchk
-    with path('iodata.test.data', 'water_hfs_321g.fchk') as fn:
+    with as_file(files("iodata.test.data").joinpath("water_hfs_321g.fchk")) as fn:
         mol = load_one(fn)
     # write input in a temporary file
     fname = os.path.join(tmpdir, 'input_from_fchk.in')
     write_input(mol, fname, fmt='gaussian')
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_gaussian_hcl_sp_rhf.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_gaussian_hcl_sp_rhf.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)
 
 
 def test_input_orca_from_xyz(tmpdir):
     # load geometry from xyz file & add level of theory & basis set
-    with path('iodata.test.data', 'water_number.xyz') as fn:
+    with as_file(files("iodata.test.data").joinpath("water_number.xyz")) as fn:
         mol = load_one(fn)
     mol.nelec = 10
     mol.lot = 'B3LYP'
@@ -138,7 +140,8 @@ end
     grid_stuff = "Grid4 TightSCF NOFINALGRID"
     write_input(mol, fname, fmt='orca', template=template, grid_stuff=grid_stuff)
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_orca_h2o_sp_b3lyp.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_orca_h2o_sp_b3lyp.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)
 
 
@@ -151,17 +154,19 @@ def test_input_orca_from_iodata(tmpdir):
     fname = os.path.join(tmpdir, 'input_from_iodata.com')
     write_input(mol, fname, fmt='orca')
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_orca_hcl_anion_opt_hf.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_orca_hcl_anion_opt_hf.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)
 
 
 def test_input_orca_from_molden(tmpdir):
     # load orca molden
-    with path('iodata.test.data', 'nh3_orca.molden') as fn:
+    with as_file(files("iodata.test.data").joinpath("nh3_orca.molden")) as fn:
         mol = load_one(fn)
     # write input in a temporary file
     fname = os.path.join(tmpdir, 'input_from_molden.in')
     write_input(mol, fname, fmt='orca')
     # compare saved input to expected input
-    with path('iodata.test.data', 'input_orca_nh3_sp_hf.txt') as fname_expected:
+    source = files("iodata.test.data").joinpath("input_orca_nh3_sp_hf.txt")
+    with as_file(source) as fname_expected:
         check_load_input_and_compare(fname, fname_expected)

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -18,7 +18,6 @@
 # --
 """Test iodata.iodata module."""
 
-
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 import pytest
@@ -26,10 +25,11 @@ import pytest
 from .common import compute_1rdm
 from ..api import load_one, IOData
 from ..overlap import compute_overlap
+
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_typecheck():
@@ -62,7 +62,7 @@ def test_unknown_format():
 
 
 def test_dm_water_sto3g_hf():
-    with path('iodata.test.data', 'water_sto3g_hf_g03.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("water_sto3g_hf_g03.fchk")) as fn_fchk:
         mol = load_one(str(fn_fchk))
     dm = mol.one_rdms['scf']
     assert_allclose(dm[0, 0], 2.10503807, atol=1.e-7)
@@ -71,7 +71,7 @@ def test_dm_water_sto3g_hf():
 
 
 def test_dm_lih_sto3g_hf():
-    with path('iodata.test.data', 'li_h_3-21G_hf_g09.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("li_h_3-21G_hf_g09.fchk")) as fn_fchk:
         mol = load_one(str(fn_fchk))
 
     dm = mol.one_rdms['scf']
@@ -88,7 +88,7 @@ def test_dm_lih_sto3g_hf():
 
 
 def test_dm_ch3_rohf_g03():
-    with path('iodata.test.data', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("ch3_rohf_sto3g_g03.fchk")) as fn_fchk:
         mol = load_one(str(fn_fchk))
     olp = compute_overlap(mol.obasis, mol.atcoords)
     dm = compute_1rdm(mol)
@@ -316,7 +316,7 @@ def test_derived1():
     # pylint: disable=protected-access
     # When loading a file with molecular orbitals, nelec, charge and spinpol are
     # derived from the mo object:
-    with path('iodata.test.data', 'ch3_rohf_sto3g_g03.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("ch3_rohf_sto3g_g03.fchk")) as fn_fchk:
         mol = load_one(str(fn_fchk))
     assert mol.nelec == mol.mo.nelec
     assert mol.charge == mol.atcorenums.sum() - mol.mo.nelec

--- a/iodata/test/test_json.py
+++ b/iodata/test/test_json.py
@@ -27,11 +27,11 @@ import pytest
 from ..api import dump_one, load_one
 from ..utils import FileFormatError, FileFormatWarning
 
-
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
+
 
 # Tests for qcschema_molecule
 # GEOMS: dict of str: np.ndarray(N, 3)
@@ -64,7 +64,7 @@ MOL_FILES = [
 @pytest.mark.parametrize("filename, atnums, charge, spinpol, geometry, nwarn", MOL_FILES)
 def test_qcschema_molecule(filename, atnums, charge, spinpol, geometry, nwarn):
     """Test qcschema_molecule parsing using manually generated files."""
-    with path("iodata.test.data", filename) as qcschema_molecule:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         if nwarn == 0:
             mol = load_one(str(qcschema_molecule))
         else:
@@ -108,7 +108,7 @@ MOLSSI_MOL_FILES = [
 @pytest.mark.parametrize("filename, atnums, charge, spinpol, nwarn", MOLSSI_MOL_FILES)
 def test_molssi_qcschema_molecule(filename, atnums, charge, spinpol, nwarn):
     """Test qcschema_molecule parsing using MolSSI-sourced files."""
-    with path("iodata.test.data", filename) as qcschema_molecule:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(qcschema_molecule))
 
@@ -136,7 +136,7 @@ PASSTHROUGH_MOL_FILES = [
 @pytest.mark.parametrize("filename, unparsed_dict", PASSTHROUGH_MOL_FILES)
 def test_passthrough_qcschema_molecule(filename, unparsed_dict):
     """Test qcschema_molecule parsing for passthrough of unparsed keys."""
-    with path("iodata.test.data", filename) as qcschema_molecule:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(qcschema_molecule))
 
@@ -169,7 +169,7 @@ INOUT_MOL_FILES = [
 @pytest.mark.parametrize("filename, nwarn", INOUT_MOL_FILES)
 def test_inout_qcschema_molecule(tmpdir, filename, nwarn):
     """Test that loading and dumping qcschema_molecule files retains all data."""
-    with path("iodata.test.data", filename) as qcschema_molecule:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         if nwarn == 0:
             mol = load_one(str(qcschema_molecule))
         else:
@@ -202,7 +202,7 @@ INOUT_MOLSSI_MOL_FILES = [
 @pytest.mark.parametrize("filename", INOUT_MOLSSI_MOL_FILES)
 def test_inout_molssi_qcschema_molecule(tmpdir, filename):
     """Test that loading and dumping qcschema_molecule files retains all relevant data."""
-    with path("iodata.test.data", filename) as qcschema_molecule:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(qcschema_molecule))
         mol1_preproc = json.loads(qcschema_molecule.read_bytes())
@@ -238,7 +238,8 @@ def test_inout_molssi_qcschema_molecule(tmpdir, filename):
 
 
 def test_ghost(tmpdir):
-    with path("iodata.test.data", "water_cluster_ghost.json") as qcschema_molecule:
+    source = files("iodata.test.data").joinpath("water_cluster_ghost.json")
+    with as_file(source) as qcschema_molecule:
         mol = load_one(str(qcschema_molecule))
     np.testing.assert_allclose(mol.atcorenums, [8, 1, 1, 0, 0, 0, 0, 0, 0])
     fn_tmp = os.path.join(tmpdir, 'test_ghost.json')
@@ -262,7 +263,7 @@ INPUT_FILES = [
     "filename, explicit_basis, lot, obasis_name, run_type, geometry", INPUT_FILES
 )
 def test_qcschema_input(filename, explicit_basis, lot, obasis_name, run_type, geometry):
-    with path('iodata.test.data', filename) as qcschema_input:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         try:
             mol = load_one(str(qcschema_input))
             assert mol.lot == lot
@@ -288,7 +289,7 @@ PASSTHROUGH_INPUT_FILES = [
 @pytest.mark.parametrize("filename, unparsed_dict, location", PASSTHROUGH_INPUT_FILES)
 def test_passthrough_qcschema_input(filename, unparsed_dict, location):
     """Test qcschema_molecule parsing for passthrough of unparsed keys."""
-    with path("iodata.test.data", filename) as qcschema_input:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         mol = load_one(str(qcschema_input))
 
     assert mol.extra[location]["unparsed"] == unparsed_dict
@@ -307,7 +308,7 @@ INOUT_INPUT_FILES = [
 @pytest.mark.parametrize("filename, nwarn", INOUT_INPUT_FILES)
 def test_inout_qcschema_input(tmpdir, filename, nwarn):
     """Test that loading and dumping qcschema_molecule files retains all data."""
-    with path("iodata.test.data", filename) as qcschema_input:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         if nwarn == 0:
             mol = load_one(str(qcschema_input))
         else:
@@ -345,7 +346,7 @@ OUTPUT_FILES = [
 
 @pytest.mark.parametrize("filename, lot, obasis_name, run_type, nwarn", OUTPUT_FILES)
 def test_qcschema_output(filename, lot, obasis_name, run_type, nwarn):
-    with path("iodata.test.data", filename) as qcschema_output:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_output:
         if nwarn == 0:
             mol = load_one(str(qcschema_output))
         else:
@@ -370,7 +371,7 @@ BAD_OUTPUT_FILES = [
 @pytest.mark.parametrize("filename, error", BAD_OUTPUT_FILES)
 def test_bad_qcschema_files(filename, error):
     # FIXME: these will move
-    with path('iodata.test.data', filename) as qcschema_input:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         with pytest.raises(error):
             load_one(str(qcschema_input))
 
@@ -384,7 +385,7 @@ INOUT_OUTPUT_FILES = [
 @pytest.mark.parametrize("filename", INOUT_OUTPUT_FILES)
 def test_inout_qcschema_output(tmpdir, filename):
     """Test that loading and dumping qcschema_molecule files retains all data."""
-    with path("iodata.test.data", filename) as qcschema_input:
+    with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         mol = load_one(str(qcschema_input))
         mol1 = json.loads(qcschema_input.read_bytes())
 

--- a/iodata/test/test_locpot.py
+++ b/iodata/test/test_locpot.py
@@ -23,14 +23,15 @@ from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one
 from ..utils import angstrom, electronvolt, volume
+
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_locpot_oxygen():
-    with path('iodata.test.data', 'LOCPOT.oxygen') as fn:
+    with as_file(files("iodata.test.data").joinpath("LOCPOT.oxygen")) as fn:
         mol = load_one(str(fn))
     assert mol.title == 'O atom in a box'
     assert_equal(mol.atnums[0], 8)

--- a/iodata/test/test_mol2.py
+++ b/iodata/test/test_mol2.py
@@ -19,7 +19,6 @@
 """Test iodata.formats.mol2 module."""
 
 import os
-
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
@@ -29,21 +28,21 @@ from ..utils import angstrom
 from ..periodic import bond2num
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_mol2_load_one():
     # test mol2 one structure
-    with path('iodata.test.data', 'caffeine.mol2') as fn_mol:
+    with as_file(files("iodata.test.data").joinpath("caffeine.mol2")) as fn_mol:
         mol = load_one(str(fn_mol))
     check_example(mol)
 
 
 def test_mol2_formaterror(tmpdir):
     # test if mol2 file has the wrong ending
-    with path('iodata.test.data', 'caffeine.mol2') as fn_test:
+    with as_file(files("iodata.test.data").joinpath("caffeine.mol2")) as fn_test:
         with truncated_file(fn_test, 2, 0, tmpdir) as fn:
             with pytest.raises(IOError):
                 load_one(str(fn))
@@ -51,13 +50,13 @@ def test_mol2_formaterror(tmpdir):
 
 def test_mol2_symbol():
     # test mol2 files with element symbols with two characters
-    with path('iodata.test.data', 'silioh3.mol2') as fn_mol:
+    with as_file(files("iodata.test.data").joinpath("silioh3.mol2")) as fn_mol:
         mol = load_one(str(fn_mol))
     assert_equal(mol.atnums, [14, 3, 8, 1, 8, 1, 8, 1])
 
 
 def test_bondtypes_benzene():
-    with path('iodata.test.data', 'benzene.mol2') as fn_test:
+    with as_file(files("iodata.test.data").joinpath("benzene.mol2")) as fn_test:
         mol = load_one(str(fn_test))
     assert_equal(mol.bonds[:, 2], [bond2num["ar"]] * 6 + [bond2num["1"]] * 6)
 
@@ -100,14 +99,14 @@ def check_load_dump_consistency(tmpdir, fn):
 
 
 def test_load_dump_consistency(tmpdir):
-    with path('iodata.test.data', 'caffeine.mol2') as fn_mol2:
+    with as_file(files("iodata.test.data").joinpath("caffeine.mol2")) as fn_mol2:
         check_load_dump_consistency(tmpdir, fn_mol2)
-    with path('iodata.test.data', 'benzene.mol2') as fn_mol2:
+    with as_file(files("iodata.test.data").joinpath("benzene.mol2")) as fn_mol2:
         check_load_dump_consistency(tmpdir, fn_mol2)
 
 
 def test_load_many():
-    with path('iodata.test.data', 'caffeine.mol2') as fn_mol2:
+    with as_file(files("iodata.test.data").joinpath("caffeine.mol2")) as fn_mol2:
         mols = list(load_many(str(fn_mol2)))
     assert len(mols) == 2
     check_example(mols[0])
@@ -118,7 +117,7 @@ def test_load_many():
 
 
 def test_load_dump_many_consistency(tmpdir):
-    with path('iodata.test.data', 'caffeine.mol2') as fn_mol2:
+    with as_file(files("iodata.test.data").joinpath("caffeine.mol2")) as fn_mol2:
         mols0 = list(load_many(str(fn_mol2)))
     # write mol2 file in a temporary folder & then read it
     fn_tmp = os.path.join(tmpdir, 'test')
@@ -133,7 +132,7 @@ def test_load_dump_many_consistency(tmpdir):
 
 
 def test_load_dump_wrong_bond_num(tmpdir):
-    with path('iodata.test.data', 'silioh3.mol2') as fn_mol:
+    with as_file(files("iodata.test.data").joinpath("silioh3.mol2")) as fn_mol:
         mol = load_one(str(fn_mol))
     mol.bonds[0][2] = -1
     fn_tmp = os.path.join(tmpdir, 'test.mol2')

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -20,7 +20,6 @@
 """Test iodata.formats.molden module."""
 
 import os
-
 import attr
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -33,15 +32,14 @@ from ..formats.molden import _load_low
 from ..overlap import compute_overlap, OVERLAP_CONVENTIONS
 from ..utils import LineIterator, angstrom, FileFormatWarning
 
-
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_molden_li2_orca():
-    with path('iodata.test.data', 'li2.molden.input') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("li2.molden.input")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -71,7 +69,7 @@ def test_load_molden_li2_orca():
 
 
 def test_load_molden_h2o_orca():
-    with path('iodata.test.data', 'h2o.molden.input') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("h2o.molden.input")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -99,7 +97,7 @@ def test_load_molden_h2o_orca():
 def test_load_molden_nh3_molden_pure():
     # The file tested here is created with molden. It should be read in
     # properly without altering normalization and sign conventions.
-    with path('iodata.test.data', 'nh3_molden_pure.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_molden_pure.molden")) as fn_molden:
         mol = load_one(str(fn_molden))
     # Check geometry
     assert_equal(mol.atnums, [7, 1, 1, 1])
@@ -118,7 +116,7 @@ def test_load_molden_nh3_molden_pure():
 
 
 def test_load_molden_low_nh3_molden_cart():
-    with path('iodata.test.data', 'nh3_molden_cart.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_molden_cart.molden")) as fn_molden:
         lit = LineIterator(str(fn_molden))
         data = _load_low(lit)
     obasis = data['obasis']
@@ -186,7 +184,7 @@ def test_load_molden_low_nh3_molden_cart():
 def test_load_molden_nh3_molden_cart():
     # The file tested here is created with molden. It should be read in
     # properly without altering normalization and sign conventions.
-    with path('iodata.test.data', 'nh3_molden_cart.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_molden_cart.molden")) as fn_molden:
         mol = load_one(str(fn_molden))
 
     # Check normalization
@@ -216,7 +214,7 @@ def test_load_molden_cfour():
         'h2o_ccpvdz_cfour.molden']
 
     for i in file_list:
-        with path('iodata.test.data', i) as fn_molden:
+        with as_file(files("iodata.test.data").joinpath(i)) as fn_molden:
             print(str(fn_molden))
             mol = load_one(str(fn_molden))
             # Check normalization
@@ -228,7 +226,7 @@ def test_load_molden_cfour():
 def test_load_molden_nh3_orca():
     # The file tested here is created with ORCA. It should be read in
     # properly by altering normalization and sign conventions.
-    with path('iodata.test.data', 'nh3_orca.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_orca.molden")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -248,7 +246,7 @@ def test_load_molden_nh3_orca():
 def test_load_molden_nh3_psi4():
     # The file tested here is created with PSI4 (pre 1.0). It should be read in
     # properly by altering normalization conventions.
-    with path('iodata.test.data', 'nh3_psi4.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_psi4.molden")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -268,7 +266,7 @@ def test_load_molden_nh3_psi4():
 def test_load_molden_nh3_psi4_1():
     # The file tested here is created with PSI4 (version 1.0).
     # It should be read in properly by renormalizing the contractions.
-    with path('iodata.test.data', 'nh3_psi4_1.0.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_psi4_1.0.molden")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -290,7 +288,8 @@ def test_load_molden_high_am_psi4(case):
     # The file tested here is created with PSI4 1.3.2.
     # This is a special case because it contains higher angular momenta than
     # officially supported by the Molden format. Most virtual orbitals were removed.
-    with path('iodata.test.data', f'psi4_{case}_cc_pvqz_pure.molden') as fn_molden:
+    source = files("iodata.test.data").joinpath(f"psi4_{case}_cc_pvqz_pure.molden")
+    with as_file(source) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -311,7 +310,8 @@ def test_load_molden_high_am_orca(case):
     # The file tested here is created with ORCA.
     # This is a special case because it contains higher angular momenta than
     # officially supported by the Molden format. Most virtual orbitals were removed.
-    with path('iodata.test.data', f'orca_{case}_cc_pvqz_pure.molden') as fn_molden:
+    source = files("iodata.test.data").joinpath(f"orca_{case}_cc_pvqz_pure.molden")
+    with as_file(source) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -324,7 +324,7 @@ def test_load_molden_high_am_orca(case):
 
 def test_load_molden_he2_ghost_psi4_1():
     # The file tested here is created with PSI4 (version 1.0).
-    with path('iodata.test.data', 'he2_ghost_psi4_1.0.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("he2_ghost_psi4_1.0.molden")) as fn_molden:
         mol = load_one(str(fn_molden))
     np.testing.assert_equal(mol.atcorenums, np.array([0.0, 2.0]))
 
@@ -342,7 +342,8 @@ def test_load_molden_he2_ghost_psi4_1():
 def test_load_molden_h2o_6_31g_d_cart_psi4():
     # The file tested here is created with PSI4 1.3.2. It should be read in
     # properly after fixing for errors in AO normalization conventions.
-    with path('iodata.test.data', 'h2o_psi4_1.3.2_6-31G_d_cart.molden') as fn_molden:
+    source = files("iodata.test.data").joinpath("h2o_psi4_1.3.2_6-31G_d_cart.molden")
+    with as_file(source) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -362,7 +363,8 @@ def test_load_molden_h2o_6_31g_d_cart_psi4():
 def test_load_molden_nh3_aug_cc_pvqz_cart_psi4():
     # The file tested here is created with PSI4 1.3.2. It should be read in
     # properly after fixing for errors in AO normalization conventions.
-    with path('iodata.test.data', 'nh3_psi4_1.3.2_aug_cc_pvqz_cart.molden') as fn_molden:
+    source = files("iodata.test.data").joinpath("nh3_psi4_1.3.2_aug_cc_pvqz_cart.molden")
+    with as_file(source) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -381,7 +383,7 @@ def test_load_molden_nh3_aug_cc_pvqz_cart_psi4():
 
 def test_load_molden_nh3_molpro2012():
     # The file tested here is created with MOLPRO2012.
-    with path('iodata.test.data', 'nh3_molpro2012.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_molpro2012.molden")) as fn_molden:
         mol = load_one(str(fn_molden))
 
     # Check normalization
@@ -397,7 +399,8 @@ def test_load_molden_nh3_molpro2012():
 
 def test_load_molden_neon_turbomole():
     # The file tested here is created with Turbomole 7.1.
-    with path('iodata.test.data', 'neon_turbomole_def2-qzvp.molden') as fn_molden:
+    source = files("iodata.test.data").joinpath("neon_turbomole_def2-qzvp.molden")
+    with as_file(source) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -414,7 +417,7 @@ def test_load_molden_neon_turbomole():
 
 def test_load_molden_nh3_turbomole():
     # The file tested here is created with Turbomole 7.1
-    with path('iodata.test.data', 'nh3_turbomole.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("nh3_turbomole.molden")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -434,7 +437,7 @@ def test_load_molden_nh3_turbomole():
 
 
 def test_load_molden_f():
-    with path('iodata.test.data', 'F.molden') as fn_molden:
+    with as_file(files("iodata.test.data").joinpath("F.molden")) as fn_molden:
         with pytest.warns(FileFormatWarning) as record:
             mol = load_one(str(fn_molden))
     assert len(record) == 1
@@ -464,7 +467,7 @@ def test_load_molden_f():
     ("ch3_rohf_sto3g_g03.fchk", None),
 ])
 def test_load_dump_consistency(tmpdir, fn, match):
-    with path('iodata.test.data', fn) as file_name:
+    with as_file(files("iodata.test.data").joinpath(fn)) as file_name:
         if match is None:
             mol1 = load_one(str(file_name))
         else:

--- a/iodata/test/test_mwfn.py
+++ b/iodata/test/test_mwfn.py
@@ -18,21 +18,21 @@
 # --
 """Test iodata.formats.mwfn module."""
 
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
+
 from ..api import load_one
 from ..overlap import compute_overlap
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def load_helper(fn):
     """Load a test file with iodata.iodata.load_one."""
-    with path('iodata.test.data', fn) as absfn:
+    with as_file(files("iodata.test.data").joinpath(fn)) as absfn:
         return load_one(absfn)
 
 

--- a/iodata/test/test_orcalog.py
+++ b/iodata/test/test_orcalog.py
@@ -26,13 +26,13 @@ from ..api import load_one
 from ..utils import angstrom
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_water_number():
-    with path('iodata.test.data', 'water_orca.out') as fn:
+    with as_file(files("iodata.test.data").joinpath("water_orca.out")) as fn:
         mol = load_one(fn)
     # Test atomic numbers and number of atoms
     assert mol.natom == 3

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -19,7 +19,6 @@
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import itertools
-
 import attr
 import numpy as np
 from numpy.testing import assert_allclose
@@ -30,9 +29,9 @@ from ..basis import MolecularBasis, Shell, convert_conventions
 from ..overlap import compute_overlap, OVERLAP_CONVENTIONS
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_normalization_basics_segmented():
@@ -56,27 +55,27 @@ def test_normalization_basics_generalized():
 
 
 def test_load_fchk_hf_sto3g_num():
-    with path('iodata.test.data', 'load_fchk_hf_sto3g_num.npy') as fn_npy:
+    with as_file(files("iodata.test.data").joinpath("load_fchk_hf_sto3g_num.npy")) as fn_npy:
         ref = np.load(str(fn_npy))
-    with path('iodata.test.data', 'hf_sto3g.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("hf_sto3g.fchk")) as fn_fchk:
         data = load_one(fn_fchk)
     assert_allclose(ref, compute_overlap(data.obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_pure_num():
-    with path('iodata.test.data',
-              'load_fchk_o2_cc_pvtz_pure_num.npy') as fn_npy:
+    source = files("iodata.test.data").joinpath("load_fchk_o2_cc_pvtz_pure_num.npy")
+    with as_file(source) as fn_npy:
         ref = np.load(str(fn_npy))
-    with path('iodata.test.data', 'o2_cc_pvtz_pure.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("o2_cc_pvtz_pure.fchk")) as fn_fchk:
         data = load_one(fn_fchk)
     assert_allclose(ref, compute_overlap(data.obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
 
 
 def test_load_fchk_o2_cc_pvtz_cart_num():
-    with path('iodata.test.data',
-              'load_fchk_o2_cc_pvtz_cart_num.npy') as fn_npy:
+    source = files("iodata.test.data").joinpath("load_fchk_o2_cc_pvtz_cart_num.npy")
+    with as_file(source) as fn_npy:
         ref = np.load(str(fn_npy))
-    with path('iodata.test.data', 'o2_cc_pvtz_cart.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("o2_cc_pvtz_cart.fchk")) as fn_fchk:
         data = load_one(fn_fchk)
     obasis = attr.evolve(data.obasis, conventions=OVERLAP_CONVENTIONS)
     assert_allclose(ref, compute_overlap(obasis, data.atcoords), rtol=1.e-5, atol=1.e-8)
@@ -93,7 +92,7 @@ def test_overlap_l1():
 
 
 def test_overlap_two_basis_exceptions():
-    with path('iodata.test.data', 'hf_sto3g.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("hf_sto3g.fchk")) as fn_fchk:
         data = load_one(fn_fchk)
     with pytest.raises(TypeError):
         compute_overlap(data.obasis, data.atcoords, data.obasis, None)
@@ -111,7 +110,7 @@ FNS_TWO_BASIS = [
 
 @pytest.mark.parametrize("fn", FNS_TWO_BASIS)
 def test_overlap_two_basis_same(fn):
-    with path('iodata.test.data', fn) as pth:
+    with as_file(files("iodata.test.data").joinpath(fn)) as pth:
         mol = load_one(pth)
     olp_a = compute_overlap(mol.obasis, mol.atcoords, mol.obasis, mol.atcoords)
     olp_b = compute_overlap(mol.obasis, mol.atcoords)
@@ -120,9 +119,9 @@ def test_overlap_two_basis_same(fn):
 
 @pytest.mark.parametrize("fn0,fn1", itertools.combinations_with_replacement(FNS_TWO_BASIS, 2))
 def test_overlap_two_basis_different(fn0, fn1):
-    with path('iodata.test.data', fn0) as pth0:
+    with as_file(files("iodata.test.data").joinpath(fn0)) as pth0:
         mol0 = load_one(pth0)
-    with path('iodata.test.data', fn1) as pth1:
+    with as_file(files("iodata.test.data").joinpath(fn1)) as pth1:
         mol1 = load_one(pth1)
     # Direct computation of the off-diagonal block.
     olp_a = compute_overlap(mol0.obasis, mol0.atcoords, mol1.obasis, mol1.atcoords)

--- a/iodata/test/test_pdb.py
+++ b/iodata/test/test_pdb.py
@@ -19,30 +19,30 @@
 """Test iodata.formats.pdb module."""
 
 import os
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 import pytest
 
 from ..api import load_one, load_many, dump_one, dump_many
 from ..utils import angstrom, FileFormatWarning
+
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 @pytest.mark.parametrize("case", ["single", "single_model"])
 def test_load_water(case):
     # test pdb of water
-    with path('iodata.test.data', f'water_{case}.pdb') as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath(f'water_{case}.pdb')) as fn_pdb:
         mol = load_one(str(fn_pdb))
     check_water(mol)
 
 
 def test_load_water_no_end():
     # test pdb of water
-    with path('iodata.test.data', 'water_single_no_end.pdb') as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath('water_single_no_end.pdb')) as fn_pdb:
         with pytest.warns(FileFormatWarning, match="The END is not found"):
             mol = load_one(str(fn_pdb))
     check_water(mol)
@@ -95,7 +95,7 @@ def check_load_dump_consistency(tmpdir, fn):
     "2bcw.pdb",
 ])
 def test_load_dump_consistency(fn_base, tmpdir):
-    with path('iodata.test.data', fn_base) as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath(fn_base)) as fn_pdb:
         check_load_dump_consistency(tmpdir, fn_pdb)
 
 
@@ -124,13 +124,13 @@ def check_load_dump_xyz_consistency(tmpdir, fn):
 
 
 def test_load_dump_xyz_consistency(tmpdir):
-    with path('iodata.test.data', 'water.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water.xyz")) as fn_xyz:
         check_load_dump_xyz_consistency(tmpdir, fn_xyz)
 
 
 def test_load_peptide_2luv():
     # test pdb of small peptide
-    with path('iodata.test.data', '2luv.pdb') as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath("2luv.pdb")) as fn_pdb:
         mol = load_one(str(fn_pdb))
     assert mol.title.startswith("INTEGRIN")
     assert_equal(len(mol.atnums), 547)
@@ -150,7 +150,7 @@ def test_load_peptide_2luv():
 
 @pytest.mark.parametrize("case", ['trajectory', 'trajectory_no_model'])
 def test_load_many(case):
-    with path('iodata.test.data', f"water_{case}.pdb") as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath(f"water_{case}.pdb")) as fn_pdb:
         mols = list(load_many(str(fn_pdb)))
     assert len(mols) == 5
     for mol in mols:
@@ -166,7 +166,7 @@ def test_load_many(case):
 
 @pytest.mark.parametrize("case", ['trajectory', 'trajectory_no_model'])
 def test_load_dump_many_consistency(case, tmpdir):
-    with path('iodata.test.data', f"water_{case}.pdb") as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath(f"water_{case}.pdb")) as fn_pdb:
         mols0 = list(load_many(str(fn_pdb)))
     # write pdb file in a temporary folder & then read it
     fn_tmp = os.path.join(tmpdir, 'test')
@@ -181,7 +181,7 @@ def test_load_dump_many_consistency(case, tmpdir):
 
 def test_load_2bcw():
     # test pdb with multiple chains
-    with path("iodata.test.data", "2bcw.pdb") as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath("2bcw.pdb")) as fn_pdb:
         mol = load_one(fn_pdb)
     assert mol.title == """\
 COORDINATES OF THE N-TERMINAL DOMAIN OF RIBOSOMAL PROTEIN L11,C-
@@ -215,6 +215,6 @@ SYNONYM: EF-G"""
 
 
 def test_load_ch5plus_bonds():
-    with path("iodata.test.data", "ch5plus.pdb") as fn_pdb:
+    with as_file(files("iodata.test.data").joinpath("ch5plus.pdb")) as fn_pdb:
         mol = load_one(fn_pdb)
     assert_equal(mol.bonds[:, :2], [[0, 1], [0, 2], [0, 3], [0, 4], [0, 5]])

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -20,7 +20,6 @@
 """Test iodata.formats.poscar module."""
 
 import os
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
@@ -28,13 +27,13 @@ from ..api import load_one, dump_one
 from ..utils import angstrom, volume
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_poscar_water():
-    with path('iodata.test.data', 'POSCAR.water') as fn:
+    with as_file(files("iodata.test.data").joinpath("POSCAR.water")) as fn:
         mol = load_one(str(fn))
     assert mol.title == 'Water molecule in a box'
     assert_equal(mol.atnums, [8, 1, 1])
@@ -44,7 +43,7 @@ def test_load_poscar_water():
 
 
 def test_load_poscar_cubicbn_cartesian():
-    with path('iodata.test.data', 'POSCAR.cubicbn_cartesian') as fn:
+    with as_file(files("iodata.test.data").joinpath("POSCAR.cubicbn_cartesian")) as fn:
         mol = load_one(str(fn))
     assert mol.title == 'Cubic BN'
     assert_equal(mol.atnums, [5, 7])
@@ -54,7 +53,7 @@ def test_load_poscar_cubicbn_cartesian():
 
 
 def test_load_poscar_cubicbn_direct():
-    with path('iodata.test.data', 'POSCAR.cubicbn_direct') as fn:
+    with as_file(files("iodata.test.data").joinpath("POSCAR.cubicbn_direct")) as fn:
         mol = load_one(str(fn))
     assert mol.title == 'Cubic BN'
     assert_equal(mol.atnums, [5, 7])
@@ -64,7 +63,7 @@ def test_load_poscar_cubicbn_direct():
 
 
 def test_load_dump_consistency(tmpdir):
-    with path('iodata.test.data', 'water_element.xyz') as fn:
+    with as_file(files("iodata.test.data").joinpath("water_element.xyz")) as fn:
         mol0 = load_one(str(fn))
     # random matrix generated from a uniform distribution on [0., 5.0)
     mol0.cellvecs = np.array([[2.05278155, 0.23284023, 1.59024118],

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -26,14 +26,14 @@ from ..formats.qchemlog import load_qchemlog_low
 from ..utils import LineIterator, angstrom, kjmol
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_load_qchemlog_low_h2o():
     """Test load_qchemlog_low with water_hf_ccpvtz_freq_qchem.out."""
-    with path('iodata.test.data', 'water_hf_ccpvtz_freq_qchem.out') as fq:
+    with as_file(files("iodata.test.data").joinpath("water_hf_ccpvtz_freq_qchem.out")) as fq:
         data = load_qchemlog_low(LineIterator(str(fq)))
 
     # check loaded data
@@ -114,7 +114,8 @@ def test_load_qchemlog_low_h2o():
 
 
 def test_load_one_qchemlog_freq():
-    with path('iodata.test.data', 'water_hf_ccpvtz_freq_qchem.out') as fn_qchemlog:
+    source = files("iodata.test.data").joinpath("water_hf_ccpvtz_freq_qchem.out")
+    with as_file(source) as fn_qchemlog:
         mol = load_one(str(fn_qchemlog), fmt='qchemlog')
     assert_allclose(mol.energy, -76.0571936393)
     assert mol.g_rot == 1
@@ -196,7 +197,7 @@ def test_load_one_qchemlog_freq():
 def test_load_qchemlog_low_qchemlog_h2o_dimer_eda2():
     """Test load_qchemlog_low with h2o_dimer_eda_qchem5.3.out."""
     # pylint: disable=too-many-statements
-    with path('iodata.test.data', 'h2o_dimer_eda_qchem5.3.out') as fq:
+    with as_file(files("iodata.test.data").joinpath("h2o_dimer_eda_qchem5.3.out")) as fq:
         data = load_qchemlog_low(LineIterator(str(fq)))
 
     # check loaded data
@@ -283,7 +284,7 @@ def test_load_qchemlog_low_qchemlog_h2o_dimer_eda2():
 def test_load_one_h2o_dimer_eda2():
     """Test load_one with h2o_dimer_eda_qchem5.3.out."""
     # pylint: disable=too-many-statements
-    with path('iodata.test.data', 'h2o_dimer_eda_qchem5.3.out') as fn_qchemlog:
+    with as_file(files("iodata.test.data").joinpath("h2o_dimer_eda_qchem5.3.out")) as fn_qchemlog:
         mol = load_one(str(fn_qchemlog), fmt='qchemlog')
 
     # check loaded data

--- a/iodata/test/test_sdf.py
+++ b/iodata/test/test_sdf.py
@@ -19,7 +19,6 @@
 """Test iodata.formats.sdf module."""
 
 import os
-
 import pytest
 from numpy.testing import assert_equal, assert_allclose
 
@@ -28,21 +27,21 @@ from ..api import load_one, load_many, dump_one, dump_many
 from ..utils import angstrom, FileFormatError
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def test_sdf_load_one_example():
     # test sdf one structure
-    with path('iodata.test.data', 'example.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("example.sdf")) as fn_sdf:
         mol = load_one(str(fn_sdf))
     check_example(mol)
 
 
 def test_sdf_load_one_formamide():
     # test sdf one structure
-    with path('iodata.test.data', 'formamide.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("formamide.sdf")) as fn_sdf:
         mol = load_one(str(fn_sdf))
     assert mol.title == "713"
     assert mol.natom == 6
@@ -53,7 +52,7 @@ def test_sdf_load_one_formamide():
 
 def test_sdf_formaterror(tmpdir):
     # test if sdf file has the wrong ending without $$$$
-    with path('iodata.test.data', 'example.sdf') as fn_test:
+    with as_file(files("iodata.test.data").joinpath("example.sdf")) as fn_test:
         with truncated_file(fn_test, 36, 0, tmpdir) as fn:
             with pytest.raises(IOError):
                 load_one(str(fn))
@@ -91,17 +90,17 @@ def check_load_dump_consistency(tmpdir, fn):
 
 
 def test_load_dump_consistency(tmpdir):
-    with path('iodata.test.data', 'example.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("example.sdf")) as fn_sdf:
         check_load_dump_consistency(tmpdir, fn_sdf)
-    with path('iodata.test.data', 'formamide.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("formamide.sdf")) as fn_sdf:
         check_load_dump_consistency(tmpdir, fn_sdf)
     # The benzene mol2 file has aromatic bonds, which are less common in SDF files.
-    with path('iodata.test.data', 'benzene.mol2') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("benzene.mol2")) as fn_sdf:
         check_load_dump_consistency(tmpdir, fn_sdf)
 
 
 def test_load_many():
-    with path('iodata.test.data', 'example.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("example.sdf")) as fn_sdf:
         mols = list(load_many(str(fn_sdf)))
     assert len(mols) == 2
     check_example(mols[0])
@@ -112,7 +111,7 @@ def test_load_many():
 
 
 def test_load_dump_many_consistency(tmpdir):
-    with path('iodata.test.data', 'example.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("example.sdf")) as fn_sdf:
         mols0 = list(load_many(str(fn_sdf)))
     # write sdf file in a temporary folder & then read it
     fn_tmp = os.path.join(tmpdir, 'test')
@@ -127,6 +126,6 @@ def test_load_dump_many_consistency(tmpdir):
 
 
 def test_v2000_check():
-    with path('iodata.test.data', 'molv3000.sdf') as fn_sdf:
+    with as_file(files("iodata.test.data").joinpath("molv3000.sdf")) as fn_sdf:
         with pytest.raises(FileFormatError):
             load_one(fn_sdf)

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -19,9 +19,7 @@
 """Test iodata.formats.wfn module."""
 
 import os
-
 import numpy as np
-
 from numpy.testing import assert_equal, assert_allclose
 
 from .common import compute_mulliken_charges, check_orthonormal, compare_mols
@@ -31,16 +29,16 @@ from ..overlap import compute_overlap
 from ..utils import LineIterator
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
+
 
 # TODO: removed density, kin, nucnuc checks
 
-
 def helper_load_wfn_low(fn_wfn):
     """Load a testing Gaussian log file with iodata.formats.wfn.load_wfn_low."""
-    with path('iodata.test.data', fn_wfn) as fn:
+    with as_file(files("iodata.test.data").joinpath(fn_wfn)) as fn:
         lit = LineIterator(str(fn))
         return load_wfn_low(lit)
 
@@ -130,7 +128,7 @@ def test_load_wfn_low_h2o():
 def check_wfn(fn_wfn, nbasis, energy, charges_mulliken):
     """Check that MO are orthonormal & energy and charges match expected values."""
     # load file
-    with path('iodata.test.data', fn_wfn) as file_wfn:
+    with as_file(files("iodata.test.data").joinpath(fn_wfn)) as file_wfn:
         mol = load_one(str(file_wfn))
     # check number of basis functions
     assert mol.obasis.nbasis == nbasis
@@ -243,7 +241,7 @@ def test_load_wfn_lih_cation_fci():
 
 
 def test_load_one_lih_cation_cisd():
-    with path('iodata.test.data', 'lih_cation_cisd.wfn') as file_wfn:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_cisd.wfn")) as file_wfn:
         mol = load_one(str(file_wfn))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'
@@ -259,7 +257,7 @@ def test_load_one_lih_cation_cisd():
 
 
 def test_load_one_lih_cation_uhf():
-    with path('iodata.test.data', 'lih_cation_uhf.wfn') as file_wfn:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_uhf.wfn")) as file_wfn:
         mol = load_one(str(file_wfn))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'
@@ -275,7 +273,7 @@ def test_load_one_lih_cation_uhf():
 
 
 def test_load_one_lih_cation_rohf():
-    with path('iodata.test.data', 'lih_cation_rohf.wfn') as file_wfn:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_rohf.wfn")) as file_wfn:
         mol = load_one(str(file_wfn))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'restricted'
@@ -292,7 +290,7 @@ def test_load_one_lih_cation_rohf():
 
 
 def test_load_one_cah110_hf_sto3g_g09():
-    with path('iodata.test.data', 'cah110_hf_sto3g_g09.wfn') as file_wfn:
+    with as_file(files("iodata.test.data").joinpath("cah110_hf_sto3g_g09.wfn")) as file_wfn:
         mol = load_one(str(file_wfn))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'
@@ -326,7 +324,7 @@ def check_load_dump_consistency(fn, tmpdir, fmt_from='wfn', fmt_to='wfn', atol=1
         Format of filename to dump and then load again.
 
     """
-    with path('iodata.test.data', fn) as file_name:
+    with as_file(files("iodata.test.data").joinpath(fn)) as file_name:
         mol1 = load_one(str(file_name), fmt=fmt_from)
     fn_tmp = os.path.join(tmpdir, 'foo.bar')
     dump_one(mol1, fn_tmp, fmt=fmt_to)

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -19,7 +19,6 @@
 """Test iodata.formats.wfn module."""
 
 import os
-
 import pytest
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
@@ -33,14 +32,14 @@ from .common import (check_orthonormal, truncated_file, compare_mols,
                      compute_mulliken_charges, load_one_warning)
 
 try:
-    from importlib_resources import path
+    from importlib_resources import as_file, files
 except ImportError:
-    from importlib.resources import path
+    from importlib.resources import as_file, files
 
 
 def helper_load_data_wfx(fn_wfx):
     """Load a testing WFX file with iodata.formats.wfx.load_data_wfx."""
-    with path('iodata.test.data', fn_wfx) as fx:
+    with as_file(files("iodata.test.data").joinpath(fn_wfx)) as fx:
         lit = LineIterator(str(fx))
         return load_data_wfx(lit)
 
@@ -55,7 +54,7 @@ def check_load_dump_consistency(fn, tmpdir):
     tmpdir : str
         The temporary directory to dump and load the file.
     """
-    with path('iodata.test.data', fn) as file_name:
+    with as_file(files("iodata.test.data").joinpath(fn)) as file_name:
         mol1 = load_one(str(file_name), fmt='wfx')
     fn_tmp = os.path.join(tmpdir, 'foo.bar')
     dump_one(mol1, fn_tmp, fmt='wfx')
@@ -353,7 +352,7 @@ def test_load_data_wfx_water():
 
 def test_parse_wfx_missing_tag_h2o():
     """Check that missing sections result in an exception."""
-    with path('iodata.test.data', 'water_sto3g_hf.wfx') as fn_wfx:
+    with as_file(files("iodata.test.data").joinpath("water_sto3g_hf.wfx")) as fn_wfx:
         lit = LineIterator(fn_wfx)
         with pytest.raises(IOError) as error:
             parse_wfx(lit, required_tags=["<Foo Bar>"])
@@ -362,7 +361,7 @@ def test_parse_wfx_missing_tag_h2o():
 
 def test_load_data_wfx_h2o_error():
     """Check that sections without a closing tag result in an exception."""
-    with path('iodata.test.data', 'h2o_error.wfx') as fn_wfx:
+    with as_file(files("iodata.test.data").joinpath("h2o_error.wfx")) as fn_wfx:
         with pytest.raises(IOError) as error:
             load_one(str(fn_wfx))
     assert str(error.value).endswith(
@@ -371,7 +370,7 @@ def test_load_data_wfx_h2o_error():
 
 def test_load_truncated_h2o(tmpdir):
     """Check that a truncated file raises an exception."""
-    with path('iodata.test.data', 'water_sto3g_hf.wfx') as fn_wfx:
+    with as_file(files("iodata.test.data").joinpath("water_sto3g_hf.wfx")) as fn_wfx:
         with truncated_file(str(fn_wfx), 152, 0, tmpdir) as fn_truncated:
             with pytest.raises(IOError) as error:
                 load_one(str(fn_truncated))
@@ -381,7 +380,7 @@ def test_load_truncated_h2o(tmpdir):
 
 def test_load_one_h2o():
     """Test load_one with h2o sto-3g WFX input."""
-    with path('iodata.test.data', 'water_sto3g_hf.wfx') as file_wfx:
+    with as_file(files("iodata.test.data").joinpath("water_sto3g_hf.wfx")) as file_wfx:
         mol = load_one(str(file_wfx))
     assert_allclose(mol.atcoords,
                     np.array([[0.00000000e+00, 0.00000000e+00, 2.40242907e-01],
@@ -429,7 +428,7 @@ def test_load_one_h2o():
 
 def test_load_one_h2():
     """Test load_one with h2 ub3lyp_ccpvtz WFX input."""
-    with path('iodata.test.data', 'h2_ub3lyp_ccpvtz.wfx') as file_wfx:
+    with as_file(files("iodata.test.data").joinpath("h2_ub3lyp_ccpvtz.wfx")) as file_wfx:
         mol = load_one(str(file_wfx))
     assert_allclose(mol.atcoords,
                     np.array([[0.0, 0.0, 0.7019452462164],
@@ -468,7 +467,7 @@ def test_load_one_h2():
 
 
 def test_load_one_lih_cation_cisd():
-    with path('iodata.test.data', 'lih_cation_cisd.wfx') as file_wfx:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_cisd.wfx")) as file_wfx:
         mol = load_one(str(file_wfx))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'
@@ -491,7 +490,7 @@ def test_load_one_lih_cation_cisd():
 
 
 def test_load_one_lih_cation_uhf():
-    with path('iodata.test.data', 'lih_cation_uhf.wfx') as file_wfx:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_uhf.wfx")) as file_wfx:
         mol = load_one(str(file_wfx))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'unrestricted'
@@ -507,7 +506,7 @@ def test_load_one_lih_cation_uhf():
 
 
 def test_load_one_lih_cation_rohf():
-    with path('iodata.test.data', 'lih_cation_rohf.wfx') as file_wfx:
+    with as_file(files("iodata.test.data").joinpath("lih_cation_rohf.wfx")) as file_wfx:
         mol = load_one(str(file_wfx))
     # check number of orbitals and occupation numbers
     assert mol.mo.kind == 'restricted'

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -19,29 +19,28 @@
 """Test iodata.formats.xyz module."""
 
 import os
-
 import numpy as np
 from numpy.testing import assert_equal, assert_allclose
 
 from ..api import load_one, load_many, dump_one, dump_many
 from ..utils import angstrom
 from ..formats.xyz import DEFAULT_ATOM_COLUMNS
-try:
-    from importlib_resources import path
-except ImportError:
-    from importlib.resources import path
 
+try:
+    from importlib_resources import as_file, files
+except ImportError:
+    from importlib.resources import as_file, files
 
 def test_load_water_number():
     # test xyz with atomic numbers
-    with path('iodata.test.data', 'water_number.xyz') as fn_xyz:
+    with as_file(files('iodata.test.data').joinpath('water_number.xyz')) as fn_xyz:
         mol = load_one(str(fn_xyz))
     check_water(mol)
 
 
 def test_load_water_element():
     # test xyz file with atomic symbols
-    with path('iodata.test.data', 'water_element.xyz') as fn_xyz:
+    with as_file(files('iodata.test.data').joinpath('water_element.xyz')) as fn_xyz:
         mol = load_one(str(fn_xyz))
     check_water(mol)
 
@@ -73,7 +72,7 @@ FCC_ATOM_COLUMNS = DEFAULT_ATOM_COLUMNS + [
 
 
 def test_load_fcc_columns():
-    with path('iodata.test.data', 'al_fcc.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("al_fcc.xyz")) as fn_xyz:
         mol = load_one(str(fn_xyz), atom_columns=FCC_ATOM_COLUMNS)
     assert "zs" in mol.extra
     assert mol.extra["zs"].dtype == int
@@ -108,27 +107,27 @@ def check_load_dump_consistency(tmpdir, fn, atom_columns=None):
 
 
 def test_load_dump_consistency(tmpdir):
-    with path('iodata.test.data', 'ch3_hf_sto3g.fchk') as fn_fchk:
+    with as_file(files("iodata.test.data").joinpath("ch3_hf_sto3g.fchk")) as fn_fchk:
         check_load_dump_consistency(tmpdir, str(fn_fchk))
 
 
 def test_dump_xyz_water_element(tmpdir):
-    with path('iodata.test.data', 'water_element.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water_element.xyz")) as fn_xyz:
         check_load_dump_consistency(tmpdir, str(fn_xyz))
 
 
 def test_dump_xyz_water_number(tmpdir):
-    with path('iodata.test.data', 'water_number.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water_number.xyz")) as fn_xyz:
         check_load_dump_consistency(tmpdir, str(fn_xyz))
 
 
 def test_dump_xyz_fcc(tmpdir):
-    with path('iodata.test.data', 'al_fcc.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("al_fcc.xyz")) as fn_xyz:
         check_load_dump_consistency(tmpdir, str(fn_xyz), FCC_ATOM_COLUMNS)
 
 
 def test_load_many():
-    with path('iodata.test.data', 'water_trajectory.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water_trajectory.xyz")) as fn_xyz:
         mols = list(load_many(str(fn_xyz)))
     assert len(mols) == 5
     for imol, mol in enumerate(mols):
@@ -141,7 +140,7 @@ def test_load_many():
 
 
 def test_load_many_dataset_emptylines():
-    with path('iodata.test.data', 'dataset_blanklines.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("dataset_blanklines.xyz")) as fn_xyz:
         mols = list(load_many(str(fn_xyz)))
     assert len(mols) == 3
     # Check 1st item
@@ -165,7 +164,7 @@ def test_load_many_dataset_emptylines():
 
 
 def test_load_dump_many_consistency(tmpdir):
-    with path('iodata.test.data', 'water_trajectory.xyz') as fn_xyz:
+    with as_file(files("iodata.test.data").joinpath("water_trajectory.xyz")) as fn_xyz:
         mols0 = list(load_many(str(fn_xyz)))
     # write xyz file in a temporary folder & then read it
     fn_tmp = os.path.join(tmpdir, 'test')

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -31,6 +31,7 @@ try:
 except ImportError:
     from importlib.resources import as_file, files
 
+
 def test_load_water_number():
     # test xyz with atomic numbers
     with as_file(files('iodata.test.data').joinpath('water_number.xyz')) as fn_xyz:


### PR DESCRIPTION
DeprecationWarning: path is deprecated. Use files() instead. Refer to https://importlib-resources.readthedocs.io/en/latest/using.html#migrating-from-legacy for migration advice.