### PR TITLE
Stricter testing

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -24,7 +24,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install oldest versions of supported dependencies
         if: ${{ matrix.python-version == "3.9"}}
-        # Changes to these dependencies must be updated
+        # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
         run: pip install numpy==1.22 scipy==1.8 attrs==21.3.0
       - name: Install development version

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ matrix.python-version == '3.9'}}
         # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
-        run: pip install numpy==1.22 scipy==1.8 attrs==21.3.0
+        run: pip install numpy==1.22 scipy==1.10 attrs==21.3.0
       - name: Install development version
         run: pip install -e .[dev]
       - name: Run Pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -26,7 +26,7 @@ jobs:
         if: ${{ matrix.python-version == '3.9'}}
         # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
-        run: pip install numpy==1.22 scipy==1.10 attrs==21.3.0
+        run: pip install numpy==1.22 scipy==1.11 attrs==21.3.0
       - name: Install development version
         run: pip install -e .[dev]
       - name: Run Pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install oldest versions of supported dependencies
-        if: ${{ matrix.python-version == "3.9"}}
+        if: ${{ matrix.python-version == '3.9'}}
         # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
         run: pip install numpy==1.22 scipy==1.8 attrs==21.3.0

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -22,6 +22,11 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install oldest versions of supported dependencies
+        if: ${{ matrix.python-version == "3.9"}}
+        # Changes to these dependencies must be updated
+        # in pyproject.toml and docs/install.rst
+        run: pip install numpy==1.22 scipy==1.8 attrs==21.3.0
       - name: Install development version
         run: pip install -e .[dev]
       - name: Run Pytest

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -31,7 +31,7 @@ Python 3 (>=3.9) must be installed before you can install IOData.
 In addition, IOData has the following dependencies:
 
 ..
-    Changes to these dependencies must be updated
+    Ensure changes to these dependencies are reflected
     in pyproject.toml and .github/workfloews/pytest.yaml
 
 - numpy >= 1.22: https://numpy.org/

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -35,7 +35,7 @@ In addition, IOData has the following dependencies:
     in pyproject.toml and .github/workfloews/pytest.yaml
 
 - numpy >= 1.22: https://numpy.org/
-- scipy >= 1.10: https://scipy.org/
+- scipy >= 1.11: https://scipy.org/
 - attrs >= 21.3.0: https://www.attrs.org/en/stable/index.html
 
 Normally, you don't need to install these dependencies manually. They will be

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -35,7 +35,7 @@ In addition, IOData has the following dependencies:
     in pyproject.toml and .github/workfloews/pytest.yaml
 
 - numpy >= 1.22: https://numpy.org/
-- scipy >= 1.8: https://scipy.org/
+- scipy >= 1.10: https://scipy.org/
 - attrs >= 21.3.0: https://www.attrs.org/en/stable/index.html
 
 Normally, you don't need to install these dependencies manually. They will be

--- a/doc/install.rst
+++ b/doc/install.rst
@@ -30,6 +30,10 @@ Latest PyPI version
 Python 3 (>=3.9) must be installed before you can install IOData.
 In addition, IOData has the following dependencies:
 
+..
+    Changes to these dependencies must be updated
+    in pyproject.toml and .github/workfloews/pytest.yaml
+
 - numpy >= 1.22: https://numpy.org/
 - scipy >= 1.8: https://scipy.org/
 - attrs >= 21.3.0: https://www.attrs.org/en/stable/index.html

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -35,7 +35,8 @@ __all__ = ["OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization"]
 def factorial2(n: Union[int, NDArray[int]]) -> Union[int, NDArray[int]]:
     """Modifcied scipy.special.factorial2 that returns 1 when the input is -1.
 
-    This is a temporary workaround while we wait for Scipy's update.
+    The future implementation of factorial2 in SciPy will not return
+    the correct result for n=-1 (for our purposes).
     To learn more, see https://github.com/scipy/scipy/issues/18409.
 
     This function only supports integer (array) arguments,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Ensure changes to these dependencies are reflected
     # in .github/workfloews/pytest.yaml and docs/install.rst
     "numpy>=1.22",
-    "scipy>=1.8",
+    "scipy>=1.10",
     "attrs>=21.3.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
 dependencies = [
-    # Changes to these dependencies must be updated
+    # Ensure changes to these dependencies are reflected
     # in .github/workfloews/pytest.yaml and docs/install.rst
     "numpy>=1.22",
     "scipy>=1.8",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Ensure changes to these dependencies are reflected
     # in .github/workfloews/pytest.yaml and docs/install.rst
     "numpy>=1.22",
-    "scipy>=1.10",
+    "scipy>=1.11",
     "attrs>=21.3.0",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Chemistry",
 ]
 dependencies = [
+    # Changes to these dependencies must be updated
+    # in .github/workfloews/pytest.yaml and docs/install.rst
     "numpy>=1.22",
     "scipy>=1.8",
     "attrs>=21.3.0",
@@ -47,7 +49,7 @@ Source = "https://github.com/theochem/iodata/"
 iodata-convert = "iodata.__main__:main"
 
 [tool.pytest.ini_options]
-addopts = "-n auto"
+addopts = "-n auto -W error"
 
 [tool.setuptools]
 packages = ["iodata"]


### PR DESCRIPTION
- When testing with the old Python version (3.9 at the moment), the oldest supported versions of the dependencies are installed.
- The oldest supported SciPy is increased from 1.8.0 to 1.11.0, due to required array support in factorial2.
- The option `-W error` is added to pytest, so that it fails in case of a warning.

This is part of the changes listed in #313. The first bullet was brought up in #325.

I will YOLO-merge this on Friday, June 14 unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request enhances the CI workflow by ensuring that the oldest supported versions of dependencies are installed when testing with Python 3.9. Additionally, it configures pytest to treat warnings as errors, improving the strictness of the tests.

* **CI**:
    - Added a step to install the oldest supported versions of dependencies when testing with Python 3.9.
    - Included the `-W error` option in pytest to treat warnings as errors.

<!-- Generated by sourcery-ai[bot]: end summary -->