### PR TITLE
Update GitHib Action to test on Python 3.14

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -14,22 +14,24 @@ jobs:
   tests:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.10', '3.11', '3.12', '3.13']
-        exclude:
-          # only test 3.13 for MacOS and Windows
-          - os: macos-latest
+        include:
+          # Test all Python versions on Ubuntu
+          - os: ubuntu-latest
             python-version: '3.10'
-          - os: macos-latest
+          - os: ubuntu-latest
             python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
+          - os: ubuntu-latest
+            python-version: '3.13'
+          - os: ubuntu-latest
+            python-version: '3.14'
+          # Test only Python 3.14 on MacOS
           - os: macos-latest
-            python-version: '3.12'
+            python-version: '3.14'
+          # Test only Python 3.14 on Windows
           - os: windows-latest
-            python-version: '3.10'
-          - os: windows-latest
-            python-version: '3.11'
-          - os: windows-latest
-            python-version: '3.12'
+            python-version: '3.14'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -38,7 +40,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install oldest versions of supported dependencies
-        if: ${{ matrix.python-version == '3.9'}}
+        if: ${{ matrix.python-version == '3.10'}}
         # Ensure changes to these dependencies are reflected
         # in pyproject.toml and docs/install.rst
         run: pip install numpy==1.26.4 scipy==1.13.1 attrs==21.3.0


### PR DESCRIPTION
This is a follow-up on #387, now enabling testing on Python 3.14.

## Summary by Sourcery

Enable testing on Python 3.14 by updating the GitHub Actions workflow matrix to include explicit OS and Python version combinations and adjust the oldest dependencies installation step to target Python 3.10.

CI:
- Restructure pytest GitHub Actions matrix to explicit include combinations
- Add Python 3.14 to tests across Ubuntu, macOS, and Windows
- Update oldest dependencies installation to run on Python 3.10 instead of 3.9