### PR TITLE
Test updated schema for adding Python 3.13 support.

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,9 +19,9 @@ jobs:
         exclude:
           # only test Python 3.9 and 3.13 for MacOS and Windows
           - os: macos-latest
-            python-version: ['3.10', '3.11', '3.12']
+            python-version: ['3.9', '3.10', '3.11', '3.12']
           - os: windows-latest
-            python-version: ['3.10', '3.11', '3.12']
+            python-version: ['3.9', '3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,17 +19,9 @@ jobs:
         exclude:
           # only test Python 3.9 and 3.13 for MacOS and Windows
           - os: macos-latest
-            python-version: '3.10'
-          - os: macos-latest
-            python-version: '3.11'
-          - os: macos-latest
-            python-version: '3.12'
+            python-version: ['3.10', '3.11', '3.12']
           - os: windows-latest
-            python-version: '3.10'
-          - os: windows-latest
-            python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.12'
+            python-version: ['3.10', '3.11', '3.12']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.12']
+        python-version: ['3.9', '3.13']
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -17,11 +17,23 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         exclude:
-          # only test Python 3.9 and 3.13 for MacOS and Windows
+          # only test 3.13 for MacOS and Windows
           - os: macos-latest
-            python-version: ['3.9', '3.10', '3.11', '3.12']
+            python-version: '3.9'
+          - os: macos-latest
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.11'
+          - os: macos-latest
+            python-version: '3.12'
           - os: windows-latest
-            python-version: ['3.9', '3.10', '3.11', '3.12']
+            python-version: '3.9'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.11'
+          - os: windows-latest
+            python-version: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -15,7 +15,21 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        exclude:
+          # only test Python 3.9 and 3.13 for MacOS and Windows
+          - os: macos-latest
+            python-version: '3.10'
+          - os: macos-latest
+            python-version: '3.11'
+          - os: macos-latest
+            python-version: '3.12'
+          - os: windows-latest
+            python-version: '3.10'
+          - os: windows-latest
+            python-version: '3.11'
+          - os: windows-latest
+            python-version: '3.12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: File Formats",
     "Topic :: Scientific/Engineering :: Physics",
     "Topic :: Scientific/Engineering :: Chemistry",


### PR DESCRIPTION
## Summary by Sourcery

Add Python 3.13 support by updating CI test matrix and project metadata

Enhancements:
- Add Python 3.13 to the project's classifiers in pyproject.toml

CI:
- Include Python 3.13 in the GitHub Actions pytest matrix and add Python 3.10 and 3.11 to the strategy
- Restrict macOS and Windows runs to only Python 3.9 and 3.13