### PR TITLE
Fix typecheck: TextIOBase instead of TextIO

### DIFF
--- a/iodata/utils.py
+++ b/iodata/utils.py
@@ -18,6 +18,7 @@
 # --
 """Utility functions module."""
 
+from io import TextIOBase
 from pathlib import Path
 from typing import Optional, TextIO, Union
 
@@ -140,7 +141,7 @@ def _interpret_file_lineno(
         if lineno is None:
             lineno = file.lineno
         return file.filename, lineno
-    if isinstance(file, TextIO):
+    if isinstance(file, TextIOBase):
         return file.name, lineno
     if file is None:
         if lineno is not None:


### PR DESCRIPTION
This fixes one aspect of #367, includes test.

As far as I understand, type hints should still use `TextIO` from the typing module, so I'm not changing these.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes a type checking issue by replacing `TextIO` with `TextIOBase` in the `_interpret_file_lineno` function and adds a new test to verify the handling of mixed pure Cartesian data.

- **Bug Fixes**:
    - Fixed type checking by replacing `TextIO` with `TextIOBase` in the `_interpret_file_lineno` function.
- **Tests**:
    - Added a new test `test_mixed_pure_cartesian` to verify the handling of mixed pure Cartesian data in the `molden_dump_one` function.

<!-- Generated by sourcery-ai[bot]: end summary -->