### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,7 +77,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v3
+      uses: sigstore/gh-action-sigstore-python@v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: "3.9"
+        python-version: "3.12"
     - name: Install pypa/build
       run: >-
         python -m pip install build
@@ -77,7 +77,7 @@ jobs:
         name: python-package-distributions
         path: dist/
     - name: Sign the dists with Sigstore
-      uses: sigstore/gh-action-sigstore-python@v2.1.1
+      uses: sigstore/gh-action-sigstore-python@v3
       with:
         inputs: >-
           ./dist/*.tar.gz


### PR DESCRIPTION
Attempt to address the failing PyPI release.

## Summary by Sourcery

Update release workflow to use Python 3.12 and Sigstore action v3 to fix PyPI release failures.

Enhancements:
- Use Python 3.12 in the GitHub Actions release workflow
- Upgrade the Sigstore GitHub Action to v3