### PR TITLE
Add support .fcidump extension

### DIFF
--- a/iodata/formats/fcidump.py
+++ b/iodata/formats/fcidump.py
@@ -40,7 +40,7 @@ from ..utils import LineIterator, LoadError, LoadWarning, set_four_index_element
 __all__ = ()
 
 
-PATTERNS = ["*FCIDUMP*"]
+PATTERNS = ["*FCIDUMP*", "*.fcidump"]
 
 
 LOAD_ONE_NOTES = """

--- a/iodata/test/test_fcidump.py
+++ b/iodata/test/test_fcidump.py
@@ -93,7 +93,7 @@ def test_dump_load_fcidimp_consistency_ao(tmpdir):
         mol0.two_ints = {"two_mo": np.load(str(fn))}
 
     # Dump to a file and load it again
-    fn_tmp = os.path.join(tmpdir, "FCIDUMP")
+    fn_tmp = os.path.join(tmpdir, "tmp.fcidump")
     dump_one(mol0, fn_tmp)
     mol1 = load_one(fn_tmp)
 


### PR DESCRIPTION
This fixes the other item in #367: adding `"*.fcidump"` to the list of patterns.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request adds support for the '*.fcidump' file extension by updating the list of patterns and modifies the test to use the new extension for consistency.

- **Enhancements**:
    - Added support for the '*.fcidump' file extension in the list of patterns.
- **Tests**:
    - Updated test to use '*.fcidump' file extension for consistency.

<!-- Generated by sourcery-ai[bot]: end summary -->