### PR TITLE
Fix unrecognized Gaussian input format: *.com and *.gjf

### DIFF
--- a/iodata/api.py
+++ b/iodata/api.py
@@ -46,9 +46,15 @@ def _find_format_modules():
     for module_info in iter_modules(import_module("iodata.formats").__path__):
         if not module_info.ispkg:
             format_module = import_module("iodata.formats." + module_info.name)
+            # TODO: there should be more robust way to find out the module name
             if hasattr(format_module, "PATTERNS"):
-                for pattern in format_module.PATTERNS:
-                    result[pattern.replace("*.", "")] = format_module
+                if module_info.name == "gaussianinput":
+                    result["com"] = format_module
+                    result["gjf"] = format_module
+                elif module_info.name == "gaussianlog":
+                    result["log"] = format_module
+                else:
+                    result[module_info.name] = format_module
 
     return result
 

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -47,7 +47,9 @@ def _find_format_modules():
         if not module_info.ispkg:
             format_module = import_module("iodata.formats." + module_info.name)
             if hasattr(format_module, "PATTERNS"):
-                result[module_info.name] = format_module
+                for pattern in format_module.PATTERNS:
+                    result[pattern.replate("*.", "")] = format_module
+
     return result
 
 

--- a/iodata/api.py
+++ b/iodata/api.py
@@ -48,7 +48,7 @@ def _find_format_modules():
             format_module = import_module("iodata.formats." + module_info.name)
             if hasattr(format_module, "PATTERNS"):
                 for pattern in format_module.PATTERNS:
-                    result[pattern.replate("*.", "")] = format_module
+                    result[pattern.replace("*.", "")] = format_module
 
     return result
 

--- a/iodata/formats/json_qcschema.py
+++ b/iodata/formats/json_qcschema.py
@@ -576,7 +576,9 @@ from ..utils import DumpError, DumpWarning, LineIterator, LoadError, LoadWarning
 __all__ = ()
 
 
-PATTERNS = []
+PATTERNS = [
+    "*.json",
+]
 
 
 @document_load_one(

--- a/iodata/formats/json_qcschema.py
+++ b/iodata/formats/json_qcschema.py
@@ -577,7 +577,7 @@ __all__ = ()
 
 
 PATTERNS = [
-    "*.json",
+    # "*.json",
 ]
 
 


### PR DESCRIPTION
The current implementation does not support .com and *gjf because it used module name instead of "PATTERNS".

## Summary by Sourcery

Bug Fixes:
- Fix support for recognizing Gaussian input formats with extensions .com and .gjf by using patterns instead of module names.