### PR TITLE
Make __all__ immutable

### DIFF
--- a/iodata/__main__.py
+++ b/iodata/__main__.py
@@ -31,7 +31,7 @@ except ImportError:
     __version__ = "0.0.0.post0"
 
 
-__all__ = []
+__all__ = ()
 
 
 DESCRIPTION = """\

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -37,7 +37,7 @@ from .utils import (
     WriteInputError,
 )
 
-__all__ = ["load_one", "load_many", "dump_one", "dump_many", "write_input"]
+__all__ = ("load_one", "load_many", "dump_one", "dump_many", "write_input")
 
 
 def _find_format_modules():

--- a/iodata/attrutils.py
+++ b/iodata/attrutils.py
@@ -22,7 +22,7 @@ from typing import Callable
 
 import numpy as np
 
-__all__ = ["convert_array_to", "validate_shape"]
+__all__ = ("convert_array_to", "validate_shape")
 
 
 def convert_array_to(dtype):

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -34,7 +34,7 @@ from numpy.typing import NDArray
 
 from .attrutils import validate_shape
 
-__all__ = [
+__all__ = (
     "angmom_sti",
     "angmom_its",
     "Shell",
@@ -44,7 +44,7 @@ __all__ = [
     "iter_cart_alphabet",
     "HORTON2_CONVENTIONS",
     "CCA_CONVENTIONS",
-]
+)
 
 ANGMOM_CHARS = "spdfghiklmnoqrtuvwxyzabce"
 

--- a/iodata/docstrings.py
+++ b/iodata/docstrings.py
@@ -20,13 +20,13 @@
 
 from typing import Callable, Optional
 
-__all__ = [
+__all__ = (
     "document_load_one",
     "document_load_many",
     "document_dump_one",
     "document_dump_many",
     "document_write_input",
-]
+)
 
 
 def _document_load(

--- a/iodata/formats/charmm.py
+++ b/iodata/formats/charmm.py
@@ -34,7 +34,7 @@ import numpy as np
 from ..docstrings import document_load_one
 from ..utils import LineIterator, LoadError, amu, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.crd"]

--- a/iodata/formats/chgcar.py
+++ b/iodata/formats/chgcar.py
@@ -32,7 +32,7 @@ from ..docstrings import document_load_one
 from ..periodic import sym2num
 from ..utils import Cube, LineIterator, angstrom, volume
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["CHGCAR*", "AECCAR*"]

--- a/iodata/formats/cp2klog.py
+++ b/iodata/formats/cp2klog.py
@@ -29,7 +29,7 @@ from ..orbitals import MolecularOrbitals
 from ..overlap import factorial2
 from ..utils import LineIterator, LoadError
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.cp2k.out"]

--- a/iodata/formats/cube.py
+++ b/iodata/formats/cube.py
@@ -35,7 +35,7 @@ from ..docstrings import document_dump_one, document_load_one
 from ..iodata import IOData
 from ..utils import Cube, LineIterator
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.cube", "*.cub"]

--- a/iodata/formats/extxyz.py
+++ b/iodata/formats/extxyz.py
@@ -37,7 +37,7 @@ from ..periodic import num2sym, sym2num
 from ..utils import LineIterator, amu, angstrom, strtobool
 from .xyz import load_one as load_one_xyz
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.extxyz"]

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -31,7 +31,7 @@ from ..iodata import IOData
 from ..orbitals import MolecularOrbitals
 from ..utils import DumpError, LineIterator, LoadError, PrepareDumpError, amu
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.fchk", "*.fch"]

--- a/iodata/formats/fcidump.py
+++ b/iodata/formats/fcidump.py
@@ -36,7 +36,7 @@ from ..docstrings import document_dump_one, document_load_one
 from ..iodata import IOData
 from ..utils import LineIterator, LoadError, set_four_index_element
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*FCIDUMP*"]

--- a/iodata/formats/gamess.py
+++ b/iodata/formats/gamess.py
@@ -24,7 +24,7 @@ from numpy.typing import NDArray
 from ..docstrings import document_load_one
 from ..utils import LineIterator, LoadError, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.dat"]

--- a/iodata/formats/gaussianinput.py
+++ b/iodata/formats/gaussianinput.py
@@ -24,7 +24,7 @@ from ..docstrings import document_load_one
 from ..periodic import sym2num
 from ..utils import LineIterator, LoadError, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.com", "*.gjf"]

--- a/iodata/formats/gaussianlog.py
+++ b/iodata/formats/gaussianlog.py
@@ -33,7 +33,7 @@ from numpy.typing import NDArray
 from ..docstrings import document_load_one
 from ..utils import LineIterator, set_four_index_element
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.log"]

--- a/iodata/formats/gromacs.py
+++ b/iodata/formats/gromacs.py
@@ -32,7 +32,7 @@ import numpy as np
 from ..docstrings import document_load_many, document_load_one
 from ..utils import LineIterator, nanometer, picosecond
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.gro"]

--- a/iodata/formats/json.py
+++ b/iodata/formats/json.py
@@ -573,7 +573,7 @@ from ..iodata import IOData
 from ..periodic import num2sym, sym2num
 from ..utils import DumpError, DumpWarning, LineIterator, LoadError, LoadWarning, PrepareDumpError
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.json"]

--- a/iodata/formats/locpot.py
+++ b/iodata/formats/locpot.py
@@ -29,7 +29,7 @@ from ..docstrings import document_load_one
 from ..utils import LineIterator, electronvolt
 from .chgcar import _load_vasp_grid
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["LOCPOT*"]

--- a/iodata/formats/mol2.py
+++ b/iodata/formats/mol2.py
@@ -39,7 +39,7 @@ from ..iodata import IOData
 from ..periodic import bond2num, num2bond, num2sym, sym2num
 from ..utils import LineIterator, LoadError, LoadWarning, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.mol2"]

--- a/iodata/formats/molden.py
+++ b/iodata/formats/molden.py
@@ -49,7 +49,7 @@ from ..periodic import num2sym, sym2num
 from ..prepare import prepare_unrestricted_aminusb
 from ..utils import DumpError, LineIterator, LoadError, LoadWarning, PrepareDumpError, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.molden.input", "*.molden"]

--- a/iodata/formats/molekel.py
+++ b/iodata/formats/molekel.py
@@ -37,7 +37,7 @@ from ..prepare import prepare_unrestricted_aminusb
 from ..utils import DumpError, LineIterator, LoadError, LoadWarning, PrepareDumpError, angstrom
 from .molden import CONVENTIONS, _fix_molden_from_buggy_codes
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.mkl"]

--- a/iodata/formats/mwfn.py
+++ b/iodata/formats/mwfn.py
@@ -26,7 +26,7 @@ from ..docstrings import document_load_one
 from ..orbitals import MolecularOrbitals
 from ..utils import LineIterator, LoadError, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.mwfn"]

--- a/iodata/formats/orcalog.py
+++ b/iodata/formats/orcalog.py
@@ -26,7 +26,7 @@ from numpy.typing import NDArray
 from ..docstrings import document_load_one
 from ..utils import LineIterator
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.out"]

--- a/iodata/formats/pdb.py
+++ b/iodata/formats/pdb.py
@@ -39,7 +39,7 @@ from ..iodata import IOData
 from ..periodic import bond2num, num2sym, sym2num
 from ..utils import LineIterator, LoadError, LoadWarning, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.pdb"]

--- a/iodata/formats/poscar.py
+++ b/iodata/formats/poscar.py
@@ -32,7 +32,7 @@ from ..periodic import num2sym
 from ..utils import LineIterator, angstrom
 from .chgcar import _load_vasp_header
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["POSCAR*"]

--- a/iodata/formats/qchemlog.py
+++ b/iodata/formats/qchemlog.py
@@ -29,7 +29,7 @@ from ..orbitals import MolecularOrbitals
 from ..periodic import sym2num
 from ..utils import LineIterator, angstrom, calmol, kcalmol, kjmol, strtobool
 
-__all__ = []
+__all__ = ()
 
 PATTERNS = ["*.qchemlog"]
 

--- a/iodata/formats/sdf.py
+++ b/iodata/formats/sdf.py
@@ -44,7 +44,7 @@ from ..iodata import IOData
 from ..periodic import num2sym, sym2num
 from ..utils import LineIterator, LoadError, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.sdf"]

--- a/iodata/formats/wfn.py
+++ b/iodata/formats/wfn.py
@@ -41,7 +41,7 @@ from ..periodic import num2sym, sym2num
 from ..prepare import prepare_unrestricted_aminusb
 from ..utils import LineIterator, LoadError, PrepareDumpError
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.wfn"]

--- a/iodata/formats/wfx.py
+++ b/iodata/formats/wfx.py
@@ -36,7 +36,7 @@ from ..prepare import prepare_unrestricted_aminusb
 from ..utils import LineIterator, LoadError, LoadWarning, PrepareDumpError
 from .wfn import CONVENTIONS, build_obasis, get_mocoeff_scales
 
-__all__ = []
+__all__ = ()
 
 PATTERNS = ["*.wfx"]
 

--- a/iodata/formats/xyz.py
+++ b/iodata/formats/xyz.py
@@ -68,7 +68,7 @@ from ..iodata import IOData
 from ..periodic import num2sym, sym2num
 from ..utils import LineIterator, angstrom
 
-__all__ = []
+__all__ = ()
 
 
 PATTERNS = ["*.xyz"]

--- a/iodata/inputs/common.py
+++ b/iodata/inputs/common.py
@@ -25,7 +25,7 @@ import numpy as np
 
 from ..iodata import IOData
 
-__all__ = ["write_input_base"]
+__all__ = ("write_input_base",)
 
 
 def write_input_base(

--- a/iodata/inputs/gaussian.py
+++ b/iodata/inputs/gaussian.py
@@ -26,7 +26,7 @@ from ..periodic import num2sym
 from ..utils import angstrom
 from .common import write_input_base
 
-__all__ = []
+__all__ = ()
 
 
 default_template = """\

--- a/iodata/inputs/orca.py
+++ b/iodata/inputs/orca.py
@@ -26,7 +26,7 @@ from ..periodic import num2sym
 from ..utils import angstrom
 from .common import write_input_base
 
-__all__ = []
+__all__ = ()
 
 
 default_template = """\

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -29,7 +29,7 @@ from .basis import MolecularBasis
 from .orbitals import MolecularOrbitals
 from .utils import Cube
 
-__all__ = ["IOData"]
+__all__ = ("IOData",)
 
 
 @attrs.define

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -29,7 +29,7 @@ from .basis import HORTON2_CONVENTIONS as OVERLAP_CONVENTIONS
 from .basis import MolecularBasis, Shell, convert_conventions, iter_cart_alphabet
 from .overlap_cartpure import tfs
 
-__all__ = ["OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization"]
+__all__ = ("OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization")
 
 
 def factorial2(n: Union[int, NDArray[int]]) -> Union[int, NDArray[int]]:

--- a/iodata/overlap_cartpure.py
+++ b/iodata/overlap_cartpure.py
@@ -28,7 +28,7 @@ were generated with:
 
 import numpy as np
 
-__all__ = ["tfs"]
+__all__ = ("tfs",)
 
 # fmt: off
 tf0 = np.array([

--- a/iodata/periodic.py
+++ b/iodata/periodic.py
@@ -18,7 +18,7 @@
 # --
 """Periodic table module."""
 
-__all__ = ["num2sym", "sym2num"]
+__all__ = ("num2sym", "sym2num")
 
 
 num2sym: dict[int, str] = {

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -35,14 +35,14 @@ from ..orbitals import MolecularOrbitals
 from ..overlap import compute_overlap
 from ..utils import LoadWarning
 
-__all__ = [
+__all__ = (
     "compute_mulliken_charges",
     "compute_1rdm",
     "compare_mols",
     "check_orthonormal",
     "load_one_warning",
     "create_generalized",
-]
+)
 
 
 def compute_1rdm(iodata):


### PR DESCRIPTION
This is one on the list in #204, just a minor cleanup, to avoid making such changes *along the way* in future pull requests.

Making __all__ a tuple is not a tradition in Python, but makes sense for things that are not supposed to be variable.

I will YOLO-merge this on Friday, June 5, unless reviewed earlier.