### PR TITLE
Remove useless catch_warnings

### DIFF
--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -19,7 +19,6 @@
 """Test iodata.formats.molden module."""
 
 import os
-import warnings
 from contextlib import ExitStack
 from importlib.resources import as_file, files
 
@@ -70,11 +69,7 @@ def test_load_molden_li2_orca():
 
 
 def test_load_molden_li2_orca_huge_threshold():
-    with (
-        as_file(files("iodata.test.data").joinpath("li2.molden.input")) as fn_molden,
-        warnings.catch_warnings(),
-    ):
-        warnings.simplefilter("error")
+    with as_file(files("iodata.test.data").joinpath("li2.molden.input")) as fn_molden:
         # The threshold is set very high, which skip a correction for ORCA.
         load_one(str(fn_molden), norm_threshold=1e4)
 

--- a/iodata/test/test_molekel.py
+++ b/iodata/test/test_molekel.py
@@ -156,10 +156,7 @@ def test_load_mkl_h2():
 
 
 def test_load_mkl_h2_huge_threshold():
-    with (
-        as_file(files("iodata.test.data").joinpath("h2_sto3g.mkl")) as fn_molekel,
-        warnings.catch_warnings(),
-    ):
+    with as_file(files("iodata.test.data").joinpath("h2_sto3g.mkl")) as fn_molekel:
         warnings.simplefilter("error")
         # The threshold is set very high, which skip a correction for ORCA.
         load_one(str(fn_molekel), norm_threshold=1e4)


### PR DESCRIPTION
A cleanup in the list of #191, deferred from #352
These are no longer needed, and they are also a poor practice for testing warnings in unit tests. Good riddance.