### PR TITLE
Fix documentation build issues

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,28 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+  configuration: docs/conf.py
+  # You can configure Sphinx to use a different builder, for instance use the dirhtml builder for simpler URLs
+  # builder: "dirhtml"
+  # Fail on all warnings to avoid broken references
+  # fail_on_warning: true
+
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+ python:
+   install:
+     - requirements: docs/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -102,7 +102,7 @@ release = ""
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = "en"
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
@@ -206,10 +206,6 @@ epub_copyright = copyright
 
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = ["search.html"]
-
-# Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {"https://docs.python.org/": None}
-
 
 # -- Configuration for autodoc extensions ---------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 dynamic = ["version"]
 
 [project.optional-dependencies]
-dev = ["pytest", "pytest-xdist"]
+dev = ["pytest", "pytest-xdist", "sphinx", "sphinx_autodoc_typehints", "sphinx-rtd-theme"]
 
 [project.urls]
 Documentation = "https://iodata.readthedocs.io/en/latest/"

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-build:
-  image: latest
-
-conda:
-  file: environment.yml


### PR DESCRIPTION
Our documentation build on read-the-docs (RTD) is failing. This should fix it, hopefully.

Because this can only be fully tested by merging the PR and monitoring the doc build in RTD, I will merge this soon.

Ideally, we get rid of RTD for the following reasons:

- RTD supports only one admin account per project, i.e. bus-factor 1 by construction, unless one shares passwords, which is a bad idea anyway.
- Testing the RTD build is only possible after merging.

As an alternative, we can build the documentation in a GitHub Action and host it on gh-pages instead.