### PR TITLE
Increment oldest scipy version because 1.11.0 is yanked

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -27,7 +27,7 @@ jobs:
         if: ${{ matrix.python-version == '3.9'}}
         # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
-        run: pip install numpy==1.22 scipy==1.11 attrs==21.3.0
+        run: pip install numpy==1.22 scipy==1.11.1 attrs==21.3.0
       - name: Install development version
         run: pip install -e .[dev]
       # If some tests are slow against expectations, pytest will abort due to timeout.

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -35,7 +35,7 @@ In addition, IOData has the following dependencies:
     in pyproject.toml and .github/workflows/pytest.yaml
 
 - numpy >= 1.22: https://numpy.org/
-- scipy >= 1.11: https://scipy.org/
+- scipy >= 1.11.1: https://scipy.org/
 - attrs >= 21.3.0: https://www.attrs.org/en/stable/index.html
 
 Normally, you don't need to install these dependencies manually. They will be

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     # Ensure changes to these dependencies are reflected
     # in .github/workflows/pytest.yaml and docs/install.rst
     "numpy>=1.22",
-    "scipy>=1.11",
+    "scipy>=1.11.1",
     "attrs>=21.3.0",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Minor fix. Will YOLO-merge Friday June 21 unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the scipy version in the pytest workflow configuration from 1.11.0 to 1.11.1 due to the former being yanked.

* **Build**:
    - Updated scipy version from 1.11.0 to 1.11.1 in the pytest workflow configuration.

<!-- Generated by sourcery-ai[bot]: end summary -->