### PR TITLE
Require optional arguments of iodata.api functions to be specified with keywords

### DIFF
--- a/docs/example_scripts/load_water_foo.py
+++ b/docs/example_scripts/load_water_foo.py
@@ -2,5 +2,5 @@
 
 from iodata import load_one
 
-mol = load_one("water.foo", "xyz")  # XYZ file with unusual extension
+mol = load_one("water.foo", fmt="xyz")  # XYZ file with unusual extension
 print(mol.atcoords)

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -151,7 +151,7 @@ def _reissue_warnings(func):
 
 
 @_reissue_warnings
-def load_one(filename: str, fmt: Optional[str] = None, **kwargs) -> IOData:
+def load_one(filename: str, *, fmt: Optional[str] = None, **kwargs) -> IOData:
     """Load data from a file.
 
     This function uses the extension or prefix of the filename to determine the
@@ -186,7 +186,7 @@ def load_one(filename: str, fmt: Optional[str] = None, **kwargs) -> IOData:
 
 
 @_reissue_warnings
-def load_many(filename: str, fmt: Optional[str] = None, **kwargs) -> Iterator[IOData]:
+def load_many(filename: str, *, fmt: Optional[str] = None, **kwargs) -> Iterator[IOData]:
     """Load multiple IOData instances from a file.
 
     This function uses the extension or prefix of the filename to determine the
@@ -406,6 +406,7 @@ def write_input(
     iodata: IOData,
     filename: str,
     fmt: str,
+    *,
     template: Optional[str] = None,
     atom_line: Optional[Callable] = None,
     **kwargs,

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -171,7 +171,7 @@ def check_orthonormal(mo_coeffs: NDArray[float], ao_overlap: NDArray[float], ato
 
 
 def load_one_warning(
-    filename: str, fmt: Optional[str] = None, match: Optional[str] = None, **kwargs
+    filename: str, *, fmt: Optional[str] = None, match: Optional[str] = None, **kwargs
 ) -> IOData:
     """Call load_one, catching expected LoadWarning.
 
@@ -195,9 +195,9 @@ def load_one_warning(
     """
     with as_file(files("iodata.test.data").joinpath(filename)) as fn:
         if match is None:
-            return load_one(str(fn), fmt, **kwargs)
+            return load_one(str(fn), fmt=fmt, **kwargs)
         with pytest.warns(LoadWarning, match=match):
-            return load_one(str(fn), fmt, **kwargs)
+            return load_one(str(fn), fmt=fmt, **kwargs)
 
 
 def create_generalized() -> IOData:

--- a/iodata/test/test_inputs.py
+++ b/iodata/test/test_inputs.py
@@ -135,10 +135,10 @@ Counterpoise calculation on {extra[name]}
         return f"{symbol}(Fragment={fid}) {atcoord[0]:10.6f} {atcoord[1]:10.6f} {atcoord[2]:10.6f}"
 
     with as_file(files("iodata.test.data").joinpath("s66_4114_02WaterMeOH.xyz")) as fn:
-        mol = load_one(fn, "extxyz")
+        mol = load_one(fn, fmt="extxyz")
 
     fn_com = os.path.join(tmpdir, "input_bsse.com")
-    write_input(mol, fn_com, "gaussian", template, atom_line)
+    write_input(mol, fn_com, fmt="gaussian", template=template, atom_line=atom_line)
     with as_file(files("iodata.test.data").joinpath("input_gaussian_bsse.com")) as fn_expected:
         check_load_input_and_compare(fn_com, fn_expected)
 
@@ -175,7 +175,9 @@ end
         return f"        {symbol:3s} {atcoord[0]:10.6f} {atcoord[1]:10.6f} {atcoord[2]:10.6f}"
 
     grid_stuff = "Grid4 TightSCF NOFINALGRID"
-    write_input(mol, fname, "orca", template, atom_line, grid_stuff=grid_stuff)
+    write_input(
+        mol, fname, fmt="orca", template=template, atom_line=atom_line, grid_stuff=grid_stuff
+    )
     # compare saved input to expected input
     source = files("iodata.test.data").joinpath("input_orca_h2o_sp_b3lyp.txt")
     with as_file(source) as fname_expected:


### PR DESCRIPTION
This fixes one of the tasks in #191, deferred from #352.

This way, scripts using IOData become more readable, lower risk of bugs. It also gives us the freedom to reorganize optional arguments with less risk of breaking API compatibility. This change is in itself API-breaking.

I will YOLO-merge this on Friday, June 5, unless reviewed earlier.