### PR TITLE
Test documentation build in pull requests

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,6 @@
 # - Update some actions to more recent versions
 
 name: release
-
 on: push
 
 env:

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -43,7 +43,9 @@ jobs:
       - name: Install development version
         run: pip install -e .[dev]
       - name: Run sphinx
-        run: cd docs; python -m sphinx -M html . _build -W --keep-going --fresh-env
+        run: |
+          cd docs
+          python -m sphinx -M html . _build -W --keep-going --fresh-env
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/.github/workflows/sphinx.yaml
+++ b/.github/workflows/sphinx.yaml
@@ -3,7 +3,16 @@
 # using the "GitHub Actions" option.
 
 name: sphinx
-on: push
+on:
+  push:
+    branches:
+    # Run tests for change on the main branch ...
+    - main
+    tags-ignore:
+    # ... but not for tags (avoids duplicate work).
+    - '**'
+  pull_request:
+  # Run tests on pull requests
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -33,8 +42,8 @@ jobs:
         uses: actions/configure-pages@v5
       - name: Install development version
         run: pip install -e .[dev]
-      - name: Run sphix
-        run: cd docs; python -m sphinx -M html . _build
+      - name: Run sphinx
+        run: cd docs; python -m sphinx -M html . _build -W --keep-going --fresh-env
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -32,7 +32,7 @@ In addition, IOData has the following dependencies:
 
 ..
     Ensure changes to these dependencies are reflected
-    in pyproject.toml and .github/workfloews/pytest.yaml
+    in pyproject.toml and .github/workflows/pytest.yaml
 
 - numpy >= 1.22: https://numpy.org/
 - scipy >= 1.11: https://scipy.org/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 ]
 dependencies = [
     # Ensure changes to these dependencies are reflected
-    # in .github/workfloews/pytest.yaml and docs/install.rst
+    # in .github/workflows/pytest.yaml and docs/install.rst
     "numpy>=1.22",
     "scipy>=1.11",
     "attrs>=21.3.0",


### PR DESCRIPTION
This is the extension of #331 towards the documentation build. These are now also built for each PR and required to pass without error or warning. (Includes a few typo fixes.)

For the bigger picture, see #313

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request extends the Sphinx documentation build workflow to run on pull requests, ensuring that documentation builds pass without errors or warnings. It also includes minor typo fixes in the workflow configuration.

* **CI**:
    - Updated the Sphinx GitHub Actions workflow to run on pull requests in addition to pushes to the main branch.
    - Configured the Sphinx build to treat warnings as errors and continue on warnings, ensuring a clean build.

<!-- Generated by sourcery-ai[bot]: end summary -->