### PR TITLE
Replace lit.error by raise LoadError

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -163,7 +163,7 @@ When you encounter a file format error while reading the file, raise a ``LoadErr
     def load_one(lit: LineIterator) -> dict:
         ...
         if something_wrong:
-            raise LoadError("Describe problem in a sentence.", lit)
+            raise LoadError("Describe the problem in a sentence.", lit)
 
 The error that appears in the terminal will automatically include the file name and line number.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -166,6 +166,9 @@ When you encounter a file format error while reading the file, raise a ``LoadErr
             raise LoadError("Describe the problem in a sentence.", lit)
 
 The error that appears in the terminal will automatically include the file name and line number.
+If your code has already read the full file and encounters an error when processing the data,
+you can use ``raise LoadError("Describe problem in a sentence.", lit.filename)`` instead.
+This way, no line number is included in the error message.
 
 
 ``dump_one`` functions: writing a single IOData object to a file

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -153,8 +153,18 @@ If necessary, you can *push back* the line for later reading with ``lit.back(lin
             lit.back(line)
             break
 
-When you encounter a file format error while reading the file, call ``lit.error(msg)``,
-where ``msg`` is a short message describing the problem.
+When you encounter a file format error while reading the file, raise a ``LoadError`` exception:
+
+.. code-block:: python
+
+    from ..utils import LoadError
+
+    @document_load_one(...)
+    def load_one(lit: LineIterator) -> dict:
+        ...
+        if something_wrong:
+            raise LoadError("Describe problem in a sentence.", lit)
+
 The error that appears in the terminal will automatically include the file name and line number.
 
 

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -154,10 +154,10 @@ def load_one(filename: str, fmt: Optional[str] = None, **kwargs) -> IOData:
             iodata = IOData(**format_module.load_one(lit, **kwargs))
         except LoadError:
             raise
-        except StopIteration:
-            lit.error("File ended before all data was read.")
+        except StopIteration as exc:
+            raise LoadError("File ended before all data was read.", lit) from exc
         except Exception as exc:
-            raise LoadError(f"{filename}: Uncaught exception while loading file.") from exc
+            raise LoadError("Uncaught exception while loading file.", lit) from exc
     return iodata
 
 
@@ -194,7 +194,7 @@ def load_many(filename: str, fmt: Optional[str] = None, **kwargs) -> Iterator[IO
         except LoadError:
             raise
         except Exception as exc:
-            raise LoadError(f"{filename}: Uncaught exception while loading file.") from exc
+            raise LoadError("Uncaught exception while loading file.", lit) from exc
 
 
 def _check_required(iodata: IOData, dump_func: Callable):

--- a/iodata/formats/charmm.py
+++ b/iodata/formats/charmm.py
@@ -32,7 +32,7 @@ y-coordinate, z-coordinate, segment identifier, residue identifier and a weighti
 import numpy as np
 
 from ..docstrings import document_load_one
-from ..utils import LineIterator, amu, angstrom
+from ..utils import LineIterator, LoadError, amu, angstrom
 
 __all__ = []
 
@@ -48,8 +48,10 @@ def load_one(lit: LineIterator) -> dict:
     while True:
         try:
             line = next(lit)
-        except StopIteration:
-            lit.error("Title section of CRD has no ending marker (missing bare *).")
+        except StopIteration as exc:
+            raise LoadError(
+                "Title section of CRD has no ending marker (missing bare *).", lit
+            ) from exc
         # Get title from crd file.
         if line.startswith("*"):
             text = line[1:]
@@ -84,7 +86,7 @@ def _helper_read_crd(lit: LineIterator) -> tuple:
     # Read the line for number of atoms.
     natom = next(lit)
     if natom is None or not natom.strip().isdigit():
-        lit.error("The number of atoms must be an integer.")
+        raise LoadError("The number of atoms must be an integer.", lit)
     natom = int(natom)
     # Read the atom lines
     resnums = []

--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -27,7 +27,7 @@ from ..basis import HORTON2_CONVENTIONS, MolecularBasis, Shell, angmom_sti
 from ..docstrings import document_load_one
 from ..orbitals import MolecularOrbitals
 from ..overlap import factorial2
-from ..utils import LineIterator
+from ..utils import LineIterator, LoadError
 
 __all__ = []
 
@@ -185,7 +185,7 @@ def _read_cp2k_obasis(lit: LineIterator) -> dict:
         " ********************* Uncontracted Gaussian Type Orbitals *********************\n"
     ):
         return _read_cp2k_uncontracted_obasis(lit)
-    lit.error("Could not find basis set in CP2K ATOM output.")
+    raise LoadError("Could not find basis set in CP2K ATOM output.", lit)
     return None
 
 
@@ -436,13 +436,13 @@ def load_one(lit: LineIterator) -> dict:
         " Atomic orbital expansion coefficients [Alpha]\n",
         " Atomic orbital expansion coefficients []\n",
     ]:
-        lit.error("Could not find orbital coefficients in CP2K ATOM output.")
+        raise LoadError("Could not find orbital coefficients in CP2K ATOM output.", lit)
     coeffs_alpha = _read_cp2k_orbital_coeffs(lit, oe_alpha)
 
     if not restricted:
         line = next(lit)
         if line != " Atomic orbital expansion coefficients [Beta]\n":
-            lit.error("Could not find beta orbital coefficient in CP2K ATOM output.")
+            raise LoadError("Could not find beta orbital coefficient in CP2K ATOM output.", lit)
         coeffs_beta = _read_cp2k_orbital_coeffs(lit, oe_beta)
 
     # Turn orbital data into a MolecularOrbitals object.

--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -186,7 +186,6 @@ def _read_cp2k_obasis(lit: LineIterator) -> dict:
     ):
         return _read_cp2k_uncontracted_obasis(lit)
     raise LoadError("Could not find basis set in CP2K ATOM output.", lit)
-    return None
 
 
 def _read_cp2k_occupations_energies(

--- a/iodata/formats/fcidump.py
+++ b/iodata/formats/fcidump.py
@@ -34,7 +34,7 @@ import numpy as np
 
 from ..docstrings import document_dump_one, document_load_one
 from ..iodata import IOData
-from ..utils import LineIterator, set_four_index_element
+from ..utils import LineIterator, LoadError, set_four_index_element
 
 __all__ = []
 
@@ -50,7 +50,7 @@ def load_one(lit: LineIterator) -> dict:
     # check header
     line = next(lit)
     if not line.startswith(" &FCI NORB="):
-        lit.error("Incorrect file header")
+        raise LoadError(f"Incorrect file header: {line.strip()}", lit)
 
     # read info from header
     words = line[5:].split(",")
@@ -77,7 +77,9 @@ def load_one(lit: LineIterator) -> dict:
     for line in lit:
         words = line.split()
         if len(words) != 5:
-            lit.error("Expecting 5 fields on each data line in FCIDUMP")
+            raise LoadError(
+                f"Expecting 5 fields on each data line in FCIDUMP, got {len(words)}.", lit
+            )
         value = float(words[0])
         if words[3] != "0":
             ii = int(words[1]) - 1

--- a/iodata/formats/gamess.py
+++ b/iodata/formats/gamess.py
@@ -22,7 +22,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from ..docstrings import document_load_one
-from ..utils import LineIterator, angstrom
+from ..utils import LineIterator, LoadError, angstrom
 
 __all__ = []
 
@@ -37,7 +37,7 @@ def _read_data(lit: LineIterator) -> tuple[str, str, list[str]]:
     # The dat file only contains symmetry-unique atoms, so we would be incapable of
     # supporting non-C1 symmetry without significant additional coding.
     if symmetry != "C1":
-        lit.error(f"Only C1 symmetry is supported. Got {symmetry}")
+        raise LoadError(f"Only C1 symmetry is supported, got {symmetry}.", lit)
     symbols = []
     line = True
     while line != " $END      \n":
@@ -86,7 +86,9 @@ def _read_hessian(lit: LineIterator, result: dict[str]) -> NDArray[float]:
     """Extract ``hessian`` from the punch file."""
     # check that $HESS is not already parsed
     if "athessian" in result:
-        lit.error("Cannot parse $HESS twice! Make sure approximate hessian is not being parsed!")
+        raise LoadError(
+            "Cannot parse $HESS twice. Make sure approximate hessian is not being parsed."
+        )
     next(lit)
     natom = len(result["symbols"])
     hessian = np.zeros((3 * natom, 3 * natom), float)

--- a/iodata/formats/gaussianinput.py
+++ b/iodata/formats/gaussianinput.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from ..docstrings import document_load_one
 from ..periodic import sym2num
-from ..utils import LineIterator, angstrom
+from ..utils import LineIterator, LoadError, angstrom
 
 __all__ = []
 
@@ -68,7 +68,7 @@ def load_one(lit: LineIterator):
         if not contents:
             break
         if len(contents) != 4:
-            lit.error("No Cartesian Structure is detected")
+            raise LoadError("No Cartesian Structure is detected.", lit)
         numbers.append(sym2num[contents[0]])
         coor = list(map(float, contents[1:]))
         coordinates.append(coor)

--- a/iodata/formats/gromacs.py
+++ b/iodata/formats/gromacs.py
@@ -41,27 +41,24 @@ PATTERNS = ["*.gro"]
 @document_load_one("GRO", ["atcoords", "atffparams", "cellvecs", "extra", "title"])
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
-    while True:
-        data = _helper_read_frame(lit)
-        title = data[0]
-        time = data[1]
-        resnums = np.array(data[2])
-        resnames = np.array(data[3])
-        attypes = np.array(data[4])
-        atcoords = data[5]
-        velocities = data[6]
-        cellvecs = data[7]
-        atffparams = {"attypes": attypes, "resnames": resnames, "resnums": resnums}
-        extra = {"time": time, "velocities": velocities}
-        return {
-            "atcoords": atcoords,
-            "atffparams": atffparams,
-            "cellvecs": cellvecs,
-            "extra": extra,
-            "title": title,
-        }
-    lit.error("Gromacs gro file could not be read.")
-    return None
+    data = _helper_read_frame(lit)
+    title = data[0]
+    time = data[1]
+    resnums = np.array(data[2])
+    resnames = np.array(data[3])
+    attypes = np.array(data[4])
+    atcoords = data[5]
+    velocities = data[6]
+    cellvecs = data[7]
+    atffparams = {"attypes": attypes, "resnames": resnames, "resnums": resnums}
+    extra = {"time": time, "velocities": velocities}
+    return {
+        "atcoords": atcoords,
+        "atffparams": atffparams,
+        "cellvecs": cellvecs,
+        "extra": extra,
+        "title": title,
+    }
 
 
 @document_load_many("GRO", ["atcoords", "atffparams", "cellvecs", "extra", "title"])

--- a/iodata/formats/json.py
+++ b/iodata/formats/json.py
@@ -651,7 +651,7 @@ def _parse_json(json_in: dict, lit: LineIterator) -> dict:
         # Check if BSE file, which is too different
         elif "molssi_bse_schema" in result:
             raise LoadError(
-                f"{lit.filename}: IOData does not currently support MolSSI BSE Basis JSON."
+                "IOData does not currently support MolSSI BSE Basis JSON.", lit.filename
             )
         # Center_data is required in any basis schema
         elif "center_data" in result:
@@ -659,7 +659,7 @@ def _parse_json(json_in: dict, lit: LineIterator) -> dict:
         elif "driver" in result:
             schema_name = "qcschema_output" if "return_result" in result else "qcschema_input"
         else:
-            raise LoadError(f"{lit.filename}: Could not determine `schema_name`.")
+            raise LoadError("Could not determine `schema_name`.", lit.filename)
     if "schema_version" not in result:
         warn(
             f"{lit.filename}: QCSchema files should have a `schema_version` key."
@@ -677,8 +677,9 @@ def _parse_json(json_in: dict, lit: LineIterator) -> dict:
     if schema_name == "qcschema_output":
         return _load_qcschema_output(result, lit)
     raise LoadError(
-        f"{lit.filename}: Invalid QCSchema type {result['schema_name']}, should be one of "
-        "`qcschema_molecule`, `qcschema_basis`, `qcschema_input`, or `qcschema_output`."
+        f"Invalid QCSchema type {result['schema_name']}, should be one of "
+        "`qcschema_molecule`, `qcschema_basis`, `qcschema_input`, or `qcschema_output`.",
+        lit.filename,
     )
 
 
@@ -759,7 +760,7 @@ def _parse_topology_keys(mol: dict, lit: LineIterator) -> dict:
             )
     for key in topology_keys:
         if key not in mol:
-            raise LoadError(f"{lit.filename}: QCSchema topology requires '{key}' key")
+            raise LoadError(f"QCSchema topology requires '{key}' key", lit.filename)
 
     topology_dict = {}
     extra_dict = {}
@@ -1038,7 +1039,7 @@ def _load_qcschema_input(result: dict, lit: LineIterator) -> dict:
     extra_dict["input"] = input_dict["extra"]
 
     if "molecule" not in result:
-        raise LoadError(f"{lit.filename}: QCSchema Input requires 'molecule' key")
+        raise LoadError("QCSchema Input requires 'molecule' key", lit.filename)
     molecule_dict = _parse_topology_keys(result["molecule"], lit)
     input_dict.update(molecule_dict)
     extra_dict["molecule"] = molecule_dict["extra"]
@@ -1078,7 +1079,7 @@ def _parse_input_keys(result: dict, lit: LineIterator) -> dict:
             )
     for key in input_keys:
         if key not in result:
-            raise LoadError(f"{lit.filename}: QCSchema `qcschema_input` file requires '{key}' key")
+            raise LoadError(f"QCSchema `qcschema_input` file requires '{key}' key", lit.filename)
     # Store all extra keys in extra_dict and gather at end
     input_dict = {}
     extra_dict = {}
@@ -1173,8 +1174,8 @@ def _parse_driver(driver: str, lit: LineIterator) -> str:
     """
     if driver not in ["energy", "gradient", "hessian", "properties"]:
         raise LoadError(
-            f"{lit.filename}: QCSchema driver must be one of `energy`, `gradient`, `hessian`, "
-            "or `properties`"
+            "QCSchema driver must be one of `energy`, `gradient`, `hessian`, or `properties`",
+            lit.filename,
         )
     return driver
 
@@ -1200,7 +1201,7 @@ def _parse_model(model: dict, lit: LineIterator) -> dict:
     extra_dict = {}
 
     if "method" not in model:
-        raise LoadError(f"{lit.filename}: QCSchema `model` requires a `method`")
+        raise LoadError("QCSchema `model` requires a `method`", lit.filename)
     model_dict["lot"] = model["method"]
     # QCEngineRecords doesn't give an empty string for basis-free methods, omits req'd key instead
     if "basis" not in model:
@@ -1264,10 +1265,10 @@ def _parse_protocols(protocols: dict, lit: LineIterator) -> dict:
         keep_stdout = protocols["stdout"]
     protocols_dict = {}
     if wavefunction not in {"all", "orbitals_and_eigenvalues", "return_results", "none"}:
-        raise LoadError(f"{lit.filename}: Invalid `protocols` `wavefunction` keyword.")
+        raise LoadError("Invalid `protocols` `wavefunction` keyword.", lit.filename)
     protocols_dict["keep_wavefunction"] = wavefunction
     if not isinstance(keep_stdout, bool):
-        raise LoadError("{}: `protocols` `stdout` option must be a boolean.")
+        raise LoadError("`protocols` `stdout` option must be a boolean.", lit.filename)
     protocols_dict["keep_stdout"] = keep_stdout
     return protocols_dict
 
@@ -1296,7 +1297,7 @@ def _load_qcschema_output(result: dict, lit: LineIterator) -> dict:
     extra_dict["output"] = output_dict["extra"]
 
     if "molecule" not in result:
-        raise LoadError(f"{lit.filename}: QCSchema Input requires 'molecule' key")
+        raise LoadError("QCSchema Input requires 'molecule' key", lit.filename)
     molecule_dict = _parse_topology_keys(result["molecule"], lit)
     output_dict.update(molecule_dict)
     extra_dict["molecule"] = molecule_dict["extra"]
@@ -1338,7 +1339,7 @@ def _parse_output_keys(result: dict, lit: LineIterator) -> dict:
             )
     for key in output_keys:
         if key not in result:
-            raise LoadError(f"{lit.filename}: QCSchema `qcschema_output` file requires '{key}' key")
+            raise LoadError(f"QCSchema `qcschema_output` file requires '{key}' key", lit.filenam)
 
     # Store all extra keys in extra_dict and gather at end
     output_dict = {}
@@ -1413,7 +1414,7 @@ def _parse_provenance(
     """
     if isinstance(provenance, dict):
         if "creator" not in provenance:
-            raise LoadError(f"{lit.filename}: `{source}` provenance requires `creator` key")
+            raise LoadError(f"`{source}` provenance requires `creator` key", lit.filename)
         if append:
             base_provenance = [provenance]
         else:
@@ -1421,10 +1422,10 @@ def _parse_provenance(
     elif isinstance(provenance, list):
         for prov in provenance:
             if "creator" not in prov:
-                raise LoadError("{}: `{}` provenance requires `creator` key")
+                raise LoadError(f"`{source}` provenance requires `creator` key", lit.filename)
         base_provenance = provenance
     else:
-        raise LoadError(f"{lit.filename}: Invalid `{source}` provenance type")
+        raise LoadError(f"Invalid `{source}` provenance type", lit.filename)
     if append:
         base_provenance.append(
             {"creator": "IOData", "version": __version__, "routine": "iodata.formats.json.load_one"}

--- a/iodata/formats/mol2.py
+++ b/iodata/formats/mol2.py
@@ -80,7 +80,7 @@ def load_one(lit: LineIterator) -> dict:
                 bonds = _load_helper_bonds(lit, nbonds)
                 result["bonds"] = bonds
     if not molecule_found:
-        lit.error("Molecule could not be read")
+        raise LoadError("Molecule could not be read.", lit)
     return result
 
 

--- a/iodata/formats/pdb.py
+++ b/iodata/formats/pdb.py
@@ -188,7 +188,7 @@ def load_one(lit: LineIterator) -> dict:
             end_reached = True
             break
     if not molecule_found:
-        lit.error("Molecule could not be read.")
+        raise LoadError("Molecule could not be read.", lit)
     if not end_reached:
         lit.warn("The END is not found, but the parsed data is returned.")
 

--- a/iodata/formats/sdf.py
+++ b/iodata/formats/sdf.py
@@ -42,7 +42,7 @@ from ..docstrings import (
 )
 from ..iodata import IOData
 from ..periodic import num2sym, sym2num
-from ..utils import LineIterator, angstrom
+from ..utils import LineIterator, LoadError, angstrom
 
 __all__ = []
 
@@ -61,7 +61,7 @@ def load_one(lit: LineIterator) -> dict:
     natom = int(words[0])
     nbond = int(words[1])
     if words[-1].upper() != "V2000":
-        lit.error("Only V2000 SDF files are supported.")
+        raise LoadError("Only V2000 SDF files are supported.", lit)
     atcoords = np.empty((natom, 3), float)
     atnums = np.empty(natom, int)
     for iatom in range(natom):
@@ -82,8 +82,8 @@ def load_one(lit: LineIterator) -> dict:
     while True:
         try:
             words = next(lit)
-        except StopIteration:
-            lit.error("Molecule specification did not end properly with $$$$")
+        except StopIteration as exc:
+            raise LoadError("Molecule specification did not end properly with $$$$.", lit) from exc
         if words == "$$$$\n":
             break
     return {

--- a/iodata/test/test_gaussianinput.py
+++ b/iodata/test/test_gaussianinput.py
@@ -24,7 +24,7 @@ import numpy as np
 from numpy.testing import assert_allclose, assert_equal, assert_raises
 
 from ..api import load_one
-from ..utils import angstrom
+from ..utils import LoadError, angstrom
 
 
 def test_load_water_com():
@@ -65,7 +65,7 @@ def test_load_multi_title():
 def test_load_error():
     # test error raises when loading .com with z-matrix
     with (
-        assert_raises(ValueError),
+        assert_raises(LoadError),
         as_file(files("iodata.test.data").joinpath("water_z.com")) as fn,
     ):
         load_one(str(fn))

--- a/iodata/test/test_wfx.py
+++ b/iodata/test/test_wfx.py
@@ -585,7 +585,7 @@ def test_parse_wfx_missing_tag_h2o():
         pytest.raises(LoadError) as error,
     ):
         parse_wfx(lit, required_tags=["<Foo Bar>"])
-    assert str(error.value).endswith("Section <Foo Bar> is missing from loaded WFX data.")
+    assert "Section <Foo Bar> is missing from loaded WFX data." in str(error)
 
 
 def test_load_data_wfx_h2o_error():
@@ -595,9 +595,7 @@ def test_load_data_wfx_h2o_error():
         pytest.raises(LoadError) as error,
     ):
         load_one(str(fn_wfx))
-    assert str(error.value).endswith(
-        "Expecting line </Number of Nuclei> but got </Number of Primitives>."
-    )
+    assert "Expecting line </Number of Nuclei> but got </Number of Primitives>." in str(error)
 
 
 def test_load_truncated_h2o(tmpdir):
@@ -608,9 +606,7 @@ def test_load_truncated_h2o(tmpdir):
         pytest.raises(LoadError) as error,
     ):
         load_one(str(fn_truncated))
-    assert str(error.value).endswith(
-        "Section <Full Virial Ratio, -(V - W)/T> is not closed at end of file."
-    )
+    assert "Section <Full Virial Ratio, -(V - W)/T> is not closed at end of file." in str(error)
 
 
 def test_load_one_h2o():

--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -19,7 +19,7 @@
 """Utility functions module."""
 
 import warnings
-from typing import TextIO
+from typing import Optional, TextIO, Union
 
 import attrs
 import numpy as np
@@ -132,8 +132,8 @@ class LoadError(Exception):
     def __init__(
         self,
         message,
-        file: str | LineIterator | TextIO | None = None,
-        lineno: int | None = None,
+        file: Optional[Union[str, LineIterator, TextIO]] = None,
+        lineno: Optional[int] = None,
     ):
         super().__init__(message)
         # Get the extra info


### PR DESCRIPTION
This is another step in #191. As a sideline in fixing that issue, the IOData error handling is improved in general, not just for errors and warnings when data is converted before writing it out.

The old code used a wrapper function `lit.error` to raise an exception when a file cannot be read for some reason. This function adds some info (filename and line number) to the error message. This was a bad idea for several reasons:

- It does not allow `raise LoadError(...) from exc` calls.
- It is less readable than a plain `raise LoadError(...`.
- Static code analysis does realize that `lit.error(...)` interrupts the control flow, leaving poor code undetected. (We had some of that in the gro and cp2klog formats, fixed in this PR.)

The logic that was in `LineIterator.error` has now been implemented in the `LoadError` exception, and has been generalized to work well for all use cases.

I will YOLO-merge this on Friday, June 28, unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors error handling by replacing the custom `lit.error` function with direct `raise LoadError` calls. This change improves code readability, allows for better exception chaining, and enhances error reporting by including filename and line number information in the `LoadError` exception. Additionally, test cases have been updated to reflect these changes.

- **Enhancements**:
    - Replaced the custom `lit.error` function with direct `raise LoadError` calls to improve readability and allow `raise ... from` syntax.
    - Generalized the `LoadError` exception to include filename and line number information, enhancing error reporting across various file formats.
- **Tests**:
    - Updated test cases to check for `LoadError` exceptions instead of `lit.error` messages.

<!-- Generated by sourcery-ai[bot]: end summary -->