### PR TITLE
Fix warning due to line iterator __del__

### DIFF
--- a/iodata/api.py
+++ b/iodata/api.py
@@ -136,11 +136,11 @@ def load_one(filename: str, fmt: Optional[str] = None, **kwargs) -> IOData:
 
     """
     format_module = _select_format_module(filename, "load_one", fmt)
-    lit = LineIterator(filename)
-    try:
-        iodata = IOData(**format_module.load_one(lit, **kwargs))
-    except StopIteration:
-        lit.error("File ended before all data was read.")
+    with LineIterator(filename) as lit:
+        try:
+            iodata = IOData(**format_module.load_one(lit, **kwargs))
+        except StopIteration:
+            lit.error("File ended before all data was read.")
     return iodata
 
 
@@ -168,12 +168,12 @@ def load_many(filename: str, fmt: Optional[str] = None, **kwargs) -> Iterator[IO
 
     """
     format_module = _select_format_module(filename, "load_many", fmt)
-    lit = LineIterator(filename)
-    try:
-        for data in format_module.load_many(lit, **kwargs):
-            yield IOData(**data)
-    except StopIteration:
-        return
+    with LineIterator(filename) as lit:
+        try:
+            for data in format_module.load_many(lit, **kwargs):
+                yield IOData(**data)
+        except StopIteration:
+            return
 
 
 def dump_one(iodata: IOData, filename: str, fmt: Optional[str] = None, **kwargs):

--- a/iodata/formats/json.py
+++ b/iodata/formats/json.py
@@ -589,7 +589,7 @@ PATTERNS = ["*.json"]
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     # Use python standard lib json module to read the file to a dict
-    json_in = json.load(lit.f)
+    json_in = json.load(lit.fh)
     return _parse_json(json_in, lit)
 
 

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -127,8 +127,10 @@ def test_load_molden_nh3_molden_pure():
 
 
 def test_load_molden_low_nh3_molden_cart():
-    with as_file(files("iodata.test.data").joinpath("nh3_molden_cart.molden")) as fn_molden:
-        lit = LineIterator(str(fn_molden))
+    with (
+        as_file(files("iodata.test.data").joinpath("nh3_molden_cart.molden")) as fn_molden,
+        LineIterator(str(fn_molden)) as lit,
+    ):
         data = _load_low(lit)
     obasis = data["obasis"]
     assert obasis.nbasis == 52

--- a/iodata/test/test_qchemlog.py
+++ b/iodata/test/test_qchemlog.py
@@ -30,8 +30,11 @@ from ..utils import LineIterator, angstrom, kjmol
 
 def test_load_qchemlog_low_h2o():
     """Test load_qchemlog_low with water_hf_ccpvtz_freq_qchem.out."""
-    with as_file(files("iodata.test.data").joinpath("water_hf_ccpvtz_freq_qchem.out")) as fq:
-        data = load_qchemlog_low(LineIterator(str(fq)))
+    with (
+        as_file(files("iodata.test.data").joinpath("water_hf_ccpvtz_freq_qchem.out")) as fq,
+        LineIterator(str(fq)) as lit,
+    ):
+        data = load_qchemlog_low(lit)
 
     # check loaded data
     assert data["run_type"] == "freq"
@@ -535,8 +538,11 @@ def test_load_one_qchemlog_freq():
 
 def test_load_qchemlog_low_qchemlog_h2o_dimer_eda2():
     """Test load_qchemlog_low with h2o_dimer_eda_qchem5.3.out."""
-    with as_file(files("iodata.test.data").joinpath("h2o_dimer_eda_qchem5.3.out")) as fq:
-        data = load_qchemlog_low(LineIterator(str(fq)))
+    with (
+        as_file(files("iodata.test.data").joinpath("h2o_dimer_eda_qchem5.3.out")) as fq,
+        LineIterator(str(fq)) as lit,
+    ):
+        data = load_qchemlog_low(lit)
 
     # check loaded data
     assert data["run_type"] == "eda"

--- a/iodata/test/test_wfn.py
+++ b/iodata/test/test_wfn.py
@@ -35,8 +35,7 @@ from .common import check_orthonormal, compare_mols, compute_mulliken_charges
 
 def helper_load_wfn_low(fn_wfn):
     """Load a testing Gaussian log file with iodata.formats.wfn.load_wfn_low."""
-    with as_file(files("iodata.test.data").joinpath(fn_wfn)) as fn:
-        lit = LineIterator(str(fn))
+    with as_file(files("iodata.test.data").joinpath(fn_wfn)) as fn, LineIterator(str(fn)) as lit:
         return load_wfn_low(lit)
 
 

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -41,8 +41,7 @@ from .common import (
 
 def helper_load_data_wfx(fn_wfx):
     """Load a testing WFX file with iodata.formats.wfx.load_data_wfx."""
-    with as_file(files("iodata.test.data").joinpath(fn_wfx)) as fx:
-        lit = LineIterator(str(fx))
+    with as_file(files("iodata.test.data").joinpath(fn_wfx)) as fx, LineIterator(str(fx)) as lit:
         return load_data_wfx(lit)
 
 
@@ -598,10 +597,12 @@ def test_load_data_wfx_water():
 
 def test_parse_wfx_missing_tag_h2o():
     """Check that missing sections result in an exception."""
-    with as_file(files("iodata.test.data").joinpath("water_sto3g_hf.wfx")) as fn_wfx:
-        lit = LineIterator(fn_wfx)
-        with pytest.raises(IOError) as error:
-            parse_wfx(lit, required_tags=["<Foo Bar>"])
+    with (
+        as_file(files("iodata.test.data").joinpath("water_sto3g_hf.wfx")) as fn_wfx,
+        LineIterator(fn_wfx) as lit,
+        pytest.raises(IOError) as error,
+    ):
+        parse_wfx(lit, required_tags=["<Foo Bar>"])
     assert str(error.value).endswith("Section <Foo Bar> is missing from loaded WFX data.")
 
 


### PR DESCRIPTION
The fixed code caused warnings, essentially due to an antipattern. One should use context managers to clean up resources, instead of doing so in the `__del__` method. See #313 for the bigger picture.

I'm planning to YOLO-merge this on Thursday, June 13 unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a warning related to resource cleanup by refactoring the `LineIterator` class to use a context manager instead of the `__del__` method. The changes include updates to the class implementation, modifications to the usage in various parts of the codebase, and adjustments to the test cases to align with the new context manager approach.

* **Bug Fixes**:
    - Fixed resource cleanup warning by replacing the use of `__del__` method with context manager in `LineIterator` class.
* **Enhancements**:
    - Refactored `LineIterator` class to be used as a context manager, improving resource management and code readability.
* **Tests**:
    - Updated test cases to use the `LineIterator` class as a context manager, ensuring proper resource cleanup during tests.

<!-- Generated by sourcery-ai[bot]: end summary -->