### PR TITLE
Clarify the representation of (generalized) contractions in docstrings

### DIFF
--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -130,7 +130,7 @@ class Shell:
     but only some quantum chemistry codes have efficient implementations for them.
     For example, the ANO-RCC basis for carbon has 8 S-type basis functions,
     all different linear combinations of the same 14 Gaussian primitives.
-    In this case, this list is ``[1, 1, 1, 1, 1, 1, 1, 1]``.
+    In this case, this list is ``[0, 0, 0, 0, 0, 0, 0, 0]``.
     """
 
     kinds: list[str] = attrs.field(validator=validate_shape(("coeffs", 1)))


### PR DESCRIPTION
This PR attempts to fix a task in #256 (It draws some inspiration from #175. I'm trying to improve terminology and naming before continuing with #191.)

I've considered changing some names, but could not come up with anything worthwhile at this stage. For example, I considered renaming `ncon` to `ngen` for the number of **gen**eralized contractions, but the result was less intuitive.

I'll YOLO-merge this on Wednesday, July 10, unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request improves the clarity and detail of the docstrings for the `Shell` and `MolecularBasis` classes, providing better explanations of generalized contractions and their attributes.

- **Documentation**:
    - Enhanced the docstring for the `Shell` class to provide a more detailed explanation of generalized contracted Gaussian basis functions, including examples and additional context.
    - Clarified the description of the `angmoms` attribute in the `Shell` class, explaining the difference between ordinary and generalized contractions.
    - Improved the docstring for the `kinds` attribute in the `Shell` class to specify the shape and normalization assumptions of the coefficients.
    - Updated the `ncon` property docstring in the `Shell` class to better describe the concept of generalized contractions and provide examples.
    - Refined the docstring for the `MolecularBasis` class to specify that it is a collection of contracted shells.

<!-- Generated by sourcery-ai[bot]: end summary -->