### PR TITLE
Disable deepsource coverage analysis

### DIFF
--- a/.deepsource.toml
+++ b/.deepsource.toml
@@ -1,10 +1,6 @@
 version = 1
 
 [[analyzers]]
-name = "test-coverage"
-enabled = true
-
-[[analyzers]]
 name = "shell"
 
 [[analyzers]]


### PR DESCRIPTION
Deepsource expects coverage reports from pull requests that do not have permissions to send pull requests. This isn't very useful. I'll keep it in the workflow file, unless it also leads to complaints in future pull requests.

We'll stick with codecov for now...

I will YOLO-merge this on Friday, June 21, unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request disables the DeepSource test coverage analyzer due to issues with coverage reports from pull requests lacking necessary permissions. The configuration for the test coverage analyzer has been removed from the .deepsource.toml file.

* **CI**:
    - Disabled the DeepSource test coverage analyzer in the configuration file.

<!-- Generated by sourcery-ai[bot]: end summary -->