### PR TITLE
Make it possible to generate a PDF of the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -66,6 +66,10 @@ html_theme_options = {
     ],
 }
 
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/latex.html#module-latex
+latex_engine = "xelatex"
+
 # -- Configuration for autodoc extensions ---------------------------------
 
 autodoc_default_options = {

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -73,7 +73,7 @@ def compute_overlap(
     r"""Compute overlap matrix for the given molecular basis set(s).
 
     .. math::
-        \braket{\psi_{i}}{\psi_{j}}
+        \left\langle \psi_i \mid\vert \psi_j \right\rangle
 
     When only one basis set is given, the overlap matrix of that basis (with
     itself) is computed. If a second basis set (with its atomic coordinates) is


### PR DESCRIPTION
This PR is just a side-effect of a small experiment, but still useful to have.

With this change, one can build a PDF of the documentation as follows:

```bash
cd docs
make latexpdf
```

(A fairly complete texlive installation is needed for this to work.)

I will YOLO-merge this on Wednesday, July 10 unless reviewed earlier.