### PR TITLE
Include warning checks in molden unit test

### DIFF
--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -20,7 +20,7 @@
 
 import os
 import warnings
-from contextlib import nullcontext
+from contextlib import ExitStack
 from importlib.resources import as_file, files
 
 import attrs
@@ -279,10 +279,10 @@ def test_load_molden_nh3_molden_cart():
     ],
 )
 def test_load_molden_cfour(path, should_warn):
-    with (
-        as_file(files("iodata.test.data").joinpath(path)) as fn_molden,
-        pytest.warns(FileFormatWarning) if should_warn else nullcontext(),
-    ):
+    with ExitStack() as stack:
+        fn_molden = stack.enter_context(as_file(files("iodata.test.data").joinpath(path)))
+        if should_warn:
+            stack.enter_context(pytest.warns(FileFormatWarning))
         mol = load_one(str(fn_molden))
     # Check normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -260,30 +260,34 @@ def test_load_molden_nh3_molden_cart():
     assert_allclose(charges, molden_charges, atol=1.0e-3)
 
 
-def test_load_molden_cfour():
-    # The file tested here is created with CFOUR 2.1.
-    file_list = [
-        "h_sonly_sph_cfour.molden",
-        "h_ponly_sph_cfour.molden",
-        "h_donly_sph_cfour.molden",
-        "h_fonly_sph_cfour.molden",
-        "h_gonly_sph_cfour.molden",
-        "h_sonly_cart_cfour.molden",
-        "h_ponly_cart_cfour.molden",
-        "h_donly_cart_cfour.molden",
-        "h_fonly_cart_cfour.molden",
-        "h_gonly_cart_cfour.molden",
-        "h2o_ccpvdz_cfour.molden",
-    ]
-
-    for i in file_list:
-        with as_file(files("iodata.test.data").joinpath(i)) as fn_molden:
-            print(str(fn_molden))
+# The file tested here is created with CFOUR 2.1.
+@pytest.mark.parametrize(
+    ("path", "should_warn"),
+    [
+        ("h_sonly_sph_cfour.molden", False),
+        ("h_ponly_sph_cfour.molden", False),
+        ("h_donly_sph_cfour.molden", True),
+        ("h_fonly_sph_cfour.molden", True),
+        ("h_gonly_sph_cfour.molden", True),
+        ("h_sonly_cart_cfour.molden", False),
+        ("h_ponly_cart_cfour.molden", False),
+        ("h_donly_cart_cfour.molden", True),
+        ("h_fonly_cart_cfour.molden", True),
+        ("h_gonly_cart_cfour.molden", True),
+        ("h2o_ccpvdz_cfour.molden", True),
+    ],
+)
+def test_load_molden_cfour(path, should_warn):
+    with as_file(files("iodata.test.data").joinpath(path)) as fn_molden:
+        if should_warn:
+            with pytest.warns(FileFormatWarning):
+                mol = load_one(str(fn_molden))
+        else:
             mol = load_one(str(fn_molden))
-            # Check normalization
-            olp = compute_overlap(mol.obasis, mol.atcoords)
-            check_orthonormal(mol.mo.coeffsa, olp)
-            check_orthonormal(mol.mo.coeffsb, olp)
+    # Check normalization
+    olp = compute_overlap(mol.obasis, mol.atcoords)
+    check_orthonormal(mol.mo.coeffsa, olp)
+    check_orthonormal(mol.mo.coeffsb, olp)
 
 
 def test_load_molden_nh3_orca():

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -20,6 +20,7 @@
 
 import os
 import warnings
+from contextlib import nullcontext
 from importlib.resources import as_file, files
 
 import attrs
@@ -278,12 +279,11 @@ def test_load_molden_nh3_molden_cart():
     ],
 )
 def test_load_molden_cfour(path, should_warn):
-    with as_file(files("iodata.test.data").joinpath(path)) as fn_molden:
-        if should_warn:
-            with pytest.warns(FileFormatWarning):
-                mol = load_one(str(fn_molden))
-        else:
-            mol = load_one(str(fn_molden))
+    with (
+        as_file(files("iodata.test.data").joinpath(path)) as fn_molden,
+        pytest.warns(FileFormatWarning) if should_warn else nullcontext(),
+    ):
+        mol = load_one(str(fn_molden))
     # Check normalization
     olp = compute_overlap(mol.obasis, mol.atcoords)
     check_orthonormal(mol.mo.coeffsa, olp)


### PR DESCRIPTION
This change now explicitly tests the expected warnings in one of the unit tests for the Molden format. See #313 for the bigger picture.

I'm planning to YOLO-merge this on Thursday, June 13 unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the Molden format unit test by adding explicit checks for expected warnings and refactors the test function to use parameterized test cases for improved readability and maintainability.

* **Tests**:
    - Added explicit checks for expected warnings in the Molden format unit test using pytest's warning mechanism.
    - Refactored the `test_load_molden_cfour` function to use pytest's parameterized test cases for better readability and maintainability.

<!-- Generated by sourcery-ai[bot]: end summary -->