### PR TITLE
Rename json to json_qcschema

### DIFF
--- a/iodata/api.py
+++ b/iodata/api.py
@@ -83,9 +83,13 @@ def _select_format_module(filename: str, attrname: str, fmt: Optional[str] = Non
                 format_module, attrname
             ):
                 return format_module
-    else:
-        return FORMAT_MODULES[fmt]
-    raise FileFormatError(f"Cannot find file format with feature {attrname}", filename)
+        raise FileFormatError(f"Cannot find file format with feature {attrname}", filename)
+    if fmt in FORMAT_MODULES:
+        format_module = FORMAT_MODULES[fmt]
+        if not hasattr(format_module, attrname):
+            raise FileFormatError(f"Format {fmt} does not support feature {attrname}", filename)
+        return format_module
+    raise FileFormatError(f"Unknown file format {fmt}", filename)
 
 
 def _find_input_modules():

--- a/iodata/formats/json_qcschema.py
+++ b/iodata/formats/json_qcschema.py
@@ -576,7 +576,7 @@ from ..utils import DumpError, DumpWarning, LineIterator, LoadError, LoadWarning
 __all__ = ()
 
 
-PATTERNS = ["*.json"]
+PATTERNS = []
 
 
 @document_load_one(

--- a/iodata/test/test_api.py
+++ b/iodata/test/test_api.py
@@ -27,9 +27,37 @@ import os
 import pytest
 from numpy.testing import assert_allclose, assert_array_equal
 
-from ..api import dump_many, dump_one, load_many
+from ..api import dump_many, dump_one, load_many, write_input
 from ..iodata import IOData
-from ..utils import DumpError, PrepareDumpError
+from ..utils import DumpError, FileFormatError, PrepareDumpError
+
+
+def test_json_no_pattern(tmpdir):
+    path_json = os.path.join(tmpdir, "name.json")
+    with pytest.raises(FileFormatError):
+        dump_one(IOData(atnums=[1, 2, 3]), path_json)
+    assert not os.path.isfile(path_json)
+
+
+def test_nonexisting_format(tmpdir):
+    path = os.path.join(tmpdir, "foobar")
+    with pytest.raises(FileFormatError):
+        dump_one(IOData(atnums=[1, 2, 3]), path, fmt="file-format-does-not-exist-at-all")
+    assert not os.path.isfile(path)
+
+
+def test_nodump(tmpdir):
+    path = os.path.join(tmpdir, "foobar")
+    with pytest.raises(FileFormatError):
+        dump_one(IOData(atnums=[1, 2, 3]), path, fmt="cp2klog")
+    assert not os.path.isfile(path)
+
+
+def test_noinput(tmpdir):
+    path = os.path.join(tmpdir, "foobar")
+    with pytest.raises(FileFormatError):
+        write_input(IOData(atnums=[1, 2, 3]), path, fmt="this-input-format-does-not-exist")
+    assert not os.path.isfile(path)
 
 
 def test_empty_dump_many_no_file(tmpdir):

--- a/iodata/test/test_json_qcschema.py
+++ b/iodata/test/test_json_qcschema.py
@@ -63,10 +63,10 @@ def test_qcschema_molecule(filename, atnums, charge, spinpol, geometry, nwarn):
     """Test qcschema_molecule parsing using manually generated files."""
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         if nwarn == 0:
-            mol = load_one(str(qcschema_molecule))
+            mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
         else:
             with pytest.warns(LoadWarning) as record:
-                mol = load_one(str(qcschema_molecule))
+                mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
             assert len(record) == nwarn
 
     np.testing.assert_equal(mol.atnums, atnums)
@@ -109,7 +109,7 @@ def test_molssi_qcschema_molecule(filename, atnums, charge, spinpol, nwarn):
         as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule,
         pytest.warns(LoadWarning) as record,
     ):
-        mol = load_one(str(qcschema_molecule))
+        mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
 
     np.testing.assert_equal(mol.atnums, atnums)
     assert mol.charge == charge
@@ -139,7 +139,7 @@ def test_passthrough_qcschema_molecule(filename, unparsed_dict):
         as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule,
         pytest.warns(LoadWarning) as record,
     ):
-        mol = load_one(str(qcschema_molecule))
+        mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
 
     assert mol.extra["molecule"]["unparsed"] == unparsed_dict
     assert len(record) == 1
@@ -172,15 +172,15 @@ def test_inout_qcschema_molecule(tmpdir, filename, nwarn):
     """Test that loading and dumping qcschema_molecule files retains all data."""
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         if nwarn == 0:
-            mol = load_one(str(qcschema_molecule))
+            mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
         else:
             with pytest.warns(LoadWarning) as record:
-                mol = load_one(str(qcschema_molecule))
+                mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
             assert len(record) == nwarn
         mol1 = json.loads(qcschema_molecule.read_bytes())
 
     fn_tmp = os.path.join(tmpdir, "test_qcschema_mol.json")
-    dump_one(mol, fn_tmp)
+    dump_one(mol, fn_tmp, fmt="json_qcschema")
 
     with open(fn_tmp) as mol2_in:
         mol2 = json.load(mol2_in)
@@ -205,12 +205,12 @@ def test_inout_molssi_qcschema_molecule(tmpdir, filename):
     """Test that loading and dumping qcschema_molecule files retains all relevant data."""
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_molecule:
         with pytest.warns(LoadWarning) as record:
-            mol = load_one(str(qcschema_molecule))
+            mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
         mol1_preproc = json.loads(qcschema_molecule.read_bytes())
     assert len(record) == 1
 
     fn_tmp = os.path.join(tmpdir, "test_qcschema_mol.json")
-    dump_one(mol, fn_tmp)
+    dump_one(mol, fn_tmp, fmt="json_qcschema")
 
     with open(fn_tmp) as mol2_in:
         mol2 = json.load(mol2_in)
@@ -241,10 +241,10 @@ def test_inout_molssi_qcschema_molecule(tmpdir, filename):
 def test_ghost(tmpdir):
     source = files("iodata.test.data").joinpath("water_cluster_ghost.json")
     with as_file(source) as qcschema_molecule:
-        mol = load_one(str(qcschema_molecule))
+        mol = load_one(str(qcschema_molecule), fmt="json_qcschema")
     np.testing.assert_allclose(mol.atcorenums, [8, 1, 1, 0, 0, 0, 0, 0, 0])
     fn_tmp = os.path.join(tmpdir, "test_ghost.json")
-    dump_one(mol, fn_tmp)
+    dump_one(mol, fn_tmp, fmt="json_qcschema")
     with open(fn_tmp) as mol2_in:
         mol2 = json.load(mol2_in)
     assert mol2["real"] == [True] * 3 + [False] * 6
@@ -267,7 +267,7 @@ def test_qcschema_input(filename, explicit_basis, lot, obasis_name, run_type, ge
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         try:
             with pytest.warns(LoadWarning):
-                mol = load_one(str(qcschema_input))
+                mol = load_one(str(qcschema_input), fmt="json_qcschema")
             assert mol.lot == lot
             if obasis_name:
                 assert mol.obasis_name == obasis_name
@@ -295,7 +295,7 @@ def test_passthrough_qcschema_input(filename, unparsed_dict, location):
         as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input,
         pytest.warns(LoadWarning),
     ):
-        mol = load_one(str(qcschema_input))
+        mol = load_one(str(qcschema_input), fmt="json_qcschema")
 
     assert mol.extra[location]["unparsed"] == unparsed_dict
 
@@ -316,15 +316,15 @@ def test_inout_qcschema_input(tmpdir, filename, nwarn):
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         if nwarn == 0:
             with pytest.warns(LoadWarning):
-                mol = load_one(str(qcschema_input))
+                mol = load_one(str(qcschema_input), fmt="json_qcschema")
         else:
             with pytest.warns(LoadWarning) as record:
-                mol = load_one(str(qcschema_input))
+                mol = load_one(str(qcschema_input), fmt="json_qcschema")
             assert len(record) == nwarn
         mol1 = json.loads(qcschema_input.read_bytes())
 
     fn_tmp = os.path.join(tmpdir, "test_input_mol.json")
-    dump_one(mol, fn_tmp)
+    dump_one(mol, fn_tmp, fmt="json_qcschema")
 
     with open(fn_tmp) as mol2_in:
         mol2 = json.load(mol2_in)
@@ -355,10 +355,10 @@ def test_qcschema_output(filename, lot, obasis_name, run_type, nwarn):
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_output:
         if nwarn == 0:
             with pytest.warns(LoadWarning):
-                mol = load_one(str(qcschema_output))
+                mol = load_one(str(qcschema_output), fmt="json_qcschema")
         else:
             with pytest.warns(LoadWarning) as record:
-                mol = load_one(str(qcschema_output))
+                mol = load_one(str(qcschema_output), fmt="json_qcschema")
             assert len(record) == nwarn
 
         assert mol.lot == lot
@@ -382,7 +382,7 @@ def test_bad_qcschema_files(filename, error):
         as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input,
         pytest.raises(error),
     ):
-        load_one(str(qcschema_input))
+        load_one(str(qcschema_input), fmt="json_qcschema")
 
 
 INOUT_OUTPUT_FILES = [
@@ -396,11 +396,11 @@ def test_inout_qcschema_output(tmpdir, filename):
     """Test that loading and dumping qcschema_molecule files retains all data."""
     with as_file(files("iodata.test.data").joinpath(filename)) as qcschema_input:
         with pytest.warns(LoadWarning):
-            mol = load_one(str(qcschema_input))
+            mol = load_one(str(qcschema_input), fmt="json_qcschema")
         mol1 = json.loads(qcschema_input.read_bytes())
 
     fn_tmp = os.path.join(tmpdir, "test_input_mol.json")
-    dump_one(mol, fn_tmp)
+    dump_one(mol, fn_tmp, fmt="json_qcschema")
 
     with open(fn_tmp) as mol2_in:
         mol2 = json.load(mol2_in)


### PR DESCRIPTION
This is one of the cleanups listed in #204.

There are several JSON schemas that could be relevant for IOData, and so we should rename our current one to something more specific, so we don't have to revise the API when adding a second JSON schema. The ones I'm aware of include:

- NOMAD has a json schema for QC jobs. https://nomad-lab.eu/prod/v1/docs/howto/plugins/schema_packages.html (See also #223)
- ASE has its own JSON schema: https://wiki.fysik.dtu.dk/ase/ase/io/formatoptions.html#json)
- There is also CJSON: https://wiki.openchemistry.org/Chemical_JSON

I've also removed the `*.json` pattern, so one has to specify explicitly which JSON schema to use.

It seemed better to use `json_qcshema.py` than `qcschema_json.py`. When another JSON schema module is added, it will be alphabetically close, making it easier to spot in the list of modules.

Edit: I've added some tests suggested by sourcery AI, but then also had to fix some error handingling in the api module to make the tests pass.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request renames the existing JSON schema module to 'json_qcschema' to facilitate the addition of other JSON schemas in the future. It also updates the test cases to use the new format explicitly.

- **Enhancements**:
    - Renamed the JSON schema module to 'json_qcschema' to allow for future additions of other JSON schemas without revising the API.
    - Updated test cases to use the new 'json_qcschema' format explicitly.

<!-- Generated by sourcery-ai[bot]: end summary -->