### PR TITLE
Update pyproject.toml to fetch all the subdirs of iodata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,8 +69,8 @@ iodata-convert = "iodata.__main__:main"
 addopts = "-n auto -W error --strict-markers"
 markers = ["slow: marks tests as slow (deselect with '-m \"not slow\"')"]
 
-[tool.setuptools]
-packages = ["iodata"]
+[tool.setuptools.packages.find]
+include = ["iodata*"]
 
 [tool.setuptools_scm]
 write_to = "iodata/_version.py"


### PR DESCRIPTION
Now when I fetch sources and run `pip install .` it does not install iodata/formats, iodata/inputs and all from iodata/tests (only test/data).
This should fix the error `ModuleNotFoundError: No module named 'iodata.formats'`