### PR TITLE
Fix Python 3.12 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,9 @@ celerybeat-schedule
 # dotenv
 .env
 
+# direnv
+.envrc
+
 # virtualenv
 .venv
 venv/

--- a/iodata/formats/extxyz.py
+++ b/iodata/formats/extxyz.py
@@ -27,7 +27,6 @@ handle an XYZ with different molecules, e.g. a molecular database.
 
 """
 
-from distutils.util import strtobool
 import shlex
 from typing import Iterator
 
@@ -35,7 +34,7 @@ import numpy as np
 
 from ..docstrings import document_load_one, document_load_many
 from ..periodic import sym2num, num2sym
-from ..utils import angstrom, amu, LineIterator
+from ..utils import angstrom, amu, LineIterator, strtobool
 
 from .xyz import load_one as load_one_xyz
 

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -22,14 +22,13 @@ This module will load Q-Chem log file into IODATA.
 """
 
 from typing import Tuple
-from distutils.util import strtobool
 
 import numpy as np
 
 from ..docstrings import document_load_one
 from ..orbitals import MolecularOrbitals
 from ..periodic import sym2num
-from ..utils import LineIterator, angstrom, kcalmol, calmol, kjmol
+from ..utils import LineIterator, angstrom, kcalmol, calmol, kjmol, strtobool
 
 __all__ = []
 

--- a/iodata/test/test_utils.py
+++ b/iodata/test/test_utils.py
@@ -18,9 +18,18 @@
 # --
 """Unit tests for iodata.utils."""
 
+import pytest
 
-from ..utils import amu
+from ..utils import amu, strtobool
 
 
 def test_amu():
     assert abs(amu * 1.008 - 1837.47) < 1e-1
+
+
+def test_strtobool():
+    assert strtobool("T") is True
+    assert strtobool("false") is False
+    assert strtobool("y") is True
+    with pytest.raises(ValueError):
+        strtobool("whatever")

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -31,7 +31,7 @@ from .attrutils import validate_shape
 
 
 __all__ = ['LineIterator', 'Cube', 'set_four_index_element', 'volume',
-           'derive_naturals', 'check_dm']
+           'derive_naturals', 'check_dm', 'strtobool']
 
 
 # The unit conversion factors below can be used as follows:
@@ -263,3 +263,27 @@ def check_dm(dm: np.ndarray, overlap: np.ndarray, eps: float = 1e-4, occ_max: fl
     if occupations.max() > occ_max + eps:
         raise ValueError('The density matrix has eigenvalues considerably larger than '
                          'max. error=%e' % (occupations.max() - 1))
+
+
+STRTOBOOL = {
+    'y': True,
+    'yes': True,
+    't': True,
+    'true': True,
+    'on': True,
+    '1': True,
+    'n': False,
+    'no': False,
+    'f': False,
+    'false': False,
+    'off': False,
+    '0': False
+}
+
+
+def strtobool(value: str) -> bool:
+    """Interpret string as a boolean."""
+    result = STRTOBOOL.get(value.lower())
+    if result is None:
+        raise ValueError(f"'{value}' cannot be converted to boolean")
+    return result


### PR DESCRIPTION
The `distutils` package is deprecated and no longer available in Python 3.12. We only used the `strtobool` function from `distutils`. This PR adds a `strtobool` replacement to `iodata.utils` and changes the imports from `distutils` by imports from our own `utils.py`.

I've also added `.envrc` to `.gitignore` because it is a local file I'm often using to manage different software envs.