### PR TITLE
Provide some guidance for keeping the Changelog up-to-date

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -20,11 +20,19 @@
     :
     : --
 
-IOData Changelog
-=================
+Changelog
+#########
 
+All notable changes to this project will be documented in this file.
 
-**Version 1.0.0**
+The format is based on `Keep a Changelog <https://keepachangelog.com/en/1.1.0/>`_,
+and this project adheres to `Semantic Versioning <https://semver.org/spec/v2.0.0.html>`_.
+
+`Unreleased`_
+=============
+
+Changed
+-------
 
 Originally, IOData was a subpackage of HORTON2. It is currently factored out,
 modernized and ported to Python 3. In this process, the API was seriously
@@ -64,3 +72,6 @@ contains the following API-breaking changes:
 In addition, several new attributes were added to the ``IOData`` class, and
 several of them can also be read from file formats we already supported
 previously. This work will be expanded upon in future releases.
+
+
+.. _Unreleased: https://github.com/theochem/iodata


### PR DESCRIPTION
This is one of the smaller items on the list in #313.

For more details, see https://keepachangelog.com/en/1.1.0/ (It is written for Markdown, but easy enough to follow the same practices in restructured text.) This is not a big change, mainly providing some more guidance on how to write helpful changelogs.

This is mainly going to be of use when we have a first stable release, but it is better to have it in place already before that time.