### PR TITLE
Fix warning by using our factorial2 wrapper

### DIFF
--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -22,11 +22,11 @@ from typing import Union
 
 import numpy as np
 from numpy.typing import NDArray
-from scipy.special import factorialk
 
 from ..basis import HORTON2_CONVENTIONS, MolecularBasis, Shell, angmom_sti
 from ..docstrings import document_load_one
 from ..orbitals import MolecularOrbitals
+from ..overlap import factorial2
 from ..utils import LineIterator
 
 __all__ = []
@@ -67,7 +67,7 @@ def _get_cp2k_norm_corrections(ell: int, alphas: Union[float, NDArray]) -> Union
 
     """
     expzet = 0.25 * (2 * ell + 3)
-    prefac = np.sqrt(np.sqrt(np.pi) / 2.0 ** (ell + 2) * factorialk(2 * ell + 1, 2))
+    prefac = np.sqrt(np.sqrt(np.pi) / 2.0 ** (ell + 2) * factorial2(2 * ell + 1))
     zeta = 2.0 * alphas
     return zeta**expzet / prefac
 


### PR DESCRIPTION
This PR solves a SciPy warning due to the deprecated use of the `factorialk` function. The solution is to use our `factorial2` wrapper. See #313 for the bigger picture.

I'm planning to YOLO-merge this on Thursday, June 13 unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a SciPy warning by replacing the deprecated `factorialk` function with the `factorial2` wrapper in the `iodata/formats/cp2klog.py` file.

* **Bug Fixes**:
    - Replaced deprecated `factorialk` function with the `factorial2` wrapper to resolve SciPy warning.

<!-- Generated by sourcery-ai[bot]: end summary -->