### PR TITLE
Test also on the soon-to-be-release python 3.13

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.12', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.12', '3.13']
+        python-version: ['3.9', '3.12', '3.13.0-beta.2']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Not sure if this is going to work, but it would be good to know.  Fingers crossed.... (Mentioned in #204)

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI configuration to include testing on Python 3.13, ensuring compatibility with the upcoming Python release.

- **CI**:
    - Added Python 3.13 to the testing matrix in the GitHub Actions workflow.

<!-- Generated by sourcery-ai[bot]: end summary -->