### PR TITLE
Clarify physicists' versus chemists' notation conventions

### DIFF
--- a/iodata/docstrings.py
+++ b/iodata/docstrings.py
@@ -39,6 +39,7 @@ def _document_load(
 ) -> Callable:
     if kwdocs is None:
         kwdocs = {}
+    notes = "" if notes is None else f"\nNotes\n-----\n\n{notes.strip()}\n"
     ifpresent = ifpresent or []
 
     def decorator(func):
@@ -117,8 +118,6 @@ def document_load_one(
     """
     if kwdocs is None:
         kwdocs = {}
-    if notes is not None:
-        notes = f"\nNotes\n-----\n\n{notes.strip()}\n"
     return _document_load(LOAD_ONE_DOC_TEMPLATE, fmt, guaranteed, ifpresent, kwdocs, notes)
 
 
@@ -171,8 +170,6 @@ def document_load_many(
     """
     if kwdocs is None:
         kwdocs = {}
-    if notes is not None:
-        notes = f"\nNotes\n-----\n\n{notes.strip()}\n"
     return _document_load(LOAD_MANY_DOC_TEMPLATE, fmt, guaranteed, ifpresent, kwdocs, notes)
 
 

--- a/iodata/docstrings.py
+++ b/iodata/docstrings.py
@@ -82,11 +82,7 @@ Returns
 result: dict
     A dictionary with IOData attributes. The following attributes are guaranteed to be
     loaded: {guaranteed}.{ifpresent}
-
-Notes
------
 {notes}
-
 """
 
 
@@ -121,6 +117,8 @@ def document_load_one(
     """
     if kwdocs is None:
         kwdocs = {}
+    if notes is not None:
+        notes = f"\nNotes\n-----\n\n{notes.strip()}\n"
     return _document_load(LOAD_ONE_DOC_TEMPLATE, fmt, guaranteed, ifpresent, kwdocs, notes)
 
 
@@ -138,11 +136,7 @@ Yields
 result: dict
     A dictionary with IOData attributes. The following attribtues are guaranteed to be
     loaded: {guaranteed}.{ifpresent}
-
-Notes
------
 {notes}
-
 """
 
 
@@ -177,6 +171,8 @@ def document_load_many(
     """
     if kwdocs is None:
         kwdocs = {}
+    if notes is not None:
+        notes = f"\nNotes\n-----\n\n{notes.strip()}\n"
     return _document_load(LOAD_MANY_DOC_TEMPLATE, fmt, guaranteed, ifpresent, kwdocs, notes)
 
 

--- a/iodata/formats/fcidump.py
+++ b/iodata/formats/fcidump.py
@@ -51,9 +51,7 @@ assumes they are stored in an FCIDUMP file in chemists' notation.
 @document_load_one(
     "Molpro 2012 FCIDUMP",
     ["core_energy", "one_ints", "nelec", "spinpol", "two_ints"],
-    [],
-    {},
-    LOAD_ONE_NOTES,
+    notes=LOAD_ONE_NOTES,
 )
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
@@ -129,8 +127,7 @@ dumps them to an FCIDUMP file in chemists' notation.
     "Molpro 2012 FCIDUMP",
     ["one_ints", "two_ints"],
     ["core_energy", "nelec", "spinpol"],
-    {},
-    DUMP_ONE_NOTES,
+    notes=DUMP_ONE_NOTES,
 )
 def dump_one(f: TextIO, data: IOData):
     """Do not edit this docstring. It will be overwritten."""

--- a/iodata/formats/fcidump.py
+++ b/iodata/formats/fcidump.py
@@ -22,7 +22,7 @@ Notes
 -----
 1. This function works only for restricted wave-functions.
 2. One- and two-electron integrals are stored in chemists' notation in an FCIDUMP file,
-   while IOData internally uses Physicist's notation.
+   while IOData internally uses physicists' notation.
 3. Keep in mind that the FCIDUMP format changed in MOLPRO 2012, so files generated with
    older versions are not supported.
 
@@ -42,8 +42,18 @@ __all__ = ()
 PATTERNS = ["*FCIDUMP*"]
 
 
+LOAD_ONE_NOTES = """
+IOData stores four-index objects in physicists' notation internally and
+assumes they are stored in an FCIDUMP file in chemists' notation.
+"""
+
+
 @document_load_one(
-    "Molpro 2012 FCIDUMP", ["core_energy", "one_ints", "nelec", "spinpol", "two_ints"]
+    "Molpro 2012 FCIDUMP",
+    ["core_energy", "one_ints", "nelec", "spinpol", "two_ints"],
+    [],
+    {},
+    LOAD_ONE_NOTES,
 )
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
@@ -107,9 +117,11 @@ def load_one(lit: LineIterator) -> dict:
     }
 
 
-LOAD_ONE_NOTES = """
-The dictionary ``one_ints`` must contain a field ``core_mo``. Similarly, ``two_ints`` must
-contain ``two_mo``.
+DUMP_ONE_NOTES = """
+The dictionary ``one_ints`` must contain a field ``core_mo``.
+Similarly, ``two_ints`` must contain ``two_mo``.
+IOData stores four-index objects in physicists' notation internally and
+dumps them to an FCIDUMP file in chemists' notation.
 """
 
 
@@ -118,7 +130,7 @@ contain ``two_mo``.
     ["one_ints", "two_ints"],
     ["core_energy", "nelec", "spinpol"],
     {},
-    LOAD_ONE_NOTES,
+    DUMP_ONE_NOTES,
 )
 def dump_one(f: TextIO, data: IOData):
     """Do not edit this docstring. It will be overwritten."""

--- a/iodata/formats/gaussianlog.py
+++ b/iodata/formats/gaussianlog.py
@@ -39,7 +39,13 @@ __all__ = ()
 PATTERNS = ["*.log"]
 
 
-@document_load_one("Gaussian Log", [], ["one_ints", "two_ints"])
+LOAD_ONE_NOTES = """\
+Note that Gaussian writes four-center integrals in chemists' notation.
+They will be reordered into physicists' notation when loading them with IOData.
+"""
+
+
+@document_load_one("Gaussian Log", [], ["one_ints", "two_ints"], {}, LOAD_ONE_NOTES)
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     # First get the line with the number of orbital basis functions
@@ -136,7 +142,7 @@ def _load_fourindex_g09(lit: LineIterator, nbasis: int) -> NDArray[float]:
         i2 = int(line[15:19]) - 1
         i3 = int(line[21:25]) - 1
         value = float(line[29:].replace("D", "E"))
-        # Gaussian uses the chemists notation for the 4-center indexes. IOdata
-        # uses the physicists notation.
+        # Gaussian uses the chemists' notation for the 4-center indexes. IOdata
+        # uses the physicists' notation.
         set_four_index_element(result, i0, i2, i1, i3, value)
     return result

--- a/iodata/formats/gaussianlog.py
+++ b/iodata/formats/gaussianlog.py
@@ -45,7 +45,7 @@ They will be reordered into physicists' notation when loading them with IOData.
 """
 
 
-@document_load_one("Gaussian Log", [], ["one_ints", "two_ints"], {}, LOAD_ONE_NOTES)
+@document_load_one("Gaussian Log", [], ["one_ints", "two_ints"], notes=LOAD_ONE_NOTES)
 def load_one(lit: LineIterator) -> dict:
     """Do not edit this docstring. It will be overwritten."""
     # First get the line with the number of orbital basis functions

--- a/iodata/iodata.py
+++ b/iodata/iodata.py
@@ -252,7 +252,7 @@ class IOData:
     When relevant, these names must have a suffix ``_ao`` or ``_mo`` to clarify in which
     basis the integrals are computed.
     See ``one_ints`` for more details.
-    Array indexes are in physicist's notation.
+    Array indexes are in physicists' notation.
     """
 
     two_rdms: dict = attrs.field(factory=dict)
@@ -262,7 +262,7 @@ class IOData:
     When relevant, these names must have a suffix ``_ao`` or ``_mo`` to clarify in which
     basis the RDMs are computed.
     See ``one_rdms`` for more details.
-    Array indexes are in physicist's notation.
+    Array indexes are in physicists' notation.
     """
 
     def __attrs_post_init__(self):

--- a/iodata/test/test_fcidump.py
+++ b/iodata/test/test_fcidump.py
@@ -42,7 +42,7 @@ def test_load_fcidump_psi4_h2():
     two_mo = mol.two_ints["two_mo"]
     assert_allclose(two_mo.shape, (10, 10, 10, 10))
     assert_allclose(two_mo[0, 0, 0, 0], 0.6589928924251115e00)
-    # Check physicist's notation and symmetry
+    # Check physicists' notation and symmetry
     assert_allclose(two_mo[6, 1, 5, 0], 0.5335846565304321e-01)
     assert_allclose(two_mo[5, 1, 6, 0], 0.5335846565304321e-01)
     assert_allclose(two_mo[6, 0, 5, 1], 0.5335846565304321e-01)
@@ -69,7 +69,7 @@ def test_load_fcidump_molpro_h2():
     two_mo = mol.two_ints["two_mo"]
     assert_allclose(two_mo.shape, (4, 4, 4, 4))
     assert_allclose(two_mo[0, 0, 0, 0], 0.6527679278914691e00)
-    # Check physicist's notation and symmetry
+    # Check physicists' notation and symmetry
     assert_allclose(two_mo[3, 0, 2, 1], 0.7756042287284058e-01)
     assert_allclose(two_mo[2, 0, 3, 1], 0.7756042287284058e-01)
     assert_allclose(two_mo[3, 1, 2, 0], 0.7756042287284058e-01)


### PR DESCRIPTION
This may help for issue #362. (If it doesn't, improving clarity never hurts.)

I've tried fixing related typos, and also fixed a minor in the docstring code: it now only adds a "Notes" section when there are notes.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request standardizes the terminology from 'physicist's notation' to 'physicists' notation' across multiple files for consistency and improves the clarity of documentation by conditionally adding a 'Notes' section.

- **Enhancements**:
    - Standardized the terminology from 'physicist's notation' to 'physicists' notation' across multiple files for consistency.
- **Documentation**:
    - Improved the clarity of documentation by adding a 'Notes' section only when there are notes to display.

<!-- Generated by sourcery-ai[bot]: end summary -->