### PR TITLE
Add prepare_segmented function

### DIFF
--- a/docs/example_scripts/convert_fchk_molden.py
+++ b/docs/example_scripts/convert_fchk_molden.py
@@ -5,4 +5,4 @@ from iodata import dump_one, load_one
 mol = load_one("water.fchk")
 # Here you may put some code to manipulate mol before writing it the data
 # to a different file.
-dump_one(mol, "water.molden")
+dump_one(mol, "water.molden", allow_changes=True)

--- a/iodata/basis.py
+++ b/iodata/basis.py
@@ -239,13 +239,3 @@ class MolecularBasis:
     def nbasis(self) -> int:
         """Number of basis functions."""
         return sum(shell.nbasis for shell in self.shells)
-
-    def get_segmented(self):
-        """Unroll generalized contractions."""
-        shells = []
-        for shell in self.shells:
-            for angmom, kind, coeffs in zip(shell.angmoms, shell.kinds, shell.coeffs.T):
-                shells.append(
-                    Shell(shell.icenter, [angmom], [kind], shell.exponents, coeffs.reshape(-1, 1))
-                )
-        return attrs.evolve(self, shells=shells)

--- a/iodata/formats/fchk.py
+++ b/iodata/formats/fchk.py
@@ -31,7 +31,8 @@ from ..convert import HORTON2_CONVENTIONS, convert_conventions
 from ..docstrings import document_dump_one, document_load_many, document_load_one
 from ..iodata import IOData
 from ..orbitals import MolecularOrbitals
-from ..utils import DumpError, LineIterator, LoadError, LoadWarning, PrepareDumpError, amu
+from ..prepare import prepare_segmented
+from ..utils import LineIterator, LoadError, LoadWarning, PrepareDumpError, amu
 
 __all__ = ()
 
@@ -592,7 +593,7 @@ def prepare_dump(data: IOData, allow_changes: bool, filename: str) -> IOData:
                 "followed by fully virtual ones.",
                 filename,
             )
-    return data
+    return prepare_segmented(data, True, allow_changes, filename, "FCHK")
 
 
 @document_dump_one(
@@ -671,7 +672,10 @@ def dump_one(f: TextIO, data: IOData):
             elif shell.ncon == 2 and (shell.angmoms == [0, 1]).all():
                 shell_types.append(-1)
             else:
-                raise DumpError("Cannot identify type of shell!", f)
+                raise RuntimeError(
+                    "Generalized contractions other than SP are not supported. "
+                    "Call prepare_dump first."
+                )
 
         num_pure_d_shells = sum([1 for st in shell_types if st == 2])
         num_pure_f_shells = sum([1 for st in shell_types if st == 3])

--- a/iodata/overlap.py
+++ b/iodata/overlap.py
@@ -27,7 +27,7 @@ from numpy.typing import NDArray
 
 from .basis import MolecularBasis, Shell
 from .convert import HORTON2_CONVENTIONS as OVERLAP_CONVENTIONS
-from .convert import convert_conventions, iter_cart_alphabet
+from .convert import convert_conventions, convert_to_segmented, iter_cart_alphabet
 from .overlap_cartpure import tfs
 
 __all__ = ("OVERLAP_CONVENTIONS", "compute_overlap", "gob_cart_normalization")
@@ -105,7 +105,7 @@ def compute_overlap(
         raise ValueError("The overlap integrals are only implemented for L2 normalization.")
 
     # Get a segmented basis, for simplicity
-    obasis0 = obasis0.get_segmented()
+    obasis0 = convert_to_segmented(obasis0)
 
     # Handle optional arguments
     if obasis1 is None:
@@ -126,7 +126,7 @@ def compute_overlap(
                 "array of atomic coordinates is expected."
             )
         # Get a segmented basis, for simplicity
-        obasis1 = obasis1.get_segmented()
+        obasis1 = convert_to_segmented(obasis1)
         identical = False
 
     # Initialize result

--- a/iodata/prepare.py
+++ b/iodata/prepare.py
@@ -55,7 +55,7 @@ def prepare_unrestricted_aminusb(data: IOData, allow_changes: bool, filename: st
     -------
     data
         The given data object if no conversion took place,
-        or a shallow copy with some new attriubtes.
+        or a shallow copy with some new attributes.
 
     Raises
     ------
@@ -113,7 +113,7 @@ def prepare_segmented(data: IOData, keep_sp: bool, allow_changes: bool, filename
     -------
     data
         The given data object if no conversion took place,
-        or a shallow copy with some new attriubtes.
+        or a shallow copy with some new attributes.
 
     Raises
     ------

--- a/iodata/test/common.py
+++ b/iodata/test/common.py
@@ -42,7 +42,8 @@ __all__ = (
     "compare_mols",
     "check_orthonormal",
     "load_one_warning",
-    "create_generalized",
+    "create_generalized_orbitals",
+    "create_generalized_contraction",
 )
 
 
@@ -201,7 +202,7 @@ def load_one_warning(
             return load_one(str(fn), fmt=fmt, **kwargs)
 
 
-def create_generalized() -> IOData:
+def create_generalized_orbitals() -> IOData:
     """Create a dummy IOData object with generalized molecular orbitals."""
     rng = np.random.default_rng()
     return IOData(
@@ -213,9 +214,40 @@ def create_generalized() -> IOData:
         obasis=MolecularBasis(
             [
                 Shell(0, [0, 1], ["c", "c"], rng.uniform(0, 1, 2), rng.uniform(0, 1, (2, 2))),
-                Shell(0, [0, 1], ["c", "c"], rng.uniform(0, 1, 2), rng.uniform(0, 1, (2, 2))),
+                Shell(1, [0, 1], ["c", "c"], rng.uniform(0, 1, 2), rng.uniform(0, 1, (2, 2))),
             ],
             {(0, "c"): ["1"], (1, "c"): ["x", "y", "z"]},
+            "L2",
+        ),
+    )
+
+
+def create_generalized_contraction() -> IOData:
+    """Create a dummy IOData object with generalized contractions in the basis."""
+    rng = np.random.default_rng()
+    return IOData(
+        atnums=[1, 1],
+        atcoords=[[0.0, 0.0, 0.0], [0.0, 0.0, 1.0]],
+        mo=MolecularOrbitals(
+            "restricted",
+            3,
+            3,
+            occs=[1.0, 1.0, 0.0],
+            energies=[0.2, 0.3, 0.4],
+            coeffs=rng.uniform(0, 1, (6, 3)),
+        ),
+        obasis=MolecularBasis(
+            [
+                Shell(
+                    0, [0, 0, 0], ["c", "c", "c"], rng.uniform(0, 1, 4), rng.uniform(0, 1, (4, 3))
+                ),
+                Shell(
+                    1, [0, 0, 0], ["c", "c", "c"], rng.uniform(0, 1, 4), rng.uniform(0, 1, (4, 3))
+                ),
+            ],
+            {
+                (0, "c"): ["1"],
+            },
             "L2",
         ),
     )

--- a/iodata/test/test_basis.py
+++ b/iodata/test/test_basis.py
@@ -21,7 +21,6 @@
 import attrs
 import numpy as np
 import pytest
-from numpy.testing import assert_equal
 
 from ..basis import (
     MolecularBasis,
@@ -163,47 +162,3 @@ def test_nbasis1():
         "L2",
     )
     assert obasis.nbasis == 9
-
-
-def test_get_segmented():
-    rng = np.random.default_rng(1)
-    obasis0 = MolecularBasis(
-        [
-            Shell(0, [0, 1], ["c", "c"], rng.uniform(0, 1, 5), rng.uniform(-1, 1, (5, 2))),
-            Shell(1, [2, 3], ["p", "p"], rng.uniform(0, 1, 7), rng.uniform(-1, 1, (7, 2))),
-        ],
-        CP2K_CONVENTIONS,
-        "L2",
-    )
-    assert obasis0.nbasis == 16
-    obasis1 = obasis0.get_segmented()
-    assert len(obasis1.shells) == 4
-    assert obasis1.nbasis == 16
-    # shell 0
-    shell0 = obasis1.shells[0]
-    assert shell0.icenter == 0
-    assert_equal(shell0.angmoms, [0])
-    assert shell0.kinds == ["c"]
-    assert_equal(shell0.exponents, obasis0.shells[0].exponents)
-    assert_equal(shell0.coeffs, obasis0.shells[0].coeffs[:, :1])
-    # shell 1
-    shell1 = obasis1.shells[1]
-    assert shell1.icenter == 0
-    assert_equal(shell1.angmoms, [1])
-    assert shell1.kinds == ["c"]
-    assert_equal(shell1.exponents, obasis0.shells[0].exponents)
-    assert_equal(shell1.coeffs, obasis0.shells[0].coeffs[:, 1:])
-    # shell 2
-    shell2 = obasis1.shells[2]
-    assert shell2.icenter == 1
-    assert_equal(shell2.angmoms, [2])
-    assert shell2.kinds == ["p"]
-    assert_equal(shell2.exponents, obasis0.shells[1].exponents)
-    assert_equal(shell2.coeffs, obasis0.shells[1].coeffs[:, :1])
-    # shell 0
-    shell3 = obasis1.shells[3]
-    assert shell3.icenter == 1
-    assert_equal(shell3.angmoms, [3])
-    assert shell3.kinds == ["p"]
-    assert_equal(shell3.exponents, obasis0.shells[1].exponents)
-    assert_equal(shell3.coeffs, obasis0.shells[1].coeffs[:, 1:])

--- a/iodata/test/test_convert.py
+++ b/iodata/test/test_convert.py
@@ -355,3 +355,11 @@ def test_convert_to_segmented_sp():
     assert_equal(shell3.kinds, ["p"])
     assert_equal(shell3.exponents, obasis0.shells[1].exponents)
     assert_equal(shell3.coeffs, obasis0.shells[1].coeffs[:, 1:])
+
+
+def test_convert_to_segmented_empty():
+    obasis0 = MolecularBasis([], HORTON2_CONVENTIONS, "L2")
+    obasis1 = convert_to_segmented(obasis0, keep_sp=False)
+    assert len(obasis1.shells) == 0
+    obasis2 = convert_to_segmented(obasis0, keep_sp=True)
+    assert len(obasis2.shells) == 0

--- a/iodata/test/test_convert.py
+++ b/iodata/test/test_convert.py
@@ -28,9 +28,11 @@ from ..convert import (
     HORTON2_CONVENTIONS,
     _convert_convention_shell,
     convert_conventions,
+    convert_to_segmented,
     convert_to_unrestricted,
     iter_cart_alphabet,
 )
+from ..formats.cp2klog import CONVENTIONS as CP2K_CONVENTIONS
 from ..orbitals import MolecularOrbitals
 
 
@@ -273,3 +275,83 @@ def test_convert_to_unrestricted_full():
     assert_allclose(mo2.energiesb, mo1.energiesb)
     assert_equal(mo2.irrepsa, mo1.irrepsa)
     assert_equal(mo2.irrepsb, mo1.irrepsb)
+
+
+def test_convert_to_segmented():
+    rng = np.random.default_rng(1)
+    obasis0 = MolecularBasis(
+        [
+            Shell(0, [0, 1], ["c", "c"], rng.uniform(0, 1, 5), rng.uniform(-1, 1, (5, 2))),
+            Shell(1, [2, 3], ["p", "p"], rng.uniform(0, 1, 7), rng.uniform(-1, 1, (7, 2))),
+        ],
+        CP2K_CONVENTIONS,
+        "L2",
+    )
+    assert obasis0.nbasis == 16
+    obasis1 = convert_to_segmented(obasis0)
+    assert len(obasis1.shells) == 4
+    assert obasis1.nbasis == 16
+    # shell 0
+    shell0 = obasis1.shells[0]
+    assert shell0.icenter == 0
+    assert_equal(shell0.angmoms, [0])
+    assert_equal(shell0.kinds, ["c"])
+    assert_equal(shell0.exponents, obasis0.shells[0].exponents)
+    assert_equal(shell0.coeffs, obasis0.shells[0].coeffs[:, :1])
+    # shell 1
+    shell1 = obasis1.shells[1]
+    assert shell1.icenter == 0
+    assert_equal(shell1.angmoms, [1])
+    assert_equal(shell1.kinds, ["c"])
+    assert_equal(shell1.exponents, obasis0.shells[0].exponents)
+    assert_equal(shell1.coeffs, obasis0.shells[0].coeffs[:, 1:])
+    # shell 2
+    shell2 = obasis1.shells[2]
+    assert shell2.icenter == 1
+    assert_equal(shell2.angmoms, [2])
+    assert_equal(shell2.kinds, ["p"])
+    assert_equal(shell2.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell2.coeffs, obasis0.shells[1].coeffs[:, :1])
+    # shell 0
+    shell3 = obasis1.shells[3]
+    assert shell3.icenter == 1
+    assert_equal(shell3.angmoms, [3])
+    assert_equal(shell3.kinds, ["p"])
+    assert_equal(shell3.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell3.coeffs, obasis0.shells[1].coeffs[:, 1:])
+
+
+def test_convert_to_segmented_sp():
+    rng = np.random.default_rng(1)
+    obasis0 = MolecularBasis(
+        [
+            Shell(0, [0, 1], ["c", "c"], rng.uniform(0, 1, 5), rng.uniform(-1, 1, (5, 2))),
+            Shell(1, [2, 3], ["p", "p"], rng.uniform(0, 1, 7), rng.uniform(-1, 1, (7, 2))),
+        ],
+        HORTON2_CONVENTIONS,
+        "L2",
+    )
+    obasis1 = convert_to_segmented(obasis0, keep_sp=True)
+    assert len(obasis1.shells) == 3
+    assert obasis1.nbasis == 16
+    # shell 0
+    shell0 = obasis1.shells[0]
+    assert shell0.icenter == 0
+    assert_equal(shell0.angmoms, [0, 1])
+    assert_equal(shell0.kinds, ["c", "c"])
+    assert_equal(shell0.exponents, obasis0.shells[0].exponents)
+    assert_equal(shell0.coeffs, obasis0.shells[0].coeffs)
+    # shell 1
+    shell2 = obasis1.shells[1]
+    assert shell2.icenter == 1
+    assert_equal(shell2.angmoms, [2])
+    assert_equal(shell2.kinds, ["p"])
+    assert_equal(shell2.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell2.coeffs, obasis0.shells[1].coeffs[:, :1])
+    # shell 3
+    shell3 = obasis1.shells[2]
+    assert shell3.icenter == 1
+    assert_equal(shell3.angmoms, [3])
+    assert_equal(shell3.kinds, ["p"])
+    assert_equal(shell3.exponents, obasis0.shells[1].exponents)
+    assert_equal(shell3.coeffs, obasis0.shells[1].coeffs[:, 1:])

--- a/iodata/test/test_molden.py
+++ b/iodata/test/test_molden.py
@@ -590,12 +590,11 @@ def test_load_molden_f():
     ],
 )
 def test_load_dump_consistency(tmpdir, fn, match, allow_changes):
-    with as_file(files("iodata.test.data").joinpath(fn)) as file_name:
-        if match is None:
-            mol1 = load_one(str(file_name))
-        else:
-            with pytest.warns(LoadWarning, match=match):
-                mol1 = load_one(str(file_name))
+    with ExitStack() as stack:
+        file_name = stack.enter_context(as_file(files("iodata.test.data").joinpath(fn)))
+        if match is not None:
+            stack.enter_context(pytest.warns(LoadWarning, match=match))
+        mol1 = load_one(file_name)
     fn_tmp = os.path.join(tmpdir, "foo.bar")
     if allow_changes:
         with pytest.warns(PrepareDumpWarning):


### PR DESCRIPTION
This addresses another task from #191: conversion to segmented basis functions is now also implemented through in the `prepare` and `convert` modules. In addition to reorganizing how this was done previously, the FCHK format now also makes use of this feature. (For FCHK, SP shells are left in place, but other types of generalized contractions are converted.) This also addresses the last point in #256 .

This is API breaking because the `MolecularBasis.get_segmented` method was removed and replaced by functions in separate modules. This improves overall modularity: separating utilities from the core data structures. Related unit tests were also moved for consistency.

:warning: I will YOLO-merge this on Thursday, July 18, unless reviewed earlier.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request introduces the `prepare_segmented` function to convert generalized contractions to segmented ones, enhancing modularity by moving this functionality to separate modules. It also updates various format modules to utilize this new feature and refactors related tests for consistency.

- **New Features**:
    - Introduced the `prepare_segmented` function to convert generalized contractions to segmented ones in the `prepare` module.
    - Added `convert_to_segmented` function in the `convert` module for converting basis sets with generalized contractions to single contractions.
- **Enhancements**:
    - Removed the `MolecularBasis.get_segmented` method and replaced it with functions in separate modules to improve modularity.
    - Updated the FCHK format to utilize the new segmented basis conversion feature.
    - Modified the `prepare_dump` functions in various format modules (Molden, Molekel, WFN, WFX) to include calls to `prepare_segmented`.
    - Refactored tests to use the new `prepare_segmented` and `convert_to_segmented` functions, ensuring consistency and modularity.
- **Tests**:
    - Added unit tests for the new `prepare_segmented` function in `test_prepare.py`.
    - Added unit tests for the new `convert_to_segmented` function in `test_convert.py`.
    - Updated existing tests to remove references to the deprecated `MolecularBasis.get_segmented` method and replace them with the new functions.

<!-- Generated by sourcery-ai[bot]: end summary -->