### PR TITLE
Fix NumPy 2 compatibilty

### DIFF
--- a/iodata/attrutils.py
+++ b/iodata/attrutils.py
@@ -31,7 +31,7 @@ def convert_array_to(dtype):
     def converter(array):
         if array is None:
             return None
-        return np.array(array, copy=False, dtype=dtype)
+        return np.asarray(array, dtype=dtype)
 
     return converter
 


### PR DESCRIPTION
Fixes #340 

The fix is just a small technical detail related to array conversion, nothing shocking...

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a compatibility issue with NumPy 2 by updating the array conversion method in the iodata/attrutils.py file.

* **Bug Fixes**:
    - Fixed compatibility issue with NumPy 2 by replacing np.array with np.asarray for array conversion.

<!-- Generated by sourcery-ai[bot]: end summary -->