### PR TITLE
Depend on importlib_resources for py37 for as_file api

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -75,5 +75,5 @@ setup(
     ],
     setup_requires=['numpy>=1.0'],
     install_requires=['numpy>=1.0', 'scipy', 'attrs>=20.1.0',
-                      'importlib_resources; python_version < "3.7"'],
+                      'importlib_resources; python_version < "3.8"'],
 )


### PR DESCRIPTION
This is a fix for py37 related to the recently merged #296

See https://github.com/theochem/iodata/actions/runs/4900272755/jobs/8750814221#step:6:933

I've locally reproduced the bug and tested the fix with py37.

It is a minor change, so I'll YOLO-merge this in the absence of comments after May 10.