### PR TITLE
Remove import_resources try-except block

### DIFF
--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -20,6 +20,7 @@
 
 import os
 from contextlib import contextmanager
+from importlib.resources import as_file, files
 from typing import Optional
 
 import numpy as np
@@ -30,11 +31,6 @@ from ..api import load_one
 from ..basis import convert_conventions
 from ..overlap import compute_overlap
 from ..utils import FileFormatWarning
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 __all__ = [
     "compute_mulliken_charges",

--- a/iodata/test/test_charmm.py
+++ b/iodata/test/test_charmm.py
@@ -18,15 +18,12 @@
 # --
 """Test iodata.formats.orcalog module."""
 
+from importlib.resources import as_file, files
+
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..utils import amu, angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_crambin():

--- a/iodata/test/test_chgcar.py
+++ b/iodata/test/test_chgcar.py
@@ -18,16 +18,13 @@
 # --
 """Test iodata.formats.chgcar module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..utils import angstrom, volume
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_chgcar_oxygen():

--- a/iodata/test/test_cli.py
+++ b/iodata/test/test_cli.py
@@ -22,16 +22,12 @@ import functools
 import os
 import subprocess
 import sys
+from importlib.resources import as_file, files
 
 from numpy.testing import assert_allclose, assert_equal
 
 from ..__main__ import convert
 from ..api import load_many, load_one
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def _check_convert_one(myconvert, tmpdir):

--- a/iodata/test/test_cp2klog.py
+++ b/iodata/test/test_cp2klog.py
@@ -18,17 +18,14 @@
 # --
 """Test iodata.formats.cp2klog module."""
 
+from importlib.resources import as_file, files
+
 import pytest
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..overlap import compute_overlap
 from .common import check_orthonormal, truncated_file
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_atom_si_uks():

--- a/iodata/test/test_cube.py
+++ b/iodata/test/test_cube.py
@@ -18,15 +18,12 @@
 # --
 """Test iodata.formats.cube module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import dump_one, load_one
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_aelta():

--- a/iodata/test/test_extxyz.py
+++ b/iodata/test/test_extxyz.py
@@ -18,16 +18,13 @@
 # --
 """Test iodata.formats.extxyz module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_many, load_one
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_fcc_extended():

--- a/iodata/test/test_fchk.py
+++ b/iodata/test/test_fchk.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.fchk module."""
 
 import os
+from importlib.resources import as_file, files
 from typing import Optional
 
 import numpy as np
@@ -30,11 +31,6 @@ from ..overlap import compute_overlap
 from ..utils import check_dm
 from .common import check_orthonormal, compare_mols, compute_1rdm, load_one_warning
 from .test_molekel import compare_mols_diff_formats
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_fchk_nonexistent():

--- a/iodata/test/test_fcidump.py
+++ b/iodata/test/test_fcidump.py
@@ -19,16 +19,12 @@
 """Test iodata.formats.fcidump module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import dump_one, load_one
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_fcidump_psi4_h2():

--- a/iodata/test/test_gamess.py
+++ b/iodata/test/test_gamess.py
@@ -18,15 +18,12 @@
 # --
 """Test iodata.formats.gamess module."""
 
+from importlib.resources import as_file, files
+
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_one_gamess_punch():

--- a/iodata/test/test_gaussianinput.py
+++ b/iodata/test/test_gaussianinput.py
@@ -18,16 +18,13 @@
 # --
 """Test iodata.formats.gaussianinput module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_raises
 
 from ..api import load_one
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_water_com():

--- a/iodata/test/test_gaussianlog.py
+++ b/iodata/test/test_gaussianlog.py
@@ -18,14 +18,11 @@
 # --
 """Test iodata.formats.log module."""
 
+from importlib.resources import as_file, files
+
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def load_log_helper(fn_log):

--- a/iodata/test/test_gromacs.py
+++ b/iodata/test/test_gromacs.py
@@ -18,15 +18,12 @@
 # --
 """Test iodata.formats.gromacs module."""
 
+from importlib.resources import as_file, files
+
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_many, load_one
 from ..utils import nanometer, picosecond
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_water():

--- a/iodata/test/test_inputs.py
+++ b/iodata/test/test_inputs.py
@@ -19,17 +19,13 @@
 """Test iodata.inputs module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 
 from ..api import load_one, write_input
 from ..iodata import IOData
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def check_load_input_and_compare(fname: str, fname_expected: str):

--- a/iodata/test/test_iodata.py
+++ b/iodata/test/test_iodata.py
@@ -19,6 +19,8 @@
 # ruff: noqa: SLF001
 """Test iodata.iodata module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 import pytest
 from numpy.testing import assert_allclose, assert_equal
@@ -26,11 +28,6 @@ from numpy.testing import assert_allclose, assert_equal
 from ..api import IOData, load_one
 from ..overlap import compute_overlap
 from .common import compute_1rdm
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_typecheck():

--- a/iodata/test/test_json.py
+++ b/iodata/test/test_json.py
@@ -20,18 +20,13 @@
 
 import json
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 import pytest
 
 from ..api import dump_one, load_one
 from ..utils import FileFormatError, FileFormatWarning
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
-
 
 # Tests for qcschema_molecule
 # GEOMS: dict of str: NDArray(N, 3)

--- a/iodata/test/test_locpot.py
+++ b/iodata/test/test_locpot.py
@@ -18,15 +18,12 @@
 # --
 """Test iodata.formats.locpot module."""
 
+from importlib.resources import as_file, files
+
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..utils import angstrom, electronvolt, volume
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_locpot_oxygen():

--- a/iodata/test/test_mol2.py
+++ b/iodata/test/test_mol2.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.mol2 module."""
 
 import os
+from importlib.resources import as_file, files
 
 import pytest
 from numpy.testing import assert_allclose, assert_equal
@@ -27,11 +28,6 @@ from ..api import dump_many, dump_one, load_many, load_one
 from ..periodic import bond2num
 from ..utils import angstrom
 from .common import truncated_file
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_mol2_load_one():

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -20,6 +20,7 @@
 
 import os
 import warnings
+from importlib.resources import as_file, files
 
 import attrs
 import numpy as np
@@ -32,11 +33,6 @@ from ..formats.molden import _load_low
 from ..overlap import OVERLAP_CONVENTIONS, compute_overlap
 from ..utils import FileFormatWarning, LineIterator, angstrom
 from .common import check_orthonormal, compare_mols, compute_mulliken_charges
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_molden_li2_orca():

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -20,6 +20,7 @@
 
 import os
 import warnings
+from importlib.resources import as_file, files
 from typing import Optional
 
 from numpy.testing import assert_allclose, assert_equal
@@ -29,11 +30,6 @@ from ..basis import convert_conventions
 from ..overlap import compute_overlap
 from ..utils import angstrom
 from .common import check_orthonormal, compare_mols, compute_mulliken_charges, load_one_warning
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def compare_mols_diff_formats(mol1, mol2):

--- a/iodata/test/test_mwfn.py
+++ b/iodata/test/test_mwfn.py
@@ -18,16 +18,13 @@
 # --
 """Test iodata.formats.mwfn module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..overlap import compute_overlap
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def load_helper(fn):

--- a/iodata/test/test_orcalog.py
+++ b/iodata/test/test_orcalog.py
@@ -18,16 +18,13 @@
 # --
 """Test iodata.formats.orcalog module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_water_number():

--- a/iodata/test/test_overlap.py
+++ b/iodata/test/test_overlap.py
@@ -19,6 +19,7 @@
 """Test iodata.overlap & iodata.overlap_accel modules."""
 
 import itertools
+from importlib.resources import as_file, files
 
 import attrs
 import numpy as np
@@ -28,11 +29,6 @@ from numpy.testing import assert_allclose
 from ..api import load_one
 from ..basis import MolecularBasis, Shell, convert_conventions
 from ..overlap import OVERLAP_CONVENTIONS, compute_overlap, factorial2
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 @pytest.mark.parametrize(

--- a/iodata/test/test_pdb.py
+++ b/iodata/test/test_pdb.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.pdb module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 import pytest
@@ -26,11 +27,6 @@ from numpy.testing import assert_allclose, assert_equal
 
 from ..api import dump_many, dump_one, load_many, load_one
 from ..utils import FileFormatWarning, angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 @pytest.mark.parametrize("case", ["single", "single_model"])

--- a/iodata/test/test_poscar.py
+++ b/iodata/test/test_poscar.py
@@ -19,17 +19,13 @@
 """Test iodata.formats.poscar module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import dump_one, load_one
 from ..utils import angstrom, volume
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_poscar_water():

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -18,17 +18,14 @@
 # --
 """Test iodata.formats.qchemlog module."""
 
+from importlib.resources import as_file, files
+
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
 
 from ..api import load_one
 from ..formats.qchemlog import load_qchemlog_low
 from ..utils import LineIterator, angstrom, kjmol
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_qchemlog_low_h2o():

--- a/iodata/test/test_sdf.py
+++ b/iodata/test/test_sdf.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.sdf module."""
 
 import os
+from importlib.resources import as_file, files
 
 import pytest
 from numpy.testing import assert_allclose, assert_equal
@@ -26,11 +27,6 @@ from numpy.testing import assert_allclose, assert_equal
 from ..api import dump_many, dump_one, load_many, load_one
 from ..utils import FileFormatError, angstrom
 from .common import truncated_file
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_sdf_load_one_example():

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.wfn module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -28,12 +29,6 @@ from ..formats.wfn import load_wfn_low
 from ..overlap import compute_overlap
 from ..utils import LineIterator
 from .common import check_orthonormal, compare_mols, compute_mulliken_charges
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
-
 
 # TODO: removed density, kin, nucnuc checks
 

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.wfn module."""
 
 import os
+from importlib.resources import as_file, files
 from typing import Optional
 
 import numpy as np
@@ -36,11 +37,6 @@ from .common import (
     load_one_warning,
     truncated_file,
 )
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def helper_load_data_wfx(fn_wfx):

--- a/iodata/test/test_xyz.py
+++ b/iodata/test/test_xyz.py
@@ -19,6 +19,7 @@
 """Test iodata.formats.xyz module."""
 
 import os
+from importlib.resources import as_file, files
 
 import numpy as np
 from numpy.testing import assert_allclose, assert_equal
@@ -26,11 +27,6 @@ from numpy.testing import assert_allclose, assert_equal
 from ..api import dump_many, dump_one, load_many, load_one
 from ..formats.xyz import DEFAULT_ATOM_COLUMNS
 from ..utils import angstrom
-
-try:
-    from importlib_resources import as_file, files
-except ImportError:
-    from importlib.resources import as_file, files
 
 
 def test_load_water_number():


### PR DESCRIPTION
Another small item on the list of #313 

These weird imports were only relevant for Python versions that are past their end of life: 3.6 and older.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the try-except blocks used for importing 'importlib_resources' to support older Python versions (3.6 and older). The code now directly imports from 'importlib.resources', simplifying the import statements and removing compatibility code for unsupported Python versions.

* **Enhancements**:
    - Removed try-except blocks for importing 'importlib_resources' in favor of direct imports from 'importlib.resources'.

<!-- Generated by sourcery-ai[bot]: end summary -->