### PR TITLE
Add workaround for scipy.special.factorial2 changes

### DIFF
--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -22,13 +22,31 @@ from typing import Optional
 
 import attr
 import numpy as np
-from scipy.special import binom, factorial2
+import scipy.special
 
 from .overlap_cartpure import tfs
 from .basis import convert_conventions, iter_cart_alphabet, MolecularBasis
 from .basis import HORTON2_CONVENTIONS as OVERLAP_CONVENTIONS
 
-__all__ = ['OVERLAP_CONVENTIONS', 'compute_overlap', 'gob_cart_normalization']
+__all__ = ["OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization"]
+
+
+def factorial2(n, exact=False):
+    """Wrap scipy.special.factorial2 to return 1.0 when the input is not positive.
+
+    This is a temporary workaround while we wait for Scipy's update.
+    To learn more, see https://github.com/scipy/scipy/issues/18409.
+
+    Parameters
+    ----------
+    n : int or np.ndarray
+        Values to calculate n!! for. If n <= 0, the return value is 1.
+    """
+    # Scipy  1.11.x returns an integer when n is an integer, but 1.10.x returns an array,
+    # so np.array(n) is passed to make sure the output is always an array.
+    out = scipy.special.factorial2(np.array(n), exact=exact)
+    out[out <= 0] = 1.0
+    return out
 
 
 # pylint: disable=too-many-nested-blocks,too-many-statements,too-many-branches
@@ -214,7 +232,9 @@ class GaussianOverlap:
             Maximum angular momentum.
 
         """
-        self.binomials = [[binom(n, i) for i in range(n + 1)] for n in range(n_max + 1)]
+        self.binomials = [
+            [scipy.special.binom(n, i) for i in range(n + 1)] for n in range(n_max + 1)
+        ]
         facts = [factorial2(m, 2) for m in range(2 * n_max)]
         facts.insert(0, 1)
         self.facts = np.array(facts)

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -32,7 +32,7 @@ __all__ = ["OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization"]
 
 
 def factorial2(n, exact=False):
-    """Wrap scipy.special.factorial2 to return 1.0 when the input is not positive.
+    """Wrap scipy.special.factorial2 to return 1.0 when the input is -1.
 
     This is a temporary workaround while we wait for Scipy's update.
     To learn more, see https://github.com/scipy/scipy/issues/18409.
@@ -40,12 +40,14 @@ def factorial2(n, exact=False):
     Parameters
     ----------
     n : int or np.ndarray
-        Values to calculate n!! for. If n <= 0, the return value is 1.
+        Values to calculate n!! for. If n={0, -1}, the return value is 1.
+        For n < -1, the return value is 0.
     """
     # Scipy  1.11.x returns an integer when n is an integer, but 1.10.x returns an array,
     # so np.array(n) is passed to make sure the output is always an array.
     out = scipy.special.factorial2(np.array(n), exact=exact)
     out[out <= 0] = 1.0
+    out[out <= -2] = 0.0
     return out
 
 


### PR DESCRIPTION
This PR adds a `factorial2` function that wraps `scipy.special.factorial2` to return 1.0 when the input is not positive. This is a temporary addition, while we wait for Scipy's update. To learn more, see https://github.com/scipy/scipy/issues/18409. This is a better solution than limiting Scipy version that works with IOData, as one might need to use scipy `1.11.x` in their environment for other purposes. A similar change was made in other QC-Devs packages; see https://github.com/theochem/gbasis/pull/138.